### PR TITLE
fix: kcctl subcommand has a bug where the ssh port is 0

### DIFF
--- a/cmd/kcctl/app/options/options.go
+++ b/cmd/kcctl/app/options/options.go
@@ -273,11 +273,8 @@ func (a AgentRegions) Exists(ip string) bool {
 
 func NewDeployOptions() *DeployConfig {
 	return &DeployConfig{
-		IPDetect: autodetection.MethodFirst,
-		SSHConfig: &sshutils.SSH{
-			User: "root",
-			Port: 22,
-		},
+		IPDetect:  autodetection.MethodFirst,
+		SSHConfig: sshutils.NewSSH(),
 		EtcdConfig: &Etcd{
 			ClientPort:  2379,
 			PeerPort:    2380,
@@ -427,7 +424,7 @@ func (c *DeployConfig) AddFlags(flags *pflag.FlagSet) {
 func AddFlagsToSSH(ssh *sshutils.SSH, flags *pflag.FlagSet) {
 	flags.StringVarP(&ssh.User, "user", "u", ssh.User, "Deploy ssh user")
 	flags.StringVar(&ssh.Password, "passwd", ssh.Password, "Deploy ssh password")
-	flags.IntVar(&ssh.Port, "ssh-port", ssh.Port, "ssh connection port of agent nodes")
+	flags.IntVar(&ssh.Port, "ssh-port", 22, "ssh connection port of agent nodes")
 	flags.StringVar(&ssh.PkFile, "pk-file", ssh.PkFile, "ssh pk file which used to remote access other agent nodes")
 	flags.StringVar(&ssh.PkPassword, "pk-passwd", ssh.PkPassword, "the password of the ssh pk file which used to remote access other agent nodes")
 }

--- a/pkg/cli/registry/registry.go
+++ b/pkg/cli/registry/registry.go
@@ -151,11 +151,9 @@ var (
 
 func NewRegistryOptions(streams options.IOStreams) *RegistryOptions {
 	return &RegistryOptions{
-		IOStreams:  streams,
-		PrintFlags: printer.NewPrintFlags(),
-		SSHConfig: &sshutils.SSH{
-			User: "root",
-		},
+		IOStreams:      streams,
+		PrintFlags:     printer.NewPrintFlags(),
+		SSHConfig:      sshutils.NewSSH(),
 		DataRoot:       "/var/lib/docker",
 		RegistryVolume: "/opt/registry",
 		RegistryPort:   5000,

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -81,11 +81,9 @@ type UpgradeOptions struct {
 func NewUpgradeOptions(stream options.IOStreams) *UpgradeOptions {
 	return &UpgradeOptions{
 		BaseOptions: BaseOptions{
-			CliOpts: options.NewCliOptions(),
-			client:  nil,
-			SSHConfig: &sshutils.SSH{
-				User: "root",
-			},
+			CliOpts:      options.NewCliOptions(),
+			client:       nil,
+			SSHConfig:    sshutils.NewSSH(),
 			IOStreams:    stream,
 			deployConfig: options.NewDeployOptions(),
 		},

--- a/pkg/utils/sshutils/ssh.go
+++ b/pkg/utils/sshutils/ssh.go
@@ -38,6 +38,13 @@ type SSH struct {
 	ConnectionTimeout *time.Duration `json:"connectionTimeout,omitempty" yaml:"connectionTimeout,omitempty"`
 }
 
+func NewSSH() *SSH {
+	return &SSH{
+		User: "root",
+		Port: 22,
+	}
+}
+
 func (ss *SSH) NewClient(host string) (*ssh.Client, error) {
 	return ss.connect(host)
 }


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Fix the bug that the kcctl subcommand has a ssh port of 0.

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #262 

### Special notes for reviewers:
```
@x893675 @Metrora 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @Metrora 