### PR TITLE
fix create cluster e2e spec

### DIFF
--- a/test/e2e/cluster/cluster_aio.go
+++ b/test/e2e/cluster/cluster_aio.go
@@ -102,7 +102,7 @@ func initAIOCluster(clusterName string, nodeID []string) *corev1.Cluster {
 				ID: nodeID[0],
 			},
 		},
-		Workers:           nil,
+		Workers:           corev1.WorkerNodeList{},
 		KubernetesVersion: "v1.23.6",
 		CertSANs:          nil,
 		LocalRegistry:     "",
@@ -124,7 +124,7 @@ func initAIOCluster(clusterName string, nodeID []string) *corev1.Cluster {
 		CNI: corev1.CNI{
 			LocalRegistry: "",
 			Type:          "calico",
-			Version:       "v3.21.2",
+			Version:       "v3.22.4",
 			Calico: &corev1.Calico{
 				IPv4AutoDetection: "first-found",
 				IPv6AutoDetection: "first-found",

--- a/test/e2e/cluster/cluster_ha.go
+++ b/test/e2e/cluster/cluster_ha.go
@@ -91,7 +91,7 @@ func initHACluster(clusterName string, nodeList corev1.WorkerNodeList) *corev1.C
 			},
 		},
 		Masters:           nodeList,
-		Workers:           nil,
+		Workers:           corev1.WorkerNodeList{},
 		KubernetesVersion: "v1.23.6",
 		CertSANs:          nil,
 		LocalRegistry:     "",
@@ -113,7 +113,7 @@ func initHACluster(clusterName string, nodeList corev1.WorkerNodeList) *corev1.C
 		CNI: corev1.CNI{
 			LocalRegistry: "",
 			Type:          "calico",
-			Version:       "v3.21.2",
+			Version:       "v3.22.4",
 			Calico: &corev1.Calico{
 				IPv4AutoDetection: "first-found",
 				IPv6AutoDetection: "first-found",


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test
/area testing

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```