### PR TITLE
add deprecated field to mark plugin be deprecated

### DIFF
--- a/pkg/component/interface.go
+++ b/pkg/component/interface.go
@@ -72,6 +72,7 @@ type Meta struct {
 	Unique         bool             `json:"unique"`
 	Template       bool             `json:"template"`
 	Category       string           `json:"category"`
+	Deprecated     bool             `json:"deprecated"`
 	Name           string           `json:"name"`
 	Version        string           `json:"version"`
 	Dependence     []string         `json:"dependence"`

--- a/pkg/component/nfs/nfs.go
+++ b/pkg/component/nfs/nfs.go
@@ -406,6 +406,7 @@ func (n *NFSProvisioner) GetComponentMeta(lang component.Lang) component.Meta {
 		Version:    version,
 		Unique:     false,
 		Template:   true,
+		Deprecated: true,
 		Dependence: []string{component.InternalCategoryKubernetes},
 		Category:   component.InternalCategoryStorage,
 		Priority:   3,


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
Add deprecated field
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```