### PR TITLE
fix: The backup name is not the same as the backup file name

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -1171,7 +1171,7 @@ func (h *handler) CreateBackup(request *restful.Request, response *restful.Respo
 	randNum := r.String(6)
 	backup.Name = fmt.Sprintf("%s-%s-%s", c.Name, backup.Name, randNum)
 	backup.Status.KubernetesVersion = c.KubernetesVersion
-	backup.Status.FileName = fmt.Sprintf("%s-%s", c.Name, backup.Name)
+	backup.Status.FileName = backup.Name
 	backup.BackupPointName = c.Labels[common.LabelBackupPoint]
 	_, ok := backup.Annotations[common.AnnotationDescription]
 	if !ok {

--- a/pkg/controller/cronbackupcontroller/controller.go
+++ b/pkg/controller/cronbackupcontroller/controller.go
@@ -283,7 +283,7 @@ func (r *CronBackupReconciler) createBackup(log logger.Logging, cronBackup *v1.C
 	}
 
 	backup.Status.KubernetesVersion = c.KubernetesVersion
-	backup.Status.FileName = fmt.Sprintf("%s-%s", c.Name, backup.Name)
+	backup.Status.FileName = backup.Name
 	backup.BackupPointName = c.Labels[common.LabelBackupPoint]
 	// check preferred node in cluster
 	if backup.PreferredNode == "" {


### PR DESCRIPTION
Signed-off-by: Liucw <liu.chuwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeclipper/kubeclipper/issues/328

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@zhuzhenfan @x893675 