### PR TITLE
fix: import cluster remove local-registry

### DIFF
--- a/pkg/clustermanage/kubeadm/wrapper.go
+++ b/pkg/clustermanage/kubeadm/wrapper.go
@@ -142,7 +142,6 @@ func (w *Wrapper) completeKubeadm(kubeadmConf *corev1.ConfigMap, c *v1.Cluster) 
 	c.Annotations[common.AnnotationActualName] = clusterConf.ClusterName
 	c.KubernetesVersion = clusterConf.KubernetesVersion
 	c.CertSANs = clusterConf.APIServer.CertSANs
-	c.LocalRegistry = clusterConf.ImageRepository
 	c.KubeProxy = v1.KubeProxy{}
 	c.Etcd.DataDir = clusterConf.Etcd.Local.DataDir
 	c.Kubelet.RootDir = ""


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
import cluster remove local-registry。
The kc cluster usually inherits the cluster's local registry when installing the plugin without specifying it, causing the image pull to fail
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lixd 