### PR TITLE
add fuzzy search for node and event

### DIFF
--- a/pkg/models/cluster/cluster.go
+++ b/pkg/models/cluster/cluster.go
@@ -550,12 +550,25 @@ func (c *clusterOperator) nodeFuzzyFilter(obj runtime.Object, q *query.Query) []
 			if !models.ObjectMetaFilter(node.ObjectMeta, k, v) {
 				selected = false
 			}
+			if !nodeCustomFilter(&nodes.Items[index], k, v) {
+				selected = false
+			}
 		}
 		if selected {
 			objs = append(objs, &nodes.Items[index])
 		}
 	}
 	return objs
+}
+
+func nodeCustomFilter(node *v1.Node, key, value string) bool {
+	switch key {
+	case "default-ip":
+		if !strings.Contains(node.Status.Ipv4DefaultIP, value) {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *clusterOperator) regionFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {

--- a/pkg/models/platform/platformsetting_test.go
+++ b/pkg/models/platform/platformsetting_test.go
@@ -54,7 +54,7 @@ func Test_platformOperator_eventFilter(t *testing.T) {
 						},
 					},
 				},
-				in1: nil,
+				in1: query.New(),
 			},
 			want: []runtime.Object{
 				&v1.Event{


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
use `fuzzy~default-ip=xxx` to query node
use `fuzzy~ip=xxx` to query event
use `fuzzy~username=xxx` to query event
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```