### PR TITLE
fix: importing clusters of the same name to the kc platform will over…

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -3171,7 +3171,7 @@ func (h *handler) PreCheckCloudProvider(req *restful.Request, resp *restful.Resp
 		return
 	}
 
-	provider, err := clustermanage.GetProvider(clustermanage.Operator{CloudProviderReader: h.clusterOperator}, *cp)
+	provider, err := clustermanage.GetProvider(clustermanage.Operator{ClusterReader: h.clusterOperator, CloudProviderReader: h.clusterOperator}, *cp)
 	if err != nil {
 		restplus.HandleBadRequest(resp, req, err)
 		return
@@ -3201,7 +3201,7 @@ func (h *handler) CreateCloudProvider(req *restful.Request, resp *restful.Respon
 		return
 	}
 
-	provider, err := clustermanage.GetProvider(clustermanage.Operator{CloudProviderReader: h.clusterOperator}, *cp)
+	provider, err := clustermanage.GetProvider(clustermanage.Operator{ClusterReader: h.clusterOperator, CloudProviderReader: h.clusterOperator}, *cp)
 	if err != nil {
 		restplus.HandleBadRequest(resp, req, err)
 		return

--- a/pkg/apis/core/v1/utils.go
+++ b/pkg/apis/core/v1/utils.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 
 	"github.com/google/uuid"
-
 	"github.com/kubeclipper/kubeclipper/pkg/models/cluster"
 
 	"github.com/kubeclipper/kubeclipper/pkg/query"

--- a/pkg/clustermanage/interface.go
+++ b/pkg/clustermanage/interface.go
@@ -35,6 +35,7 @@ type ProviderFactory interface {
 }
 
 type Operator struct {
+	ClusterReader cluster.ClusterReader
 	ClusterLister listerv1.ClusterLister
 	ClusterWriter cluster.ClusterWriter
 

--- a/pkg/clustermanage/kubeadm/provider.go
+++ b/pkg/clustermanage/kubeadm/provider.go
@@ -521,6 +521,14 @@ func (r Kubeadm) getDeployConfig() (*options.DeployConfig, error) {
 }
 
 func (r Kubeadm) PreCheck(ctx context.Context) (bool, error) {
+	clu, err := r.Operator.ClusterReader.GetCluster(ctx, r.Config.ClusterName)
+	if err != nil && !apimachineryErrors.IsNotFound(err) {
+		return false, err
+	}
+	if clu != nil {
+		return false, fmt.Errorf("cluster %s already exists", clu.Name)
+	}
+
 	providers, err := r.Operator.CloudProviderReader.ListCloudProviders(ctx, &query.Query{})
 	if err != nil {
 		return false, err


### PR DESCRIPTION
…write each other

Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
importing clusters of the same name to the kc platform will overwrite each other
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #315 

### Special notes for reviewers:
```
@x893675 @lixd 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lixd 