### PR TITLE
fix: deploy aio support master branch

### DIFF
--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -183,8 +183,11 @@ func (d *DeployOptions) Complete() error {
 	if d.deployConfig.ServerIPs == nil && d.agents == nil {
 		d.aio = true
 		if d.deployConfig.Pkg == "" {
-			tag, _ := strutil.ParseGitDescribeInfo(version.Get().GitVersion)
-			d.deployConfig.Pkg = fmt.Sprintf(defaultPkg, tag, runtime.GOARCH)
+			v := os.Getenv("KC_VERSION")
+			if v == "" {
+				v, _ = strutil.ParseGitDescribeInfo(version.Get().GitVersion)
+			}
+			d.deployConfig.Pkg = fmt.Sprintf(defaultPkg, v, runtime.GOARCH)
 		}
 		// set etcd port to avoid conflicts with k8s
 		d.deployConfig.EtcdConfig.ClientPort = allInOneEtcdClientPort


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```