### PR TITLE
test: add cluster cert update e2e test

### DIFF
--- a/pkg/simple/client/kc/api.go
+++ b/pkg/simple/client/kc/api.go
@@ -38,6 +38,7 @@ import (
 const (
 	ListNodesPath     = "/api/core.kubeclipper.io/v1/nodes"
 	clustersPath      = "/api/core.kubeclipper.io/v1/clusters"
+	clustersCertPath  = "/api/core.kubeclipper.io/v1/clusters/%s/certification"
 	componentPath     = "/api/core.kubeclipper.io/v1/clusters/%s/plugins"
 	backupPath        = "/api/core.kubeclipper.io/v1/backups"
 	backupPonitPath   = "/api/core.kubeclipper.io/v1/backuppoints"
@@ -312,6 +313,21 @@ func (cli *Client) GetComponentMeta(ctx context.Context) (*ComponentMeta, error)
 func (cli *Client) InstallOrUninstallComponent(ctx context.Context, cluName string, component *corev1.PatchComponents) (*ClustersList, error) {
 	url := fmt.Sprintf(componentPath, cluName)
 	resp, err := cli.patch(ctx, url, nil, component, nil)
+	defer ensureReaderClosed(resp)
+	if err != nil {
+		return nil, err
+	}
+	clu := v1.Cluster{}
+	err = json.NewDecoder(resp.body).Decode(&clu)
+	clusters := &ClustersList{
+		Items: []v1.Cluster{clu},
+	}
+	return clusters, err
+}
+
+func (cli *Client) UpdateCert(ctx context.Context, cluName string) (*ClustersList, error) {
+	u := fmt.Sprintf(clustersCertPath, cluName)
+	resp, err := cli.post(ctx, u, nil, nil, nil)
 	defer ensureReaderClosed(resp)
 	if err != nil {
 		return nil, err

--- a/test/e2e/cluster/cluster_aio_cert.go
+++ b/test/e2e/cluster/cluster_aio_cert.go
@@ -1,0 +1,136 @@
+/*
+ *
+ *  * Copyright 2021 KubeClipper Authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeclipper/kubeclipper/test/e2e/project"
+
+	"github.com/kubeclipper/kubeclipper/pkg/query"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
+	"github.com/kubeclipper/kubeclipper/test/framework"
+	"github.com/kubeclipper/kubeclipper/test/framework/cluster"
+)
+
+var _ = SIGDescribe("[Slow] [Serial] Update Cert", func() {
+	f := framework.NewDefaultFramework("aio")
+
+	var nodeID []string
+	clusterName := "e2e-aio"
+	f.AddAfterEach("cleanup aio", func(f *framework.Framework, failed bool) {
+		ginkgo.By("delete aio cluster")
+		err := f.Client.DeleteClusterWithQuery(context.TODO(), clusterName, nil)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("waiting for cluster to be deleted")
+		err = cluster.WaitForClusterNotFound(f.Client, clusterName, f.Timeouts.ClusterDelete)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("delete e2e project")
+		err = project.DeleteProject(f)
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Check that there are enough available nodes")
+		nodes, err := f.Client.ListNodes(context.TODO(), kc.Queries{
+			Pagination:    query.NoPagination(),
+			LabelSelector: fmt.Sprintf("!%s", common.LabelNodeRole),
+		})
+		framework.ExpectNoError(err)
+		if len(nodes.Items) == 0 {
+			framework.Failf("Not enough nodes to test")
+		}
+
+		for _, item := range nodes.Items {
+			nodeID = append(nodeID, item.Name)
+		}
+
+		ginkgo.By("create e2e project")
+		err = project.CreateProject(f)
+		framework.ExpectNoError(err)
+
+	})
+
+	ginkgo.It("should create a AIO minimal kubernetes cluster and update cert when ensure cluster is running.", func() {
+		ginkgo.By("create aio cluster")
+
+		clus, err := f.Client.CreateCluster(context.TODO(), initAIOCluster(clusterName, nodeID))
+		framework.ExpectNoError(err)
+
+		if len(clus.Items) == 0 {
+			framework.Failf("unexpected problem, cluster not be nil at this time")
+		}
+
+		ginkgo.By("check cluster status is running")
+		clusterName = fmt.Sprintf("%s-%s", project.DefaultE2EProject, clusterName)
+		err = cluster.WaitForClusterRunning(f.Client, clusterName, f.Timeouts.ClusterInstall)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("wait for cluster is healthy")
+		err = cluster.WaitForClusterHealthy(f.Client, clusterName, f.Timeouts.ClusterInstallShort)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("wait for cert init")
+		err = cluster.WaitForCertInit(f.Client, clusterName, f.Timeouts.CommonTimeout)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("get cert expiration time")
+		t, err := GetCertExpirationTime(f, clusterName)
+		framework.ExpectNoError(err)
+
+		framework.Logf("current cert expiration time: %v", t.Format(time.RFC3339))
+		ginkgo.By("update cert")
+		err = UpdateCert(f, clusterName)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("wait for cert update")
+		err = cluster.WaitForCertUpdated(f.Client, clusterName, *t, f.Timeouts.CommonTimeout)
+		framework.ExpectNoError(err)
+	})
+})
+
+func UpdateCert(f *framework.Framework, clusterName string) error {
+	_, err := f.Client.UpdateCert(context.TODO(), clusterName)
+	return err
+}
+
+func GetCertExpirationTime(f *framework.Framework, clusterName string) (*metav1.Time, error) {
+	describeCluster, err := f.Client.DescribeCluster(context.TODO(), clusterName)
+	if err != nil {
+		return nil, err
+	}
+	if len(describeCluster.Items) == 0 {
+		return nil, fmt.Errorf("unexpected problem, cluster %s not found", clusterName)
+	}
+	for _, certification := range describeCluster.Items[0].Status.Certifications {
+		if !strings.Contains(certification.Name, "ca") {
+			return &certification.ExpirationTime, nil
+		}
+	}
+	return nil, fmt.Errorf("unexpected problem, cluster %s ca expiration time not exist", clusterName)
+}


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind  test

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```