### PR TITLE
cherrypick: optimize force drain node and delete cluster (#382)

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -84,7 +84,7 @@ import (
 
 var (
 	allowedDeleteStatus = sets.NewString(string(v1.ClusterInstallFailed), string(v1.ClusterRunning), string(v1.ClusterUpgradeFailed),
-		string(v1.ClusterBackupError), string(v1.ClusterRestoreFailed), string(v1.ClusterTerminateFailed))
+		string(v1.ClusterRestoreFailed), string(v1.ClusterTerminateFailed), string(v1.ClusterUpdateFailed))
 )
 
 type handler struct {
@@ -220,7 +220,7 @@ func (h *handler) AddOrRemoveNodes(request *restful.Request, response *restful.R
 	nodeSet := c.GetAllNodes()
 
 	// We need IP addresses of all master nodes later.
-	extraMeta, err := h.getClusterMetadata(ctx, c)
+	extraMeta, err := h.getClusterMetadata(ctx, c, false)
 	if err != nil {
 		if apimachineryErrors.IsNotFound(err) || err == ErrNodesRegionDifferent {
 			restplus.HandleBadRequest(response, request, err)
@@ -241,7 +241,7 @@ func (h *handler) AddOrRemoveNodes(request *restful.Request, response *restful.R
 
 	// Get workers node information must be called before pn.MakeCompare, in order to ensure pn.Nodes = extraMeta.Workers.
 	// Replace cluster worker nodes with nodes to be operated.
-	nodes, err := h.getNodeInfo(ctx, pn.Nodes)
+	nodes, err := h.getNodeInfo(ctx, pn.Nodes, false)
 	if err != nil {
 		if err == ErrNodesRegionDifferent {
 			restplus.HandleBadRequest(response, request, err)
@@ -395,13 +395,26 @@ func (h *handler) DeleteCluster(request *restful.Request, response *restful.Resp
 		return
 	}
 
-	extraMeta, err := h.getClusterMetadata(request.Request.Context(), c)
+	extraMeta, err := h.getClusterMetadata(request.Request.Context(), c, force)
 	if err != nil {
 		if apimachineryErrors.IsNotFound(err) || err == ErrNodesRegionDifferent {
 			restplus.HandleBadRequest(response, request, err)
 			return
 		}
 		restplus.HandleInternalError(response, request, err)
+		return
+	}
+
+	if force && len(extraMeta.Masters) == 0 {
+		logger.Warn("force delete cluster when master node not found, delete cluster directly", zap.String("cluster", name))
+		if !dryRun {
+			err = h.clusterOperator.DeleteCluster(request.Request.Context(), name)
+			if err != nil {
+				restplus.HandleInternalError(response, request, err)
+				return
+			}
+		}
+		response.WriteHeader(http.StatusOK)
 		return
 	}
 
@@ -500,7 +513,7 @@ func (h *handler) CreateClusters(request *restful.Request, response *restful.Res
 	}
 	c.Complete()
 	// validate node exist
-	extraMeta, err := h.getClusterMetadata(request.Request.Context(), &c)
+	extraMeta, err := h.getClusterMetadata(request.Request.Context(), &c, false)
 	if err != nil {
 		if apimachineryErrors.IsNotFound(err) || err == ErrNodesRegionDifferent {
 			restplus.HandleBadRequest(response, request, err)
@@ -802,7 +815,7 @@ func (h *handler) UpdateClusterCertification(request *restful.Request, response 
 		}
 	}
 
-	extraMeta, err := h.getClusterMetadata(ctx, c)
+	extraMeta, err := h.getClusterMetadata(ctx, c, false)
 	if err != nil {
 		restplus.HandleBadRequest(response, request, err)
 		return
@@ -868,7 +881,7 @@ func (h *handler) GetKubeConfig(request *restful.Request, response *restful.Resp
 			return
 		}
 	} else {
-		extraMeta, err := h.getClusterMetadata(ctx, clu)
+		extraMeta, err := h.getClusterMetadata(ctx, clu, false)
 		if err != nil {
 			restplus.HandleInternalError(response, request, err)
 			return
@@ -1242,7 +1255,7 @@ func (h *handler) watchOperations(req *restful.Request, resp *restful.Response, 
 	restplus.ServeWatch(watcher, v1.SchemeGroupVersion.WithKind("Operation"), req, resp, timeout)
 }
 
-func (h *handler) getClusterMetadata(ctx context.Context, c *v1.Cluster) (*component.ExtraMetadata, error) {
+func (h *handler) getClusterMetadata(ctx context.Context, c *v1.Cluster, skipNodeNotFound bool) (*component.ExtraMetadata, error) {
 	meta := &component.ExtraMetadata{
 		ClusterName:        c.Name,
 		Offline:            c.Offline(),
@@ -1257,12 +1270,12 @@ func (h *handler) getClusterMetadata(ctx context.Context, c *v1.Cluster) (*compo
 
 	meta.Addons = append(meta.Addons, c.Addons...)
 
-	masters, err := h.getNodeInfo(ctx, c.Masters)
+	masters, err := h.getNodeInfo(ctx, c.Masters, skipNodeNotFound)
 	if err != nil {
 		return nil, err
 	}
 	meta.Masters = append(meta.Masters, masters...)
-	workers, err := h.getNodeInfo(ctx, c.Workers)
+	workers, err := h.getNodeInfo(ctx, c.Workers, skipNodeNotFound)
 	if err != nil {
 		return nil, err
 	}
@@ -1288,11 +1301,14 @@ func (h *handler) regionCheck(master, worker []component.Node) error {
 	return nil
 }
 
-func (h *handler) getNodeInfo(ctx context.Context, nodes v1.WorkerNodeList) ([]component.Node, error) {
+func (h *handler) getNodeInfo(ctx context.Context, nodes v1.WorkerNodeList, skipNodeNotFound bool) ([]component.Node, error) {
 	var meta []component.Node
 	for _, node := range nodes {
 		n, err := h.clusterOperator.GetNodeEx(ctx, node.ID, "0")
 		if err != nil {
+			if skipNodeNotFound && apimachineryErrors.IsNotFound(err) {
+				continue
+			}
 			return nil, err
 		}
 		item := component.Node{
@@ -2183,7 +2199,7 @@ func (h *handler) InstallOrUninstallPlugins(request *restful.Request, response *
 	}
 
 	// We need IP addresses of all master nodes later.
-	extraMeta, err := h.getClusterMetadata(ctx, clu)
+	extraMeta, err := h.getClusterMetadata(ctx, clu, false)
 	if err != nil {
 		if apimachineryErrors.IsNotFound(err) || err == ErrNodesRegionDifferent {
 			restplus.HandleBadRequest(response, request, err)
@@ -2294,7 +2310,7 @@ func (h *handler) UpgradeCluster(request *restful.Request, response *restful.Res
 	if v := request.QueryParameter("timeout"); v != "" {
 		timeoutSecs = v
 	}
-	extraMeta, err := h.getClusterMetadata(request.Request.Context(), clu)
+	extraMeta, err := h.getClusterMetadata(request.Request.Context(), clu, false)
 	if err != nil {
 		if apimachineryErrors.IsNotFound(err) || err == ErrNodesRegionDifferent {
 			restplus.HandleBadRequest(response, request, err)

--- a/pkg/apis/core/v1/utils.go
+++ b/pkg/apis/core/v1/utils.go
@@ -147,7 +147,7 @@ func (h *handler) initComponentExtraCluster(ctx context.Context, p component.Int
 	extraClulsterMeta := make(map[string]component.ExtraMetadata, len(cluNames))
 	for _, cluName := range cluNames {
 		if clu, err := h.clusterOperator.GetClusterEx(ctx, cluName, "0"); err == nil {
-			extra, err := h.getClusterMetadata(ctx, clu)
+			extra, err := h.getClusterMetadata(ctx, clu, false)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

fix auto cherrypick failed

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #384 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```