### PR TITLE
add e2e spec install aio cluster timeout parameter

### DIFF
--- a/test/framework/test_context.go
+++ b/test/framework/test_context.go
@@ -66,4 +66,6 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 		"cri image registry addr, default 127.0.0.1:5000")
 	flag.StringVar(&TestContext.WorkerNodeVip, "vip", defaultWorkerNodeVip,
 		"cluster worker node loadblance vip, default 169.254.169.100")
+	flag.DurationVar(&clusterInstallShort, "cluster-install-short-timeout", clusterInstallShort,
+		"cluster install short timeout interval")
 }

--- a/test/framework/timeouts.go
+++ b/test/framework/timeouts.go
@@ -2,7 +2,7 @@ package framework
 
 import "time"
 
-const (
+var (
 	// Default timeouts to be used in TimeoutContext
 	clusterInstall      = 15 * time.Minute
 	clusterInstallShort = 5 * time.Minute


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake
/area testing
### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
use  flag `cluster-install-short-timeout` set install aio cluster timeouts, default is 5m
e2e.test -cluster-install-short-timeout=10m -ginkgo.focus="AIO"
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```