### PR TITLE
fix: update the default package address for AIO

### DIFF
--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -27,11 +27,16 @@ import (
 	"net"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
 	"text/template"
 	"time"
+
+	"k8s.io/component-base/version"
+
+	"github.com/kubeclipper/kubeclipper/pkg/utils/strutil"
 
 	"github.com/kubeclipper/kubeclipper/pkg/utils/autodetection"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/netutil"
@@ -102,7 +107,7 @@ const (
   kcctl deploy --deploy-config deploy-config.yaml
 
   Please read 'kcctl deploy -h' get more deploy flags`
-	defaultPkg              = "https://oss.kubeclipper.io/release/v1.1.0/kc-amd64.tar.gz"
+	defaultPkg              = "https://oss.kubeclipper.io/release/%s/kc-%s.tar.gz"
 	allInOneEtcdClientPort  = 12379
 	allInOneEtcdPeerPort    = 12380
 	allInOneEtcdMetricsPort = 12381
@@ -162,7 +167,8 @@ func (d *DeployOptions) Complete() error {
 	if d.deployConfig.ServerIPs == nil && d.agents == nil {
 		d.aio = true
 		if d.deployConfig.Pkg == "" {
-			d.deployConfig.Pkg = defaultPkg
+			tag, _ := strutil.ParseGitDescribeInfo(version.Get().GitVersion)
+			d.deployConfig.Pkg = fmt.Sprintf(defaultPkg, tag, runtime.GOARCH)
 		}
 		// set etcd port to avoid conflicts with k8s
 		d.deployConfig.EtcdConfig.ClientPort = allInOneEtcdClientPort

--- a/pkg/utils/strutil/strutil.go
+++ b/pkg/utils/strutil/strutil.go
@@ -20,6 +20,7 @@ package strutil
 
 import (
 	"encoding/base64"
+	"strings"
 )
 
 func Base64Encode(src string) string {
@@ -47,4 +48,17 @@ func TrimDuplicates(src []string) []string {
 		}
 	}
 	return src[:i]
+}
+
+// ParseGitDescribeInfo parse `git describe` command return information
+// Determine if there are currently any new commits
+// new commit info example: v1.1.0-11+b25c67df4a2e87, it must be a branch.
+// no new commit info example: v1.1.0, it could be a branch or a tag.
+func ParseGitDescribeInfo(v string) (string, bool) {
+	var nc bool
+	i := strings.Split(v, "-")
+	if len(i) > 1 {
+		nc = true
+	}
+	return i[0], nc
 }


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```