### PR TITLE
fix: add global resource view api

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3200,6 +3200,69 @@
         }
       }
     },
+    "/api/core.kubeclipper.io/v1/projects/{project}/backuppoints": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Core-Cluster"
+        ],
+        "summary": "List of backup point api for project",
+        "operationId": "ListBackupPoints",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "limit=%d,page=%d",
+            "default": "limit=10,page=1",
+            "description": "paging query, e.g. limit=100,page=1",
+            "name": "paging",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "labelSelector=%s=%s",
+            "description": "resource filter by metadata label",
+            "name": "labelSelector",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "fieldSelector=%s=%s",
+            "description": "resource filter by field",
+            "name": "fieldSelector",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "resource sort reverse or not",
+            "name": "reverse",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "foo~bar,bar~baz",
+            "description": "fuzzy search conditions",
+            "name": "fuzzy",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/models.PageableResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/errors.HTTPError"
+            }
+          }
+        }
+      }
+    },
     "/api/core.kubeclipper.io/v1/projects/{project}/clusters": {
       "get": {
         "produces": [
@@ -3983,6 +4046,69 @@
         }
       }
     },
+    "/api/core.kubeclipper.io/v1/projects/{project}/domains": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Core-Cluster"
+        ],
+        "summary": "List domains api for project.",
+        "operationId": "ListDomains",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "limit=%d,page=%d",
+            "default": "limit=10,page=1",
+            "description": "paging query, e.g. limit=100,page=1",
+            "name": "paging",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "labelSelector=%s=%s",
+            "description": "resource filter by metadata label",
+            "name": "labelSelector",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "fieldSelector=%s=%s",
+            "description": "resource filter by field",
+            "name": "fieldSelector",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "resource sort reverse or not",
+            "name": "reverse",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "watch request",
+            "name": "watch",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "default": 60,
+            "description": "watch timeout seconds",
+            "name": "timeoutSeconds",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/models.PageableResponse"
+            }
+          }
+        }
+      }
+    },
     "/api/core.kubeclipper.io/v1/projects/{project}/logs": {
       "get": {
         "produces": [
@@ -4464,6 +4590,125 @@
             "description": "OK",
             "schema": {
               "$ref": "#/definitions/v1.Cluster"
+            }
+          }
+        }
+      }
+    },
+    "/api/core.kubeclipper.io/v1/projects/{project}/registries": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Core-Cluster"
+        ],
+        "summary": "List Registries api for projects.",
+        "operationId": "ListRegistry",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "limit=%d,page=%d",
+            "default": "limit=10,page=1",
+            "description": "paging query, e.g. limit=100,page=1",
+            "name": "paging",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "labelSelector=%s=%s",
+            "description": "resource filter by metadata label",
+            "name": "labelSelector",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "fieldSelector=%s=%s",
+            "description": "resource filter by field",
+            "name": "fieldSelector",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "resource sort reverse or not",
+            "name": "reverse",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "watch request",
+            "name": "watch",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "default": 60,
+            "description": "watch timeout seconds",
+            "name": "timeoutSeconds",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/models.PageableResponse"
+            }
+          }
+        }
+      }
+    },
+    "/api/core.kubeclipper.io/v1/projects/{project}/templates": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Core-Cluster"
+        ],
+        "summary": "List templates api for project.",
+        "operationId": "ListTemplates",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "limit=%d,page=%d",
+            "default": "limit=10,page=1",
+            "description": "paging query, e.g. limit=100,page=1",
+            "name": "paging",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "labelSelector=%s=%s",
+            "description": "resource filter by metadata label",
+            "name": "labelSelector",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "fieldSelector=%s=%s",
+            "description": "resource filter by field",
+            "name": "fieldSelector",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "resource sort reverse or not",
+            "name": "reverse",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/models.PageableResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/errors.HTTPError"
             }
           }
         }
@@ -5473,6 +5718,89 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/errors.HTTPError"
+            }
+          }
+        }
+      }
+    },
+    "/api/iam.kubeclipper.io/v1/projects/{project}/users": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Core-IAM"
+        ],
+        "summary": "List users api for project.",
+        "operationId": "ListUsers",
+        "parameters": [
+          {
+            "type": "string",
+            "format": "limit=%d,page=%d",
+            "default": "limit=10,page=1",
+            "description": "paging query, e.g. limit=100,page=1",
+            "name": "paging",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "role=%s",
+            "description": "resource filter by user role",
+            "name": "role",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "labelSelector=%s=%s",
+            "description": "resource filter by metadata label",
+            "name": "labelSelector",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "fieldSelector=%s=%s",
+            "description": "resource filter by field",
+            "name": "fieldSelector",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "resource sort reverse or not",
+            "name": "reverse",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
+            "description": "watch request",
+            "name": "watch",
+            "in": "query"
+          },
+          {
+            "type": "integer",
+            "default": 60,
+            "description": "watch timeout seconds",
+            "name": "timeoutSeconds",
+            "in": "query"
+          },
+          {
+            "type": "string",
+            "format": "foo~bar,bar~baz",
+            "description": "fuzzy search conditions",
+            "name": "fuzzy",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/models.PageableResponse"
+            }
           },
           "500": {
             "description": "Internal Server Error",

--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -2242,6 +2242,22 @@ func (h *handler) DescribeLease(request *restful.Request, response *restful.Resp
 
 func (h *handler) ListDomains(request *restful.Request, response *restful.Response) {
 	q := query.ParseQueryParameter(request)
+	ctx := request.Request.Context()
+
+	info, _ := reqpkg.InfoFrom(ctx)
+	if info.IsProjectScope() && !q.HasLabelSelector(fmt.Sprintf("!%s", common.LabelProject)) {
+		project := request.PathParameter("project")
+		if _, err := h.tenantOperator.GetProject(ctx, project); err != nil {
+			if apimachineryErrors.IsNotFound(err) {
+				restplus.HandleNotFound(response, request, err)
+				return
+			}
+			restplus.HandleInternalError(response, request, err)
+			return
+		}
+		q.AddLabelSelector([]string{fmt.Sprintf("%s=%s", common.LabelProject, project)})
+	}
+
 	if q.Watch {
 		h.watchDomain(request, response, q)
 		return
@@ -2871,6 +2887,21 @@ func decodeMsgToSSH(msg string) (*SSHCredential, error) {
 
 func (h *handler) ListTemplates(request *restful.Request, response *restful.Response) {
 	q := query.ParseQueryParameter(request)
+	ctx := request.Request.Context()
+	info, _ := reqpkg.InfoFrom(ctx)
+	if info.IsProjectScope() && !q.HasLabelSelector(fmt.Sprintf("!%s", common.LabelProject)) {
+		project := request.PathParameter("project")
+		if _, err := h.tenantOperator.GetProject(ctx, project); err != nil {
+			if apimachineryErrors.IsNotFound(err) {
+				restplus.HandleNotFound(response, request, err)
+				return
+			}
+			restplus.HandleInternalError(response, request, err)
+			return
+		}
+		q.AddLabelSelector([]string{fmt.Sprintf("%s=%s", common.LabelProject, project)})
+	}
+
 	templates, err := h.clusterOperator.ListTemplatesEx(request.Request.Context(), q)
 	if err != nil {
 		restplus.HandleInternalError(response, request, err)
@@ -2990,19 +3021,35 @@ func (h *handler) DescribeBackupPoint(request *restful.Request, response *restfu
 
 func (h *handler) ListBackupPoints(request *restful.Request, response *restful.Response) {
 	q := query.ParseQueryParameter(request)
+	ctx := request.Request.Context()
+
+	info, _ := reqpkg.InfoFrom(ctx)
+	if info.IsProjectScope() && !q.HasLabelSelector(fmt.Sprintf("!%s", common.LabelProject)) {
+		project := request.PathParameter("project")
+		if _, err := h.tenantOperator.GetProject(ctx, project); err != nil {
+			if apimachineryErrors.IsNotFound(err) {
+				restplus.HandleNotFound(response, request, err)
+				return
+			}
+			restplus.HandleInternalError(response, request, err)
+			return
+		}
+		q.AddLabelSelector([]string{fmt.Sprintf("%s=%s", common.LabelProject, project)})
+	}
+
 	if q.Watch {
 		h.watchBackupPoints(request, response, q)
 		return
 	}
 	if clientrest.IsInformerRawQuery(request.Request) {
-		result, err := h.clusterOperator.ListBackupPoints(request.Request.Context(), q)
+		result, err := h.clusterOperator.ListBackupPoints(ctx, q)
 		if err != nil {
 			restplus.HandleInternalError(response, request, err)
 			return
 		}
 		_ = response.WriteHeaderAndEntity(http.StatusOK, result)
 	} else {
-		result, err := h.clusterOperator.ListBackupPointEx(request.Request.Context(), q)
+		result, err := h.clusterOperator.ListBackupPointEx(ctx, q)
 		if err != nil {
 			restplus.HandleInternalError(response, request, err)
 			return
@@ -3791,19 +3838,35 @@ func (h *handler) DescribeRegistry(req *restful.Request, resp *restful.Response)
 
 func (h *handler) ListRegistry(req *restful.Request, resp *restful.Response) {
 	q := query.ParseQueryParameter(req)
+	ctx := req.Request.Context()
+
+	info, _ := reqpkg.InfoFrom(ctx)
+	if info.IsProjectScope() && !q.HasLabelSelector(fmt.Sprintf("!%s", common.LabelProject)) {
+		project := req.PathParameter("project")
+		if _, err := h.tenantOperator.GetProject(ctx, project); err != nil {
+			if apimachineryErrors.IsNotFound(err) {
+				restplus.HandleNotFound(resp, req, err)
+				return
+			}
+			restplus.HandleInternalError(resp, req, err)
+			return
+		}
+		q.AddLabelSelector([]string{fmt.Sprintf("%s=%s", common.LabelProject, project)})
+	}
+
 	if q.Watch {
 		h.watchRegistries(req, resp, q)
 		return
 	}
 	if clientrest.IsInformerRawQuery(req.Request) {
-		result, err := h.clusterOperator.ListRegistries(req.Request.Context(), q)
+		result, err := h.clusterOperator.ListRegistries(ctx, q)
 		if err != nil {
 			restplus.HandleInternalError(resp, req, err)
 			return
 		}
 		_ = resp.WriteHeaderAndEntity(http.StatusOK, result)
 	} else {
-		result, err := h.clusterOperator.ListRegistriesEx(req.Request.Context(), q)
+		result, err := h.clusterOperator.ListRegistriesEx(ctx, q)
 		if err != nil {
 			restplus.HandleInternalError(resp, req, err)
 			return

--- a/pkg/apis/core/v1/registry.go
+++ b/pkg/apis/core/v1/registry.go
@@ -919,6 +919,29 @@ func SetupWebService(h *handler) *restful.WebService {
 			DefaultValue("60").
 			Required(false)).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}))
+	webservice.Route(webservice.GET("/projects/{project}/domains").
+		To(h.ListDomains).
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		Doc("List domains api for project.").
+		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
+			Required(false).
+			DataFormat("limit=%d,page=%d").
+			DefaultValue("limit=10,page=1")).
+		Param(webservice.QueryParameter(query.ParameterLabelSelector, "resource filter by metadata label").
+			Required(false).
+			DataFormat("labelSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParameterFieldSelector, "resource filter by field").
+			Required(false).
+			DataFormat("fieldSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParamReverse, "resource sort reverse or not").Required(false).
+			DataType("boolean")).
+		Param(webservice.QueryParameter(query.ParameterWatch, "watch request").Required(false).
+			DataType("boolean")).
+		Param(webservice.QueryParameter(query.ParameterTimeoutSeconds, "watch timeout seconds").
+			DataType("integer").
+			DefaultValue("60").
+			Required(false)).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}))
 
 	webservice.Route(webservice.GET("/domains/{name}").
 		To(h.GetDomain).
@@ -1059,6 +1082,24 @@ func SetupWebService(h *handler) *restful.WebService {
 			DataType("boolean")).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}).
 		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
+	webservice.Route(webservice.GET("/projects/{project}/templates").
+		To(h.ListTemplates).
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		Doc("List templates api for project.").
+		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
+			Required(false).
+			DataFormat("limit=%d,page=%d").
+			DefaultValue("limit=10,page=1")).
+		Param(webservice.QueryParameter(query.ParameterLabelSelector, "resource filter by metadata label").
+			Required(false).
+			DataFormat("labelSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParameterFieldSelector, "resource filter by field").
+			Required(false).
+			DataFormat("fieldSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParamReverse, "resource sort reverse or not").Required(false).
+			DataType("boolean")).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}).
+		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
 
 	webservice.Route(webservice.GET("/templates/{name}").
 		To(h.DescribeTemplate).
@@ -1118,6 +1159,27 @@ func SetupWebService(h *handler) *restful.WebService {
 
 	webservice.Route(webservice.GET("/backuppoints").
 		Doc("List of backup point").
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		To(h.ListBackupPoints).
+		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
+			Required(false).
+			DataFormat("limit=%d,page=%d").
+			DefaultValue("limit=10,page=1")).
+		Param(webservice.QueryParameter(query.ParameterLabelSelector, "resource filter by metadata label").
+			Required(false).
+			DataFormat("labelSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParameterFieldSelector, "resource filter by field").
+			Required(false).
+			DataFormat("fieldSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParamReverse, "resource sort reverse or not").Required(false).
+			DataType("boolean")).
+		Param(webservice.QueryParameter(query.ParameterFuzzySearch, "fuzzy search conditions").
+			DataFormat("foo~bar,bar~baz").
+			Required(false)).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}).
+		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
+	webservice.Route(webservice.GET("/projects/{project}/backuppoints").
+		Doc("List of backup point api for project").
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
 		To(h.ListBackupPoints).
 		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
@@ -1438,6 +1500,29 @@ func SetupWebService(h *handler) *restful.WebService {
 		To(h.ListRegistry).
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
 		Doc("List Registries.").
+		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
+			Required(false).
+			DataFormat("limit=%d,page=%d").
+			DefaultValue("limit=10,page=1")).
+		Param(webservice.QueryParameter(query.ParameterLabelSelector, "resource filter by metadata label").
+			Required(false).
+			DataFormat("labelSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParameterFieldSelector, "resource filter by field").
+			Required(false).
+			DataFormat("fieldSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParamReverse, "resource sort reverse or not").Required(false).
+			DataType("boolean")).
+		Param(webservice.QueryParameter(query.ParameterWatch, "watch request").Required(false).
+			DataType("boolean")).
+		Param(webservice.QueryParameter(query.ParameterTimeoutSeconds, "watch timeout seconds").
+			DataType("integer").
+			DefaultValue("60").
+			Required(false)).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}))
+	webservice.Route(webservice.GET("/projects/{project}/registries").
+		To(h.ListRegistry).
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		Doc("List Registries api for projects.").
 		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
 			Required(false).
 			DataFormat("limit=%d,page=%d").

--- a/pkg/apis/iam/v1/handler.go
+++ b/pkg/apis/iam/v1/handler.go
@@ -600,15 +600,9 @@ func (h *handler) ListProjectMember(request *restful.Request, response *restful.
 	}
 
 	users := make([]iamv1.User, 0)
-	// TODO: add user selector filter
-	// q := query.ParseQueryParameter(request)
 	for _, roleBinding := range roleBindings.Items {
 		user, err := h.getProjectMember(&roleBinding)
 		if err != nil {
-			if apimachineryErrors.IsNotFound(err) {
-				restplus.HandleNotFound(response, request, err)
-				return
-			}
 			restplus.HandleInternalError(response, request, err)
 			return
 		}
@@ -720,6 +714,10 @@ func (h *handler) getProjectMember(roleBinding *iamv1.ProjectRoleBinding) (*iamv
 	}
 	user, err := h.iamOperator.GetUser(context.TODO(), roleBinding.Subjects[0].Name)
 	if err != nil {
+		// if user not found,ignore this roleBinding
+		if apimachineryErrors.IsNotFound(err) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if user.Annotations == nil {

--- a/pkg/apis/iam/v1/registry.go
+++ b/pkg/apis/iam/v1/registry.go
@@ -131,6 +131,36 @@ func AddToContainer(c *restful.Container, iamOperator iam.Operator, tenantOperat
 			Required(false)).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}).
 		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
+	webservice.Route(webservice.GET("/projects/{project}/users").
+		To(h.ListUsers).
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreIAMTag}).
+		Doc("List users api for project.").
+		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
+			Required(false).
+			DataFormat("limit=%d,page=%d").
+			DefaultValue("limit=10,page=1")).
+		Param(webservice.QueryParameter(query.ParamRole, "resource filter by user role").
+			Required(false).
+			DataFormat("role=%s")).
+		Param(webservice.QueryParameter(query.ParameterLabelSelector, "resource filter by metadata label").
+			Required(false).
+			DataFormat("labelSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParameterFieldSelector, "resource filter by field").
+			Required(false).
+			DataFormat("fieldSelector=%s=%s")).
+		Param(webservice.QueryParameter(query.ParamReverse, "resource sort reverse or not").Required(false).
+			DataType("boolean")).
+		Param(webservice.QueryParameter(query.ParameterWatch, "watch request").Required(false).
+			DataType("boolean")).
+		Param(webservice.QueryParameter(query.ParameterTimeoutSeconds, "watch timeout seconds").
+			DataType("integer").
+			DefaultValue("60").
+			Required(false)).
+		Param(webservice.QueryParameter(query.ParameterFuzzySearch, "fuzzy search conditions").
+			DataFormat("foo~bar,bar~baz").
+			Required(false)).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}).
+		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
 
 	webservice.Route(webservice.HEAD("/users").
 		To(h.CheckUserExist).

--- a/pkg/apis/iam/v1/registry.go
+++ b/pkg/apis/iam/v1/registry.go
@@ -364,9 +364,9 @@ func AddToContainer(c *restful.Container, iamOperator iam.Operator, tenantOperat
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), iamv1.ProjectRole{}).
 		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
 
-	webservice.Route(webservice.PUT("/projects/{project}/projectroles").
+	webservice.Route(webservice.PUT("/projects/{project}/projectroles/{projectrole}").
 		To(h.UpdateProjectRole).
-		Doc("Update role info").
+		Doc("Update projectrole info").
 		Reads(iamv1.ProjectRole{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreIAMTag}).
 		Param(webservice.PathParameter("project", "project name")).
@@ -424,7 +424,7 @@ func AddToContainer(c *restful.Container, iamOperator iam.Operator, tenantOperat
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), &iamv1.User{}).
 		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
 
-	webservice.Route(webservice.PUT("/projects/{project}/projectmembers").
+	webservice.Route(webservice.PUT("/projects/{project}/projectmembers/{projectmember}").
 		To(h.UpdateProjectMember).
 		Doc("Update member info in specified project").
 		Reads(iamv1.Member{}).

--- a/pkg/controller/projectcontroller/controller.go
+++ b/pkg/controller/projectcontroller/controller.go
@@ -368,7 +368,7 @@ var ProjectRoles = []iamv1.ProjectRole{
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubeclipper.io/aggregation-roles": "[\"role-template-view-projectroles\",\"role-template-create-projectroles\",\"role-template-edit-projectroles\",\"role-template-delete-projectroles\",\"role-template-view-projectmembers\",\"role-template-create-projectmembers\",\"role-template-edit-projectmembers\",\"role-template-delete-projectmembers\",\"role-template-view-clusters\",\"role-template-access-clusters\",\"role-template-create-clusters\",\"role-template-edit-clusters\",\"role-template-delete-clusters\",\"role-template-view-nodes\",\"role-template-create-nodes\",\"role-template-edit-nodes\",\"role-template-delete-nodes\"]",
+				"kubeclipper.io/aggregation-roles": "[\"role-template-view-users\",\"role-template-view-dns\",\"role-template-view-backuppoints\",\"role-template-view-templates\",\"role-template-view-registries\",\"role-template-view-projectroles\",\"role-template-create-projectroles\",\"role-template-edit-projectroles\",\"role-template-delete-projectroles\",\"role-template-view-projectmembers\",\"role-template-create-projectmembers\",\"role-template-edit-projectmembers\",\"role-template-delete-projectmembers\",\"role-template-view-clusters\",\"role-template-access-clusters\",\"role-template-create-clusters\",\"role-template-edit-clusters\",\"role-template-delete-clusters\",\"role-template-view-nodes\",\"role-template-create-nodes\",\"role-template-edit-nodes\",\"role-template-delete-nodes\"]",
 				"kubeclipper.io/internal":          "true",
 			},
 			Name: "admin", // real name will generate when creating,format is {project}-admin
@@ -392,7 +392,7 @@ var ProjectRoles = []iamv1.ProjectRole{
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubeclipper.io/aggregation-roles": "[\"role-template-view-clusters\",\"role-template-access-clusters\",\"role-template-create-clusters\",\"role-template-edit-clusters\",\"role-template-delete-clusters\",\"role-template-view-nodes\",\"role-template-create-nodes\",\"role-template-edit-nodes\",\"role-template-delete-nodes\"]",
+				"kubeclipper.io/aggregation-roles": "[\"role-template-view-dns\",\"role-template-view-backuppoints\",\"role-template-view-templates\",\"role-template-view-registries\",\"role-template-view-clusters\",\"role-template-access-clusters\",\"role-template-create-clusters\",\"role-template-edit-clusters\",\"role-template-delete-clusters\",\"role-template-view-nodes\",\"role-template-create-nodes\",\"role-template-edit-nodes\",\"role-template-delete-nodes\"]",
 				"kubeclipper.io/internal":          "true",
 			},
 			Name: "user",
@@ -400,12 +400,12 @@ var ProjectRoles = []iamv1.ProjectRole{
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"core.kubeclipper.io"},
-				Resources: []string{"clusters", "nodes", "regions", "operations"},
+				Resources: []string{"domains", "domains/records", "backuppoints", "templates", "templates"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{"core.kubeclipper.io"},
-				Resources: []string{"clusters", "clusters/nodes", "clusters/plugins", "nodes", "regions", "operations"},
+				Resources: []string{"clusters", "clusters/plugins", "clusters/join", "clusters/nodes", "clusters/backups", "clusters/cronbackups", "clusters/certification", "clusters/kubeconfig", "nodes", "operations"},
 				Verbs:     []string{"*"},
 			},
 		},
@@ -417,7 +417,7 @@ var ProjectRoles = []iamv1.ProjectRole{
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubeclipper.io/aggregation-roles": "[\"role-template-view-projectroles\",\"role-template-view-projectmembers\",\"role-template-view-clusters\",\"role-template-view-nodes\"]",
+				"kubeclipper.io/aggregation-roles": "[\"role-template-view-dns\",\"role-template-view-backuppoints\",\"role-template-view-templates\",\"role-template-view-registries\",\"role-template-view-projectroles\",\"role-template-view-projectmembers\",\"role-template-view-clusters\",\"role-template-view-nodes\"]",
 				"kubeclipper.io/internal":          "true",
 			},
 			Name: "view",

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -158,6 +158,16 @@ func (q *Query) AddLabelSelector(selector []string) {
 	q.LabelSelector = fmt.Sprintf("%s,%s", q.LabelSelector, strings.Join(selector, ","))
 }
 
+func (q *Query) HasLabelSelector(selector string) bool {
+	split := strings.Split(q.LabelSelector, ",")
+	for _, v := range split {
+		if v == selector {
+			return true
+		}
+	}
+	return false
+}
+
 func New() *Query {
 	return &Query{
 		Pagination: NoPagination(),

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -158,6 +158,7 @@ func (q *Query) AddLabelSelector(selector []string) {
 	q.LabelSelector = fmt.Sprintf("%s,%s", q.LabelSelector, strings.Join(selector, ","))
 }
 
+// HasLabelSelector check label is exist
 func (q *Query) HasLabelSelector(selector string) bool {
 	split := strings.Split(q.LabelSelector, ",")
 	for _, v := range split {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1187,7 +1187,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectmembers\": \"view\"}",
 				"kubeclipper.io/alias-name":          "ProjectMember View",
 				"kubeclipper.io/internal":            "true",
@@ -1213,7 +1213,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/dependencies":        "[\"role-template-view-projectmembers\",\"role-template-view-projectroles\"]",
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectmembers\": \"create\"}",
 				"kubeclipper.io/alias-name":          "ProjectMember Create",
 				"kubeclipper.io/internal":            "true",
@@ -1239,7 +1239,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/dependencies":        "[\"role-template-view-projectmembers\",\"role-template-view-projectroles\"]",
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectmembers\": \"edit\"}",
 				"kubeclipper.io/alias-name":          "ProjectMember Edit",
 				"kubeclipper.io/internal":            "true",
@@ -1265,7 +1265,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/dependencies":        "[\"role-template-view-projectmembers\",\"role-template-view-projectroles\"]",
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectmembers\": \"delete\"}",
 				"kubeclipper.io/alias-name":          "ProjectMember Delete",
 				"kubeclipper.io/internal":            "true",
@@ -1291,7 +1291,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/dependencies":        "[\"role-template-view-members\"]",
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectroles\": \"view\"}",
 				"kubeclipper.io/alias-name":          "ProjectRole View",
 				"kubeclipper.io/internal":            "true",
@@ -1317,7 +1317,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/dependencies":        "[\"role-template-view-projectroles\"]",
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectroles\": \"create\"}",
 				"kubeclipper.io/alias-name":          "ProjectRole Create",
 				"kubeclipper.io/internal":            "true",
@@ -1343,7 +1343,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/dependencies":        "[\"role-template-view-projectroles\"]",
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectroles\": \"edit\"}",
 				"kubeclipper.io/alias-name":          "ProjectRole Edit",
 				"kubeclipper.io/internal":            "true",
@@ -1369,7 +1369,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"kubeclipper.io/dependencies":        "[\"role-template-view-projectroles\"]",
-				"kubeclipper.io/module":              "Access Control",
+				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectroles\": \"delete\"}",
 				"kubeclipper.io/alias-name":          "ProjectRole Delete",
 				"kubeclipper.io/internal":            "true",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1911,4 +1911,108 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 			},
 		},
 	},
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       iamv1.KindProjectRole,
+			APIVersion: iamv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubeclipper.io/dependencies":        "[\"role-template-view-templates\"]",
+				"kubeclipper.io/module":              "Template",
+				"kubeclipper.io/role-template-rules": "{\"templates\": \"view\"}",
+				"kubeclipper.io/alias-name":          "Templates View",
+				"kubeclipper.io/internal":            "true",
+			},
+			Labels: map[string]string{
+				"kubeclipper.io/role-template": "true",
+			},
+			Name: "role-template-view-templates",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"core.kubeclipper.io"},
+				Resources: []string{"templates"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+		},
+	},
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       iamv1.KindProjectRole,
+			APIVersion: iamv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubeclipper.io/dependencies":        "[\"role-template-view-templates\"]",
+				"kubeclipper.io/module":              "Template",
+				"kubeclipper.io/role-template-rules": "{\"templates\": \"create\"}",
+				"kubeclipper.io/alias-name":          "Templates Create",
+				"kubeclipper.io/internal":            "true",
+			},
+			Labels: map[string]string{
+				"kubeclipper.io/role-template": "true",
+			},
+			Name: "role-template-create-templates",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"core.kubeclipper.io"},
+				Resources: []string{"templates"},
+				Verbs:     []string{"create"},
+			},
+		},
+	},
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       iamv1.KindProjectRole,
+			APIVersion: iamv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubeclipper.io/dependencies":        "[\"role-template-view-templates\"]",
+				"kubeclipper.io/module":              "Template",
+				"kubeclipper.io/role-template-rules": "{\"templates\": \"edit\"}",
+				"kubeclipper.io/alias-name":          "Templates Edit",
+				"kubeclipper.io/internal":            "true",
+			},
+			Labels: map[string]string{
+				"kubeclipper.io/role-template": "true",
+			},
+			Name: "role-template-edit-templates",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"core.kubeclipper.io"},
+				Resources: []string{"templates"},
+				Verbs:     []string{"update", "patch"},
+			},
+		},
+	},
+	{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       iamv1.KindProjectRole,
+			APIVersion: iamv1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				"kubeclipper.io/dependencies":        "[\"role-template-view-templates\"]",
+				"kubeclipper.io/module":              "Template",
+				"kubeclipper.io/role-template-rules": "{\"templates\": \"delete\"}",
+				"kubeclipper.io/alias-name":          "Templates Delete",
+				"kubeclipper.io/internal":            "true",
+			},
+			Labels: map[string]string{
+				"kubeclipper.io/role-template": "true",
+			},
+			Name: "role-template-delete-templates",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"core.kubeclipper.io"},
+				Resources: []string{"templates"},
+				Verbs:     []string{"delete"},
+			},
+		},
+	},
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -859,7 +859,7 @@ var Roles = []iamv1.GlobalRole{
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubeclipper.io/rego-override": "package authz\ndefault allow = false\nallow = true {\n  allowedResources := [\"users\"]\n  allowedResources[_] == input.Resource\n  input.User.Name == input.Name\n}\nallow = true {\nallowedResources := [\"projects\"]\nallowedResources[_] == input.Resource\ninput.Verb=\"list\"\n}",
+				"kubeclipper.io/rego-override": "package authz\ndefault allow = false\nallow = true {\n  allowedResources := [\"users\",\"projectmembers\"]\n  allowedResources[_] == input.Resource\n  input.User.Name == input.Name\n}\nallow = true {\nallowedResources := [\"projects\"]\nallowedResources[_] == input.Resource\ninput.Verb=\"list\"\n}",
 				"kubeclipper.io/internal":      "true",
 			},
 			Labels: map[string]string{

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1290,7 +1290,7 @@ var ProjectRolesTemplate = []iamv1.ProjectRole{
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"kubeclipper.io/dependencies":        "[\"role-template-view-members\"]",
+				"kubeclipper.io/dependencies":        "[\"role-template-view-projectmembers\"]",
 				"kubeclipper.io/module":              "Project Setting",
 				"kubeclipper.io/role-template-rules": "{\"projectroles\": \"view\"}",
 				"kubeclipper.io/alias-name":          "ProjectRole View",


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
add global resource's view api in project scope,and update roles
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```