### PR TITLE
fix: add worker node not install addon component

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -883,6 +883,9 @@ func (h *handler) getClusterMetadata(ctx context.Context, c *v1.Cluster) (*compo
 		CNI:                c.CNI.Type,
 		CNINamespace:       c.CNI.Namespace,
 	}
+
+	meta.Addons = append(meta.Addons, c.Addons...)
+
 	masters, err := h.getNodeInfo(ctx, c.Masters)
 	if err != nil {
 		return nil, err

--- a/pkg/component/ctx.go
+++ b/pkg/component/ctx.go
@@ -45,9 +45,9 @@ type ExtraMetadata struct {
 	OperationType      string
 	KubeletDataDir     string
 	ControlPlaneStatus []v1.ControlPlaneHealth
-
-	CNI          string
-	CNINamespace string
+	Addons             []v1.Addon
+	CNI                string
+	CNINamespace       string
 }
 
 type Node struct {

--- a/pkg/component/utils/utils.go
+++ b/pkg/component/utils/utils.go
@@ -23,9 +23,8 @@ import (
 	"strings"
 	"time"
 
-	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
-
 	"github.com/kubeclipper/kubeclipper/pkg/component"
+	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 
 	"github.com/kubeclipper/kubeclipper/pkg/logger"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/cmdutil"

--- a/pkg/scheme/core/v1/k8s/node.go
+++ b/pkg/scheme/core/v1/k8s/node.go
@@ -150,6 +150,30 @@ func (stepper *GenNode) MakeInstallSteps(metadata *component.ExtraMetadata, patc
 			return err
 		}
 		stepper.installSteps = append(stepper.installSteps, steps...)
+
+		for _, addon := range metadata.Addons {
+			ad, ok := component.Load(fmt.Sprintf(component.RegisterFormat, addon.Name, addon.Version))
+			if !ok {
+				continue
+			}
+			compMeta := ad.NewInstance()
+			if err := json.Unmarshal(addon.Config.Raw, compMeta); err != nil {
+				return err
+			}
+			newComp, _ := compMeta.(component.Interface)
+			if err := newComp.InitSteps(component.WithExtraMetadata(context.TODO(), *metadata)); err != nil {
+				return err
+			}
+			stepList := newComp.GetInstallSteps()
+			for _, st := range stepList {
+				// TODO: Temporarily use hardcode to adjust, and subsequently optimize the step code for image download and load
+				if st.Name == "imageLoader" {
+					st.Nodes = patchNodes
+					stepper.installSteps = append(stepper.installSteps, st)
+					break
+				}
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
when a worker node is added to a cluster, it is not useful to load the image of the addon component

Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
When the worker node is added to the cluster, the image of the addon component is not loaded, resulting in the pod landing on the node without the corresponding addon image

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #346

### Special notes for reviewers:
```
@x893675 @qinyer 
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @qinyer 