### PR TITLE
Fix the bug that importing clusters cannot use kubectl terminal

### DIFF
--- a/pkg/scheme/core/v1/k8s/kubeadm.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm.go
@@ -850,7 +850,7 @@ func (stepper *KubectlTerminal) NewInstance() component.ObjectMeta {
 
 func (stepper *KubectlTerminal) renderTo(w io.Writer) error {
 	at := tmplutil.New()
-	_, err := at.RenderTo(w, kubectlPodTemplate, stepper)
+	_, err := at.RenderTo(w, KubectlPodTemplate, stepper)
 	return err
 }
 

--- a/pkg/scheme/core/v1/k8s/template.go
+++ b/pkg/scheme/core/v1/k8s/template.go
@@ -162,7 +162,8 @@ spec:
 status: {}
 `
 
-const kubectlPodTemplate = `
+// KubectlPodTemplate kubectl terminal service yaml template
+const KubectlPodTemplate = `
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
Importing a cluster does not work with the kubectl terminal. The reason is that the kubectl pod proxy service is not runnin


### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #344

### Special notes for reviewers:
```
@x893675 @lixd 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lixd 