### PR TITLE
add ForceIgnoreError option to delivery service

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1281,6 +1281,13 @@
           },
           {
             "type": "boolean",
+            "default": false,
+            "description": "force delete cluster, will ignore operation error",
+            "name": "force",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
             "description": "dry run delete clusters",
             "name": "dryRun",
             "in": "query"
@@ -5550,7 +5557,8 @@
         "type",
         "Version",
         "CriType",
-        "Offline"
+        "Offline",
+        "namespace"
       ],
       "properties": {
         "CriType": {
@@ -5568,6 +5576,9 @@
         "localRegistry": {
           "type": "string"
         },
+        "namespace": {
+          "type": "string"
+        },
         "type": {
           "type": "string",
           "enum": [
@@ -5577,10 +5588,6 @@
       }
     },
     "v1.CRIRegistry": {
-      "required": [
-        "insecureRegistry",
-        "registryRef"
-      ],
       "properties": {
         "insecureRegistry": {
           "type": "string"
@@ -5826,6 +5833,12 @@
             "$ref": "#/definitions/v1.ComponentConditions"
           }
         },
+        "controlPlaneHealth": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1.ControlPlaneHealth"
+          }
+        },
         "phase": {
           "type": "string"
         },
@@ -5984,6 +5997,22 @@
           "enum": [
             "1.4.4"
           ]
+        }
+      }
+    },
+    "v1.ControlPlaneHealth": {
+      "properties": {
+        "address": {
+          "type": "string"
+        },
+        "hostname": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
         }
       }
     },

--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -304,6 +304,7 @@ func (h *handler) DeleteCluster(request *restful.Request, response *restful.Resp
 		timeoutSecs = v1.DefaultOperationTimeoutSecs
 	}
 	dryRun := query.GetBoolValueWithDefault(request, query.ParamDryRun, false)
+	force := query.GetBoolValueWithDefault(request, query.ParameterForce, false)
 	c, err := h.clusterOperator.GetClusterEx(request.Request.Context(), name, "0")
 	if err != nil {
 		if apimachineryErrors.IsNotFound(err) {
@@ -366,7 +367,7 @@ func (h *handler) DeleteCluster(request *restful.Request, response *restful.Resp
 		if err := h.delivery.DeliverTaskOperation(context.TODO(), o, opts); err != nil {
 			logger.Error("delivery task error", zap.Error(err))
 		}
-	}(op, &service.Options{DryRun: dryRun})
+	}(op, &service.Options{DryRun: dryRun, ForceSkipError: force})
 	response.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/apis/core/v1/registry.go
+++ b/pkg/apis/core/v1/registry.go
@@ -121,6 +121,8 @@ func SetupWebService(h *handler) *restful.WebService {
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
 		Doc("Delete clusters.").
 		Param(webservice.PathParameter("name", "cluster name")).
+		Param(webservice.QueryParameter(query.ParameterForce, "force delete cluster, will ignore operation error").
+			Required(false).DataType("boolean").DefaultValue("false")).
 		Param(webservice.QueryParameter(query.ParamDryRun, "dry run delete clusters").
 			Required(false).DataType("boolean")).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), nil))

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -54,6 +54,7 @@ const (
 	ParamOffline                  = "offline"
 	ParameterSubDomain            = "subdomain"
 	ParameterFuzzySearch          = "fuzzy"
+	ParameterForce                = "force"
 )
 
 const (

--- a/pkg/service/delivery/delivery.go
+++ b/pkg/service/delivery/delivery.go
@@ -446,7 +446,7 @@ func (s *Service) DeliverTaskOperation(ctx context.Context, operation *v1.Operat
 		logger.Debug("after delivery task step", zap.Error(err))
 		if err != nil {
 			logger.Error("delivery task step error", zap.Error(err), zap.String("step", step.Name))
-			if step.ErrIgnore {
+			if step.ErrIgnore || opts.ForceSkipError {
 				logger.Debug("delivery task step, ignore the error", zap.Error(err), zap.String("step", step.Name))
 				// reset error
 				err = nil

--- a/pkg/service/msg.go
+++ b/pkg/service/msg.go
@@ -82,5 +82,6 @@ type LogOperation struct {
 }
 
 type Options struct {
-	DryRun bool
+	DryRun         bool
+	ForceSkipError bool
 }


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```