### PR TITLE
fix: The month-end cronbackup cannot be edited

### DIFF
--- a/pkg/controller/cronbackupcontroller/controller.go
+++ b/pkg/controller/cronbackupcontroller/controller.go
@@ -130,7 +130,7 @@ func (r *CronBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if cronBackup.Spec.Schedule != "" {
 		// first created cron backup, update next schedule time
 		if cronBackup.Status.NextScheduleTime == nil {
-			schedule := r.parseSchedule(cronBackup.Spec.Schedule)
+			schedule := r.ParseSchedule(cronBackup.Spec.Schedule)
 			s, _ := cron.NewParser(4 | 8 | 16 | 32 | 64).Parse(schedule)
 			// update the next schedule time
 			nextRunAt := metav1.NewTime(s.Next(time.Now()))
@@ -158,7 +158,7 @@ func (r *CronBackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			cronBackup.Status.LastScheduleTime = &now
 			cronBackup.Status.LastSuccessfulTime = cronBackup.Status.LastScheduleTime
 
-			schedule := r.parseSchedule(cronBackup.Spec.Schedule)
+			schedule := r.ParseSchedule(cronBackup.Spec.Schedule)
 			s, _ := cron.NewParser(4 | 8 | 16 | 32 | 64).Parse(schedule)
 			// update the next schedule time
 			nextRunAt := metav1.NewTime(s.Next(now.Time))
@@ -540,7 +540,7 @@ func (r *CronBackupReconciler) deleteBackup(log logger.Logging, clusterName stri
 	return nil
 }
 
-func (r *CronBackupReconciler) parseSchedule(schedule string) string {
+func (r *CronBackupReconciler) ParseSchedule(schedule string) string {
 	currentTime := r.Now()
 	arr := strings.Split(schedule, " ")
 	if arr[2] == "L" {

--- a/pkg/controller/cronbackupcontroller/controller_test.go
+++ b/pkg/controller/cronbackupcontroller/controller_test.go
@@ -78,7 +78,7 @@ func TestCronBackupReconciler_parseSchedule(t *testing.T) {
 			s := &CronBackupReconciler{
 				Now: tt.fields.Now,
 			}
-			if got := s.parseSchedule(tt.args.schedule); got != tt.want {
+			if got := s.ParseSchedule(tt.args.schedule); got != tt.want {
 				t.Errorf("CronBackupReconciler.parseSchedule() = %v, want %v, %v", got, tt.want, tt.fields.Now().String())
 			}
 		})


### PR DESCRIPTION
Signed-off-by: Liucw <liu.chuwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeclipper/kubeclipper/issues/365

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@zhuzhenfan @x893675 