### PR TITLE
fix: cluster struct feild json-tag (#413)

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -5507,6 +5507,9 @@
           "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources",
           "type": "string"
         },
+        "description": {
+          "type": "string"
+        },
         "fsConfig": {
           "$ref": "#/definitions/v1.FsConfig"
         },
@@ -5555,23 +5558,17 @@
     "v1.CNI": {
       "required": [
         "type",
-        "Version",
-        "CriType",
-        "Offline",
+        "version",
+        "criType",
+        "offline",
         "namespace"
       ],
       "properties": {
-        "CriType": {
-          "type": "string"
-        },
-        "Offline": {
-          "type": "boolean"
-        },
-        "Version": {
-          "type": "string"
-        },
         "calico": {
           "$ref": "#/definitions/v1.Calico"
+        },
+        "criType": {
+          "type": "string"
         },
         "localRegistry": {
           "type": "string"
@@ -5579,11 +5576,17 @@
         "namespace": {
           "type": "string"
         },
+        "offline": {
+          "type": "boolean"
+        },
         "type": {
           "type": "string",
           "enum": [
             "calico"
           ]
+        },
+        "version": {
+          "type": "string"
         }
       }
     },
@@ -5765,6 +5768,12 @@
         "etcd": {
           "$ref": "#/definitions/v1.Etcd"
         },
+        "externalCaCert": {
+          "type": "string"
+        },
+        "externalCaKey": {
+          "type": "string"
+        },
         "kind": {
           "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds",
           "type": "string"
@@ -5811,16 +5820,7 @@
       }
     },
     "v1.ClusterStatus": {
-      "required": [
-        "Registries"
-      ],
       "properties": {
-        "Registries": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/v1.RegistrySpec"
-          }
-        },
         "certifications": {
           "type": "array",
           "items": {
@@ -5841,6 +5841,12 @@
         },
         "phase": {
           "type": "string"
+        },
+        "registries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/v1.RegistrySpec"
+          }
         },
         "versions": {
           "$ref": "#/definitions/v1.ClusterVersionsStatus"
@@ -6220,9 +6226,6 @@
     "v1.FsConfig": {
       "properties": {
         "backupRootDir": {
-          "type": "string"
-        },
-        "description": {
           "type": "string"
         }
       }

--- a/pkg/scheme/core/v1/cluster_types.go
+++ b/pkg/scheme/core/v1/cluster_types.go
@@ -128,7 +128,7 @@ type ClusterStatus struct {
 
 	Certifications []Certification `json:"certifications,omitempty"`
 	// Registries all CRI registry
-	Registries []RegistrySpec
+	Registries []RegistrySpec `json:"registries,omitempty"`
 	// ControlPlane Health
 	ControlPlaneHealth []ControlPlaneHealth `json:"controlPlaneHealth,omitempty"`
 }
@@ -235,10 +235,10 @@ var (
 type CNI struct {
 	LocalRegistry string `json:"localRegistry" optional:"true"`
 	// TODO: Cluster multiple cni plugins are not supported at this time
-	Type      string `json:"type" enum:"calico"`
-	Version   string
-	CriType   string
-	Offline   bool
+	Type      string  `json:"type" enum:"calico"`
+	Version   string  `json:"version"`
+	CriType   string  `json:"criType"`
+	Offline   bool    `json:"offline"`
 	Namespace string  `json:"namespace"`
 	Calico    *Calico `json:"calico" optional:"true"`
 }


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
cluster struct feild json-tag
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lyp256 