### PR TITLE
add --force for kcctl delete cluster

### DIFF
--- a/pkg/cli/registry/registry.go
+++ b/pkg/cli/registry/registry.go
@@ -24,13 +24,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
 	"net/http"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
 
 	pkgerr "github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/sets"

--- a/pkg/clustermanage/kubeadm/provider.go
+++ b/pkg/clustermanage/kubeadm/provider.go
@@ -10,6 +10,17 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
+	v13 "k8s.io/api/core/v1"
+	v14 "k8s.io/api/rbac/v1"
+	apimachineryErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
 	agentconfig "github.com/kubeclipper/kubeclipper/pkg/agent/config"
 	"github.com/kubeclipper/kubeclipper/pkg/cli/config"
@@ -22,16 +33,6 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/k8s"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
 	tmplutil "github.com/kubeclipper/kubeclipper/pkg/utils/template"
-	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
-	v13 "k8s.io/api/core/v1"
-	v14 "k8s.io/api/rbac/v1"
-	apimachineryErrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/client-go/kubernetes"
 )
 
 func init() {

--- a/pkg/simple/client/kc/api.go
+++ b/pkg/simple/client/kc/api.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 
@@ -248,8 +249,20 @@ func (cli *Client) DeleteRole(ctx context.Context, name string) error {
 	return nil
 }
 
+// DeleteCluster Delete Cluster with name
+// Deprecated. Use DeleteClusterWithQuery instead
 func (cli *Client) DeleteCluster(ctx context.Context, name string) error {
 	serverResp, err := cli.delete(ctx, fmt.Sprintf("%s/%s", clustersPath, name), nil, nil)
+	defer ensureReaderClosed(serverResp)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteClusterWithQuery Delete Cluster with name and custom query parameter
+func (cli *Client) DeleteClusterWithQuery(ctx context.Context, name string, queryString url.Values) error {
+	serverResp, err := cli.delete(ctx, fmt.Sprintf("%s/%s", clustersPath, name), queryString, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind optimize

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```