### PR TITLE
fix: support query global resource in project

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -4029,7 +4029,7 @@
           "Core-Cluster"
         ],
         "summary": "List domains api for project.",
-        "operationId": "ListDomains",
+        "operationId": "ListDomainsProject",
         "parameters": [
           {
             "type": "string",
@@ -4648,7 +4648,7 @@
           "Core-Cluster"
         ],
         "summary": "List Registries api for projects.",
-        "operationId": "ListRegistry",
+        "operationId": "ListRegistryProject",
         "parameters": [
           {
             "type": "string",
@@ -4711,7 +4711,7 @@
           "Core-Cluster"
         ],
         "summary": "List templates api for project.",
-        "operationId": "ListTemplates",
+        "operationId": "ListTemplatesProject",
         "parameters": [
           {
             "type": "string",
@@ -4747,6 +4747,46 @@
             "description": "OK",
             "schema": {
               "$ref": "#/definitions/models.PageableResponse"
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "schema": {
+              "$ref": "#/definitions/errors.HTTPError"
+            }
+          }
+        }
+      },
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "Core-Cluster"
+        ],
+        "summary": "Create template.",
+        "operationId": "CreateTemplate",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1.Template"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/v1.Template"
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "schema": {
+              "$ref": "#/definitions/errors.HTTPError"
             }
           },
           "500": {

--- a/pkg/apis/core/v1/registry.go
+++ b/pkg/apis/core/v1/registry.go
@@ -941,8 +941,9 @@ func SetupWebService(h *handler) *restful.WebService {
 			Required(false)).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}))
 	webservice.Route(webservice.GET("/projects/{project}/domains").
-		To(h.ListDomains).
+		To(h.ListDomainsProject).
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		Param(webservice.PathParameter("project", "project name")).
 		Doc("List domains api for project.").
 		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
 			Required(false).
@@ -1104,8 +1105,9 @@ func SetupWebService(h *handler) *restful.WebService {
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}).
 		Returns(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), errors.HTTPError{}))
 	webservice.Route(webservice.GET("/projects/{project}/templates").
-		To(h.ListTemplates).
+		To(h.ListTemplatesProject).
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		Param(webservice.PathParameter("project", "project name")).
 		Doc("List templates api for project.").
 		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
 			Required(false).
@@ -1202,7 +1204,8 @@ func SetupWebService(h *handler) *restful.WebService {
 	webservice.Route(webservice.GET("/projects/{project}/backuppoints").
 		Doc("List of backup point api for project").
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
-		To(h.ListBackupPoints).
+		Param(webservice.PathParameter("project", "project name")).
+		To(h.ListBackupPointsProject).
 		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
 			Required(false).
 			DataFormat("limit=%d,page=%d").
@@ -1541,8 +1544,9 @@ func SetupWebService(h *handler) *restful.WebService {
 			Required(false)).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}))
 	webservice.Route(webservice.GET("/projects/{project}/registries").
-		To(h.ListRegistry).
+		To(h.ListRegistryProject).
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreClusterTag}).
+		Param(webservice.PathParameter("project", "project name")).
 		Doc("List Registries api for projects.").
 		Param(webservice.QueryParameter(query.PagingParam, "paging query, e.g. limit=100,page=1").
 			Required(false).

--- a/pkg/models/cluster/cluster.go
+++ b/pkg/models/cluster/cluster.go
@@ -320,7 +320,7 @@ func (c *clusterOperator) ListBackupPoints(ctx context.Context, query *query.Que
 }
 
 func (c *clusterOperator) ListBackupPointEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	return models.ListExV2(ctx, c.backupPointStorage, query, c.backupPointFuzzyFilter, nil, nil)
+	return models.ListExV2(ctx, c.backupPointStorage, query, BackupPointFuzzyFilter, nil, nil)
 }
 
 func (c *clusterOperator) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
@@ -438,7 +438,7 @@ func (c *clusterOperator) WatchDomain(ctx context.Context, query *query.Query) (
 }
 
 func (c *clusterOperator) ListDomainsEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	return models.ListExV2(ctx, c.dnsStorage, query, c.dnsFuzzyFilter, nil, nil)
+	return models.ListExV2(ctx, c.dnsStorage, query, DNSFuzzyFilter, nil, nil)
 }
 
 func (c *clusterOperator) GetDomain(ctx context.Context, name string) (*v1.Domain, error) {
@@ -591,7 +591,7 @@ func RegionFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
 	return objs
 }
 
-func (c *clusterOperator) dnsFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
+func DNSFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
 	domains, ok := obj.(*v1.DomainList)
 	if !ok {
 		return nil
@@ -631,7 +631,7 @@ func (c *clusterOperator) backupFuzzyFilter(obj runtime.Object, q *query.Query) 
 	return objs
 }
 
-func (c *clusterOperator) backupPointFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
+func BackupPointFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
 	backupPoints, ok := obj.(*v1.BackupPointList)
 	if !ok {
 		return nil
@@ -702,7 +702,7 @@ func (c *clusterOperator) GetTemplate(ctx context.Context, name string) (*v1.Tem
 }
 
 func (c *clusterOperator) ListTemplatesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	return models.ListExV2(ctx, c.templateStorage, query, c.templateFuzzyFilter, nil, nil)
+	return models.ListExV2(ctx, c.templateStorage, query, TemplateFuzzyFilter, nil, nil)
 }
 
 func (c *clusterOperator) GetTemplateEx(ctx context.Context, name string, resourceVersion string) (*v1.Template, error) {
@@ -752,7 +752,7 @@ func (c *clusterOperator) DeleteTemplateCollection(ctx context.Context, query *q
 	return nil
 }
 
-func (c *clusterOperator) templateFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
+func TemplateFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
 	templates, ok := obj.(*v1.TemplateList)
 	if !ok {
 		return nil
@@ -875,7 +875,7 @@ func (c *clusterOperator) GetRegistryEx(ctx context.Context, name string, resour
 }
 
 func (c *clusterOperator) ListRegistriesEx(ctx context.Context, query *query.Query) (*models.PageableResponse, error) {
-	return models.ListExV2(ctx, c.registryStorage, query, c.registryFuzzyFilter, nil, nil)
+	return models.ListExV2(ctx, c.registryStorage, query, RegistryFuzzyFilter, nil, nil)
 }
 
 func (c *clusterOperator) CreateRegistry(ctx context.Context, r *v1.Registry) (*v1.Registry, error) {
@@ -906,7 +906,7 @@ func (c *clusterOperator) DeleteRegistry(ctx context.Context, name string) error
 	return err
 }
 
-func (c *clusterOperator) registryFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
+func RegistryFuzzyFilter(obj runtime.Object, q *query.Query) []runtime.Object {
 	registries, ok := obj.(*v1.RegistryList)
 	if !ok {
 		return nil

--- a/pkg/query/query.go
+++ b/pkg/query/query.go
@@ -152,12 +152,17 @@ func (q *Query) GetFieldSelector() fields.Selector {
 }
 
 // AddLabelSelector add labelSelector to query.
-func (q *Query) AddLabelSelector(selector []string) {
+func (q *Query) AddLabelSelector(selectors []string) {
 	if q.LabelSelector == "" {
-		q.LabelSelector = strings.Join(selector, ",")
+		q.LabelSelector = strings.Join(selectors, ",")
 		return
 	}
-	q.LabelSelector = fmt.Sprintf("%s,%s", q.LabelSelector, strings.Join(selector, ","))
+	for _, selector := range selectors {
+		if q.HasLabelSelector(selector) {
+			continue
+		}
+		q.LabelSelector = fmt.Sprintf("%s,%s", q.LabelSelector, selector)
+	}
 }
 
 // HasLabelSelector check label is exist
@@ -169,6 +174,26 @@ func (q *Query) HasLabelSelector(selector string) bool {
 		}
 	}
 	return false
+}
+
+// DeepCopy copy query.
+func (q *Query) DeepCopy() *Query {
+	out := *q
+	if q.Pagination != nil {
+		out.Pagination = newPagination(q.Pagination.Limit, q.Pagination.Offset)
+	}
+	if q.TimeoutSeconds != nil {
+		newTimeoutSeconds := *q.TimeoutSeconds
+		out.TimeoutSeconds = &newTimeoutSeconds
+	}
+	if q.FuzzySearch != nil {
+		newFuzzySearch := make(map[string]string)
+		for k, v := range q.FuzzySearch {
+			newFuzzySearch[k] = v
+		}
+		out.FuzzySearch = q.FuzzySearch
+	}
+	return &out
 }
 
 func New() *Query {

--- a/pkg/query/query_test.go
+++ b/pkg/query/query_test.go
@@ -49,3 +49,31 @@ func Test_parseFuzzy(t *testing.T) {
 		})
 	}
 }
+
+func TestQuery_AddLabelSelector(t *testing.T) {
+	type args struct {
+		selectors []string
+	}
+	tests := []struct {
+		name string
+		old  args
+		add  args
+		want string
+	}{
+		{name: "empty", old: args{selectors: []string{""}}, add: args{selectors: []string{""}}, want: ""},
+		{name: "normal", old: args{selectors: []string{""}}, add: args{selectors: []string{"a=b"}}, want: "a=b"},
+		{name: "normal2", old: args{selectors: []string{"a=b"}}, add: args{selectors: []string{"c=d"}}, want: "a=b,c=d"},
+		{name: "normal3", old: args{selectors: []string{"a=b", "c=d"}}, add: args{selectors: []string{"e=f"}}, want: "a=b,c=d,e=f"},
+		{name: "override", old: args{selectors: []string{"a=b", "c=d"}}, add: args{selectors: []string{"c=d"}}, want: "a=b,c=d"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			q := New()
+			q.AddLabelSelector(tt.old.selectors)
+			q.AddLabelSelector(tt.add.selectors)
+			if q.LabelSelector != tt.want {
+				t.Fatalf("want:%s got:%s", tt.want, q.LabelSelector)
+			}
+		})
+	}
+}

--- a/pkg/server/restplus/multi_watch.go
+++ b/pkg/server/restplus/multi_watch.go
@@ -1,0 +1,66 @@
+package restplus
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type multiWatcher struct {
+	watchers []watch.Interface
+	stop     chan struct{}
+
+	ch      chan watch.Event
+	stopped bool
+	sync.Mutex
+}
+
+func NewMultiWatcher(watchers []watch.Interface) watch.Interface {
+	m := &multiWatcher{
+		watchers: watchers,
+		ch:       make(chan watch.Event),
+		stop:     make(chan struct{}),
+	}
+
+	// merge watchers
+	var wg sync.WaitGroup
+	wg.Add(len(m.watchers))
+
+	for _, watcher := range m.watchers {
+		go func(w watch.Interface) {
+			defer wg.Done()
+			events := w.ResultChan()
+			for event := range events {
+				m.ch <- event
+			}
+		}(watcher)
+	}
+	go func() {
+		wg.Wait()
+		// when all watcher closed,send a signal to stop chan
+		m.stop <- struct{}{}
+	}()
+	return m
+}
+
+func (m *multiWatcher) Stop() {
+	m.Lock()
+	defer m.Unlock()
+
+	if m.stopped {
+		return
+	}
+
+	m.stopped = true
+	for _, watcher := range m.watchers {
+		watcher.Stop()
+	}
+
+	// waiting for all watcher closed
+	<-m.stop
+	close(m.ch)
+}
+
+func (m *multiWatcher) ResultChan() <-chan watch.Event {
+	return m.ch
+}

--- a/pkg/server/restplus/multi_watch_test.go
+++ b/pkg/server/restplus/multi_watch_test.go
@@ -1,0 +1,48 @@
+package restplus
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type testType string
+
+func (obj testType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (obj testType) DeepCopyObject() runtime.Object   { return obj }
+
+func TestNewMultiWatcher(t *testing.T) {
+	w1 := watch.NewFake()
+	w2 := watch.NewFake()
+	m := NewMultiWatcher([]watch.Interface{w1, w2})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			w1.Add(testType("watcher1" + strconv.Itoa(i)))
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 10; i++ {
+			w2.Add(testType("watcher2" + strconv.Itoa(i)))
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		m.Stop()
+	}()
+
+	resultChan := m.ResultChan()
+	for event := range resultChan {
+		t.Log("event:", event)
+	}
+}


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug
### What this PR does / why we need it:
support query global resource in project
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
add api to support query global resource in project, query global resource and project resource at the same time
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```