### PR TITLE
the kcctl tool to create a cluster is missing the project parameter

### DIFF
--- a/pkg/cli/create/create_cluster.go
+++ b/pkg/cli/create/create_cluster.go
@@ -53,16 +53,16 @@ const (
   Create cluster using command line`
 	createClusterExample = `
   # Create cluster offline. The default value of offline is true, so it can be omitted.
-  kcctl create cluster --name demo --master 192.168.10.123
+  kcctl create cluster --name demo --master 192.168.10.123 --project pro-demo
 
   # Create cluster online
-  kcctl create cluster --name demo --master 192.168.10.123 --offline false --local-registry 192.168.10.123:5000
+  kcctl create cluster --name demo --master 192.168.10.123 --offline false --local-registry 192.168.10.123:5000 --project pro-demo
 
   # Create cluster with taint manage
-  kcctl create cluster --name demo --master 192.168.10.123 --untaint-master
+  kcctl create cluster --name demo --master 192.168.10.123 --untaint-master --project pro-demo
 
   # Create cluster with worker.
-  kcctl create cluster --name demo --master 192.168.10.123 --worker 192.168.10.124
+  kcctl create cluster --name demo --master 192.168.10.123 --worker 192.168.10.124 --project pro-demo
 
   Please read 'kcctl create cluster -h' get more create cluster flags.`
 )
@@ -84,6 +84,7 @@ type CreateClusterOptions struct {
 	CertSans      []string
 	CaCertFile    string
 	CaKeyFile     string
+	Project       string
 }
 
 var (
@@ -136,6 +137,7 @@ func NewCmdCreateCluster(streams options.IOStreams) *cobra.Command {
 	cmd.Flags().StringSliceVar(&o.CertSans, "cert-sans", o.CertSans, "k8s cluster certificate signing ipList or domainList")
 	cmd.Flags().StringVar(&o.CaCertFile, "ca-cert", o.CaCertFile, "k8s external root-ca cert file")
 	cmd.Flags().StringVar(&o.CaKeyFile, "ca-key", o.CaKeyFile, "k8s external root-ca key file")
+	cmd.Flags().StringVar(&o.Project, "project", o.Project, "the project to which this k8s cluster belongs")
 	o.CliOpts.AddFlags(cmd.Flags())
 	o.PrintFlags.AddFlags(cmd)
 
@@ -364,6 +366,10 @@ func (l *CreateClusterOptions) newCluster() *v1.Cluster {
 		},
 
 		Status: v1.ClusterStatus{},
+	}
+
+	if l.Project != "" {
+		c.Labels = map[string]string{common.LabelProject: l.Project}
 	}
 
 	masters := make([]v1.WorkerNode, 0)


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
the kcctl tool to create a cluster is missing the project parameter
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #394

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lixd 