### PR TITLE
fix: use agentID to drain node,compatible multiple nic

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -33,6 +33,15 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+	apimachineryErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/json"
+	r "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/remotecommand"
+
 	"github.com/kubeclipper/kubeclipper/pkg/client/clientrest"
 	"github.com/kubeclipper/kubeclipper/pkg/clustermanage"
 	"github.com/kubeclipper/kubeclipper/pkg/component"
@@ -58,14 +67,6 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/utils/netutil"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/strutil"
-	"github.com/robfig/cron/v3"
-	"go.uber.org/zap"
-	apimachineryErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/json"
-	r "k8s.io/apimachinery/pkg/util/rand"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/remotecommand"
 )
 
 type handler struct {

--- a/pkg/apis/core/v1/utils.go
+++ b/pkg/apis/core/v1/utils.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 
 	"github.com/google/uuid"
+
 	"github.com/kubeclipper/kubeclipper/pkg/models/cluster"
 
 	"github.com/kubeclipper/kubeclipper/pkg/query"

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -67,8 +67,8 @@ func TestDeployOptions_getKcAgentConfigTemplateContent(t *testing.T) {
 		FloatIP: "1.1.1.1",
 	}
 	for range d.deployConfig.ServerIPs {
-		agentID := uuid.New().String()
-		t.Log(d.deployConfig.GetKcAgentConfigTemplateContent(metadata, agentID))
+		metadata.AgentID = uuid.New().String()
+		t.Log(d.deployConfig.GetKcAgentConfigTemplateContent(metadata))
 	}
 }
 

--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -192,7 +192,10 @@ func (c *JoinOptions) RunJoinNode() error {
 
 func (c *JoinOptions) runJoinAgentNode() error {
 	var err error
-	for ip, metadata := range c.parseAgent {
+	for ip := range c.parseAgent {
+		metadata := c.parseAgent[ip]
+		metadata.AgentID = uuid.New().String()
+		c.parseAgent[ip] = metadata
 		if err = c.agentNodeFiles(ip, metadata); err != nil {
 			return err
 		}
@@ -295,7 +298,7 @@ func (c *JoinOptions) getKcAgentConfigTemplateContent(metadata options.Metadata)
 	data["Region"] = metadata.Region
 	data["FloatIP"] = metadata.FloatIP
 	data["IPDetect"] = c.deployConfig.IPDetect
-	data["AgentID"] = uuid.New().String()
+	data["AgentID"] = metadata.AgentID
 	data["StaticServerAddress"] = fmt.Sprintf("http://%s:%d", c.deployConfig.ServerIPs[0], c.deployConfig.StaticServerPort)
 	if c.deployConfig.Debug {
 		data["LogLevel"] = "debug"

--- a/pkg/cli/utils/file.go
+++ b/pkg/cli/utils/file.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"os"
+	"path/filepath"
 )
 
 func FileExist(path string) bool {
@@ -27,8 +28,12 @@ func FileExist(path string) bool {
 	return !os.IsNotExist(err)
 }
 
-func WriteToFile(filePath string, data []byte) error {
-	f, err := os.Create(filePath)
+func WriteToFile(path string, data []byte) error {
+	err := os.MkdirAll(filepath.Dir(path), 0777)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path)
 	if err != nil {
 		return err
 	}

--- a/pkg/clustermanage/kubeadm/provider.go
+++ b/pkg/clustermanage/kubeadm/provider.go
@@ -406,7 +406,7 @@ func (r Kubeadm) deployKCAgent(ctx context.Context, node *v1.WorkerNode, region 
 	}
 
 	// 2. generate kubeclipper-agent.yaml、systemd conf,then start kc-agent
-	agentConfig, err := deployConfig.GetKcAgentConfigTemplateContent(options.Metadata{Region: region}, node.ID)
+	agentConfig, err := deployConfig.GetKcAgentConfigTemplateContent(options.Metadata{Region: region, AgentID: node.ID})
 	if err != nil {
 		return errors.WithMessage(err, "GetKcAgentConfigTemplateContent")
 	}
@@ -461,7 +461,7 @@ func (r Kubeadm) drainAgent(nodeIP, agentID string, ssh *sshutils.SSH) error {
 		return errors.WithMessage(err, "getDeployConfig")
 	}
 
-	if !deployConfig.Agents.Exists(nodeIP) {
+	if deployConfig.Agents.ExistsByID(nodeIP) {
 		err = r.updateDeployConfigAgents(nodeIP, nil, "del")
 		if err != nil {
 			logger.Errorf("add agent ip to deploy config failed: %v", err)

--- a/pkg/controller/cluster_status.go
+++ b/pkg/controller/cluster_status.go
@@ -25,9 +25,10 @@ import (
 	"strings"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubeclipper/kubeclipper/pkg/clustermanage"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/k8s"
 

--- a/pkg/controller/clustercontroller/controller.go
+++ b/pkg/controller/clustercontroller/controller.go
@@ -24,10 +24,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kubeclipper/kubeclipper/pkg/clustermanage"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/kubeclipper/kubeclipper/pkg/clustermanage"
 
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/reconcile"
 


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->
/kind bug
### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
bug fix，compatible multiple nic
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #201

### Special notes for reviewers:
```
deploy-config add agentID field
and used kcctl drain $agentID to drain
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```