### PR TITLE
feat: add nfs-csi

### DIFF
--- a/cmd/kubeclipper-agent/main.go
+++ b/cmd/kubeclipper-agent/main.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kubeclipper/kubeclipper/cmd/kubeclipper-agent/app"
 	_ "github.com/kubeclipper/kubeclipper/pkg/component/nfs"
+	_ "github.com/kubeclipper/kubeclipper/pkg/component/nfscsi"
 	_ "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/cri"
 	_ "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/k8s"
 )

--- a/cmd/kubeclipper-server/main.go
+++ b/cmd/kubeclipper-server/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kubeclipper/kubeclipper/cmd/kubeclipper-server/app"
 	_ "github.com/kubeclipper/kubeclipper/pkg/authentication/identityprovider/oidc"
 	_ "github.com/kubeclipper/kubeclipper/pkg/component/nfs"
+	_ "github.com/kubeclipper/kubeclipper/pkg/component/nfscsi"
 	_ "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/cri"
 	_ "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/k8s"
 )

--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -399,7 +399,7 @@ func (h *handler) CreateClusters(request *restful.Request, response *restful.Res
 	if v := request.QueryParameter("timeout"); v != "" {
 		timeoutSecs = v
 	}
-
+	c.Complete()
 	// validate node exist
 	extraMeta, err := h.getClusterMetadata(request.Request.Context(), &c)
 	if err != nil {
@@ -415,7 +415,6 @@ func (h *handler) CreateClusters(request *restful.Request, response *restful.Res
 		restplus.HandleBadRequest(response, request, err)
 		return
 	}
-	c.Complete()
 
 	extraMeta.OperationType = v1.OperationCreateCluster
 	op, err := h.parseOperationFromCluster(extraMeta, &c, v1.ActionInstall)
@@ -784,11 +783,12 @@ func (h *handler) watchOperations(req *restful.Request, resp *restful.Response, 
 
 func (h *handler) getClusterMetadata(ctx context.Context, c *v1.Cluster) (*component.ExtraMetadata, error) {
 	meta := &component.ExtraMetadata{
-		ClusterName:   c.Name,
-		Offline:       c.Offline(),
-		LocalRegistry: c.LocalRegistry,
-		CRI:           c.ContainerRuntime.Type,
-		KubeVersion:   c.KubernetesVersion,
+		ClusterName:    c.Name,
+		Offline:        c.Offline(),
+		LocalRegistry:  c.LocalRegistry,
+		CRI:            c.ContainerRuntime.Type,
+		KubeVersion:    c.KubernetesVersion,
+		KubeletDataDir: c.Kubelet.RootDir,
 	}
 	masters, err := h.getNodeInfo(ctx, c.Masters)
 	if err != nil {

--- a/pkg/component/ctx.go
+++ b/pkg/component/ctx.go
@@ -33,14 +33,15 @@ type (
 )
 
 type ExtraMetadata struct {
-	Masters       NodeList
-	Workers       NodeList
-	Offline       bool
-	LocalRegistry string
-	CRI           string
-	ClusterName   string
-	KubeVersion   string
-	OperationType string
+	Masters        NodeList
+	Workers        NodeList
+	Offline        bool
+	LocalRegistry  string
+	CRI            string
+	ClusterName    string
+	KubeVersion    string
+	OperationType  string
+	KubeletDataDir string
 }
 
 type Node struct {

--- a/pkg/component/nfscsi/nfs_csi.go
+++ b/pkg/component/nfscsi/nfs_csi.go
@@ -1,0 +1,427 @@
+package nfscsi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeclipper/kubeclipper/pkg/component"
+	"github.com/kubeclipper/kubeclipper/pkg/component/common"
+	nfsprovisioner "github.com/kubeclipper/kubeclipper/pkg/component/nfs"
+	"github.com/kubeclipper/kubeclipper/pkg/component/utils"
+	"github.com/kubeclipper/kubeclipper/pkg/component/validation"
+	"github.com/kubeclipper/kubeclipper/pkg/logger"
+	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	"github.com/kubeclipper/kubeclipper/pkg/simple/downloader"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/fileutil"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/netutil"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/strutil"
+	tmplutil "github.com/kubeclipper/kubeclipper/pkg/utils/template"
+)
+
+var (
+	errEmptyServerAddr   = errors.New("NFS server address must be provided")
+	errInvalidServerAddr = errors.New("invalid NFS server address")
+	errEmptySharedPath   = errors.New("NFS shared path must be provided")
+	errInvalidSharedPath = errors.New("invalid NFS shared path")
+)
+
+const (
+	nfs                   = "nfs"
+	name                  = "nfs-csi"
+	version               = "v1"
+	AgentImageLoader      = "ImageLoader"
+	defaultSCName         = "nfs-sc"
+	defaultReclaimPolicy  = "Delete"
+	defaultNamespace      = "kube-system"
+	defaultManifestsDir   = "/tmp/.nfs-csi"
+	defaultFilenameFormat = "nfs-csi-%s.yaml"
+)
+
+func init() {
+	n := &NFS{}
+	if err := component.Register(fmt.Sprintf(component.RegisterFormat, name, version), n); err != nil {
+		panic(err)
+	}
+
+	if err := component.RegisterTemplate(fmt.Sprintf(component.RegisterTemplateKeyFormat, name, version, nfs), n); err != nil {
+		panic(err)
+	}
+
+	if err := component.RegisterAgentStep(fmt.Sprintf(component.RegisterTemplateKeyFormat, name, version, AgentImageLoader), &nfsprovisioner.ImageLoader{}); err != nil {
+		panic(err)
+	}
+	if err := initI18nForComponentMeta(); err != nil {
+		panic(err)
+	}
+}
+
+var (
+	_ component.Interface      = (*NFS)(nil)
+	_ component.TemplateRender = (*NFS)(nil)
+)
+
+type NFS struct {
+	ImageRepoMirror                            string   `json:"imageRepoMirror"` // optional
+	Namespace                                  string   `json:"namespace"`       // optional
+	Replicas                                   int      `json:"replicas"`
+	ManifestsDir                               string   `json:"manifestsDir"`  // optional
+	ServerAddr                                 string   `json:"serverAddr"`    // required
+	SharedPath                                 string   `json:"sharedPath"`    // required
+	StorageClassName                           string   `json:"scName"`        // optional
+	IsDefault                                  bool     `json:"isDefaultSC"`   // optional
+	ReclaimPolicy                              string   `json:"reclaimPolicy"` // optional
+	MountOptions                               []string `json:"mountOptions"`  // optional
+	KubeletRootDir                             string   `json:"kubeletRootDir"`
+	installSteps, uninstallSteps, upgradeSteps []v1.Step
+}
+
+func (n NFS) GetComponentMeta(lang component.Lang) component.Meta {
+	loc := component.GetLocalizer(lang)
+
+	f := component.JSON(false)
+	sc := component.JSON(defaultSCName)
+
+	propMap := map[string]component.JSONSchemaProps{
+		"serverAddr": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.serverAddr"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeString,
+			Default:      nil,
+			Description:  "NFS server address",
+			Priority:     2,
+			Dependencies: []string{"enabled"},
+		},
+		"sharedPath": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.sharedPath"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeString,
+			Default:      nil,
+			Description:  "NFS shared path",
+			Priority:     3,
+			Dependencies: []string{"enabled"},
+		},
+		"scName": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.scName"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeString,
+			Default:      &sc,
+			Description:  "Storage Class name",
+			Priority:     4,
+			Dependencies: []string{"enabled"},
+		},
+		"isDefaultSC": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.isDefaultSC"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeBool,
+			Default:      &f,
+			Description:  "set as default Storage Class",
+			Priority:     5,
+			Dependencies: []string{"enabled"},
+		},
+		"reclaimPolicy": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.reclaimPolicy"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeString,
+			Default:      component.JSON(defaultReclaimPolicy),
+			Description:  "Storage Class reclaim policy",
+			Priority:     6,
+			Dependencies: []string{"enabled"},
+			EnumNames:    []string{"Retain", "Delete"},
+			Enum:         []component.JSON{"Retain", "Delete"},
+		},
+		"mountOptions": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.mountOptions"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeArray,
+			Default:      nil,
+			Description:  "mount options (e.g. 'nfsvers=3')",
+			Priority:     7,
+			Dependencies: []string{"enabled"},
+		},
+		"replicas": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.replicas"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeInt,
+			Default:      component.JSON(1),
+			Description:  "nfs provisioner replicas. It should only run on the master nodes",
+			Priority:     8,
+			Dependencies: []string{"enabled"},
+		},
+		"imageRepoMirror": {
+			Title:        loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs.imageRepoMirror"}),
+			Properties:   nil,
+			Type:         component.JSONSchemaTypeString,
+			Default:      nil,
+			Description:  "nfs image repository mirror, the component official repository is used by default",
+			Priority:     9,
+			Dependencies: []string{"enabled"},
+		},
+	}
+
+	return component.Meta{
+		Title:      loc.MustLocalize(&i18n.LocalizeConfig{MessageID: "nfs-csi.metaTitle"}),
+		Name:       name,
+		Version:    version,
+		Unique:     true,
+		Template:   true,
+		Dependence: []string{component.InternalCategoryKubernetes},
+		Category:   component.InternalCategoryStorage,
+		Priority:   3,
+		Schema: &component.JSONSchemaProps{
+			Properties: propMap,
+			Required:   []string{"serverAddr", "sharedPath", "scName"},
+			Type:       component.JSONSchemaTypeObject,
+			Default:    nil,
+		},
+	}
+}
+
+func (n *NFS) Render(ctx context.Context, opts component.Options) error {
+	if err := os.MkdirAll(n.ManifestsDir, 0755); err != nil {
+		return err
+	}
+	manifestsFile := filepath.Join(n.ManifestsDir, fmt.Sprintf(defaultFilenameFormat, n.StorageClassName))
+	return fileutil.WriteFileWithContext(ctx, manifestsFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644,
+		n.renderTo, opts.DryRun)
+}
+
+func (n *NFS) renderTo(w io.Writer) error {
+	at := tmplutil.New()
+	_, err := at.RenderTo(w, csiControllerTemplate, n)
+	return err
+}
+
+func (n *NFS) NewInstance() component.ObjectMeta {
+	return &NFS{
+		Namespace:        defaultNamespace,
+		ManifestsDir:     defaultManifestsDir,
+		StorageClassName: defaultSCName,
+		ReclaimPolicy:    defaultReclaimPolicy,
+	}
+}
+
+func (n *NFS) Ns() string {
+	return ""
+}
+
+func (n *NFS) Svc() string {
+	return ""
+}
+
+func (n *NFS) RequestPath() string {
+	return ""
+}
+
+func (n *NFS) Supported() bool {
+	return false
+}
+
+func (n *NFS) GetInstanceName() string {
+	return n.StorageClassName
+}
+
+func (n *NFS) GetDependence() []string {
+	return []string{component.InternalCategoryKubernetes}
+}
+
+func (n *NFS) RequireExtraCluster() []string {
+	return nil
+}
+
+func (n *NFS) CompleteWithExtraCluster(extra map[string]component.ExtraMetadata) error {
+	return nil
+}
+
+func (n *NFS) Validate() error {
+	// namespace
+	if !validation.MatchKubernetesNamespace(n.Namespace) {
+		return validation.ErrInvalidNamespace
+	}
+	// server address
+	if n.ServerAddr == "" {
+		return errEmptyServerAddr
+	}
+	if !validation.IsHostNameRFC952(n.ServerAddr) && !netutil.IsValidIP(n.ServerAddr) {
+		return errInvalidServerAddr
+	}
+	// shared path
+	if n.SharedPath == "" {
+		return errEmptySharedPath
+	}
+	if !validation.MatchLinuxFilePath(n.SharedPath) {
+		return errInvalidSharedPath
+	}
+	// storage class name
+	if !validation.MatchKubernetesStorageClass(n.StorageClassName) {
+		return validation.ErrInvalidSCName
+	}
+	// reclaim policy
+	return validation.MatchKubernetesReclaimPolicy(n.ReclaimPolicy)
+}
+
+func (n *NFS) InitSteps(ctx context.Context) error {
+	metadata := component.GetExtraMetadata(ctx)
+	n.Replicas = len(metadata.Masters.GetNodeIDs())
+	n.KubeletRootDir = metadata.KubeletDataDir
+	// when the component does not specify an ImageRepoMirror, the cluster LocalRegistry is inherited
+	if n.ImageRepoMirror == "" {
+		n.ImageRepoMirror = metadata.LocalRegistry
+	} else {
+		// set the component image repository to CRI insecure registry to avoid image pull failure
+		insecureRegistryStep, err := common.GetAddInsecureRegistry(metadata.Masters, metadata.CRI, n.ImageRepoMirror)
+		if err != nil {
+			return err
+		}
+		n.installSteps = append(n.installSteps, insecureRegistryStep)
+	}
+	if metadata.Offline && n.ImageRepoMirror == "" {
+		// TODO: arch is unnecessary, version can be configured
+		imageloader := &ImageLoader{
+			Version: "v4.1.0",
+			CriType: metadata.CRI,
+			Offline: metadata.Offline,
+		}
+		iData, err := json.Marshal(imageloader)
+		if err != nil {
+			return err
+		}
+		n.installSteps = append(n.installSteps, v1.Step{
+			ID:         strutil.GetUUID(),
+			Name:       "imageLoader",
+			Timeout:    metav1.Duration{Duration: 5 * time.Minute},
+			ErrIgnore:  false,
+			RetryTimes: 1,
+			Nodes:      utils.UnwrapNodeList(metadata.Masters),
+			Action:     v1.ActionInstall,
+			Commands: []v1.Command{
+				{
+					Type:          v1.CommandCustom,
+					Identity:      fmt.Sprintf(component.RegisterTemplateKeyFormat, name, version, AgentImageLoader),
+					CustomCommand: iData,
+				},
+			},
+		})
+	}
+	bytes, err := json.Marshal(n)
+	if err != nil {
+		return err
+	}
+
+	stepMaster0 := utils.UnwrapNodeList(metadata.Masters[:1])
+	rs := v1.Step{
+		ID:         strutil.GetUUID(),
+		Name:       "renderNFSCSIManifests",
+		Timeout:    metav1.Duration{Duration: 3 * time.Second},
+		ErrIgnore:  true,
+		RetryTimes: 1,
+		Nodes:      stepMaster0,
+		Action:     v1.ActionInstall,
+		Commands: []v1.Command{
+			{
+				Type: v1.CommandTemplateRender,
+				Template: &v1.TemplateCommand{
+					Identity: fmt.Sprintf(component.RegisterTemplateKeyFormat, name, version, nfs),
+					Data:     bytes,
+				},
+			},
+		},
+	}
+	n.installSteps = append(n.installSteps, []v1.Step{
+		rs,
+		{
+			ID:         strutil.GetUUID(),
+			Name:       "deployNFSProvisioner",
+			Timeout:    metav1.Duration{Duration: 3 * time.Second},
+			ErrIgnore:  true,
+			RetryTimes: 1,
+			Nodes:      stepMaster0,
+			Action:     v1.ActionInstall,
+			Commands: []v1.Command{
+				{
+					Type:         v1.CommandShell,
+					ShellCommand: []string{"kubectl", "apply", "-f", filepath.Join(n.ManifestsDir, fmt.Sprintf(defaultFilenameFormat, n.StorageClassName))},
+				},
+			},
+		},
+	}...)
+	return nil
+}
+
+func (n *NFS) GetInstallSteps() []v1.Step {
+	return n.installSteps
+}
+
+func (n *NFS) GetUninstallSteps() []v1.Step {
+	return n.uninstallSteps
+}
+
+func (n *NFS) GetUpgradeSteps() []v1.Step {
+	return n.upgradeSteps
+}
+
+func (n *NFS) Install(ctx context.Context) error {
+	return nil
+}
+
+func (n *NFS) UnInstall(ctx context.Context) error {
+	return nil
+}
+
+type ImageLoader struct {
+	Version string
+	CriType string
+	Offline bool
+}
+
+func (n *ImageLoader) Install(ctx context.Context, opts component.Options) ([]byte, error) {
+	instance, err := downloader.NewInstance(ctx, nfs, n.Version, runtime.GOARCH, !n.Offline, opts.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	dstFile, err := instance.DownloadImages()
+	if err != nil {
+		return nil, err
+	}
+	// load image package
+	if err = utils.LoadImage(ctx, opts.DryRun, dstFile, n.CriType); err == nil {
+		logger.Info("nfs packages offline install successfully")
+	}
+
+	return nil, err
+}
+
+func (n *ImageLoader) Uninstall(ctx context.Context, opts component.Options) ([]byte, error) {
+	instance, err := downloader.NewInstance(ctx, nfs, n.Version, runtime.GOARCH, !n.Offline, opts.DryRun)
+	if err != nil {
+		return nil, err
+	}
+	if err = instance.RemoveImages(); err != nil {
+		logger.Error("remove nfs images compressed file failed", zap.Error(err))
+	}
+	return nil, nil
+}
+
+func (n *ImageLoader) NewInstance() component.ObjectMeta {
+	return &ImageLoader{}
+}
+
+func initI18nForComponentMeta() error {
+	return component.AddI18nMessages(component.I18nMessages{
+		{
+			ID:      "nfs-csi.metaTitle",
+			English: "NFS CSI Setting",
+			Chinese: "NFS CSI 设置",
+		},
+	})
+}

--- a/pkg/component/nfscsi/template.go
+++ b/pkg/component/nfscsi/template.go
@@ -1,0 +1,342 @@
+package nfscsi
+
+const csiControllerTemplate = `---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nfs-controller-sa
+  namespace: {{.Namespace}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-nfs-node-sa
+  namespace: {{.Namespace}}
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nfs-external-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nfs-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-nfs-controller-sa
+    namespace: {{.Namespace}}
+roleRef:
+  kind: ClusterRole
+  name: nfs-external-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: csi-nfs-node
+  namespace: {{.Namespace}}
+spec:
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-nfs-node
+  template:
+    metadata:
+      labels:
+        app: csi-nfs-node
+    spec:
+      hostNetwork: true  # original nfs connection would be broken without hostNetwork setting
+      dnsPolicy: Default  # available values: Default, ClusterFirstWithHostNet, ClusterFirst
+      serviceAccountName: csi-nfs-node-sa
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: "Exists"
+      containers:
+        - name: liveness-probe
+          image: {{with .ImageRepoMirror}}{{.}}/{{end}}caas4/livenessprobe:v2.7.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29653
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: node-driver-registrar
+          image: {{with .ImageRepoMirror}}{{.}}/{{end}}caas4/csi-node-driver-registrar:v2.5.1
+          args:
+            - --v=2
+            - --csi-address=/csi/csi.sock
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
+          env:
+            - name: DRIVER_REG_SOCK_PATH
+              value: {{.KubeletRootDir}}/plugins/csi-nfsplugin/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: nfs
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          image: {{with .ImageRepoMirror}}{{.}}/{{end}}caas4/nfsplugin:v4.1.0
+          args:
+            - "-v=5"
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+          ports:
+            - containerPort: 29653
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 30
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: {{.KubeletRootDir}}/pods
+              mountPropagation: "Bidirectional"
+          resources:
+            limits:
+              memory: 300Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: {{.KubeletRootDir}}/plugins/csi-nfsplugin
+            type: DirectoryOrCreate
+        - name: pods-mount-dir
+          hostPath:
+            path: {{.KubeletRootDir}}/pods
+            type: Directory
+        - hostPath:
+            path: {{.KubeletRootDir}}/plugins_registry
+            type: Directory
+          name: registration-dir
+---
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: nfs.csi.k8s.io
+spec:
+  attachRequired: false
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral
+  fsGroupPolicy: File
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: csi-nfs-controller
+  namespace: {{.Namespace}}
+spec:
+  replicas: {{with .Replicas}}{{.}}{{else}}1{{end}}
+  selector:
+    matchLabels:
+      app: csi-nfs-controller
+  template:
+    metadata:
+      labels:
+        app: csi-nfs-controller
+    spec:
+      hostNetwork: true  # controller also needs to mount nfs to create dir
+      dnsPolicy: Default  # available values: Default, ClusterFirstWithHostNet, ClusterFirst
+      serviceAccountName: csi-nfs-controller-sa
+      nodeSelector:
+        kubernetes.io/os: linux  # add "kubernetes.io/role: master" to run controller on master node
+      priorityClassName: system-cluster-critical
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/controlplane"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: "Exists"
+          effect: "NoSchedule"
+      containers:
+        - name: csi-provisioner
+          image: {{with .ImageRepoMirror}}{{.}}/{{end}}caas4/csi-provisioner:v3.2.0
+          args:
+            - "-v=2"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--leader-election-namespace={{.Namespace}}"
+            - "--extra-create-metadata=true"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+          resources:
+            limits:
+              memory: 400Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: liveness-probe
+          image: {{with .ImageRepoMirror}}{{.}}/{{end}}caas4/livenessprobe:v2.7.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --probe-timeout=3s
+            - --health-port=29652
+            - --v=2
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+          resources:
+            limits:
+              memory: 100Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+        - name: nfs
+          image: {{with .ImageRepoMirror}}{{.}}/{{end}}caas4/nfsplugin:v4.1.0
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          imagePullPolicy: IfNotPresent
+          args:
+            - "-v=5"
+            - "--nodeid=$(NODE_ID)"
+            - "--endpoint=$(CSI_ENDPOINT)"
+          env:
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+          ports:
+            - containerPort: 29652
+              name: healthz
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 30
+          volumeMounts:
+            - name: pods-mount-dir
+              mountPath: {{.KubeletRootDir}}/pods
+              mountPropagation: "Bidirectional"
+            - mountPath: /csi
+              name: socket-dir
+          resources:
+            limits:
+              memory: 200Mi
+            requests:
+              cpu: 10m
+              memory: 20Mi
+      volumes:
+        - name: pods-mount-dir
+          hostPath:
+            path: {{.KubeletRootDir}}/pods
+            type: Directory
+        - name: socket-dir
+          emptyDir: {}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{.StorageClassName}}
+  {{- if .IsDefault}}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+  {{- end}}
+provisioner: nfs.csi.k8s.io
+parameters:
+  server: {{.ServerAddr}}
+  share: {{.SharedPath}}
+reclaimPolicy: {{.ReclaimPolicy}}
+volumeBindingMode: Immediate
+{{- if .MountOptions}}
+mountOptions:
+  {{- range .MountOptions }}
+  - {{ . }}
+  {{- end }}
+{{- end}}`


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

support nfs csi
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```