### PR TITLE
force delete cluster e2e test

### DIFF
--- a/test/e2e/cluster/delete_cluster.go
+++ b/test/e2e/cluster/delete_cluster.go
@@ -1,0 +1,40 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/cmdutil"
+	"github.com/kubeclipper/kubeclipper/test/framework"
+	"github.com/kubeclipper/kubeclipper/test/framework/cluster"
+	"github.com/onsi/ginkgo"
+)
+
+var _ = SIGDescribe("[Slow] [Serial] Force delete cluster", func() {
+	f := framework.NewDefaultFramework("aio")
+
+	clu := &corev1.Cluster{}
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("create aio cluster")
+		clusters, err := createClusterBeforeEach(f, "cluster-aio", initAIOCluster)
+		framework.ExpectNoError(err)
+		clu = clusters.Items[0].DeepCopy()
+	})
+
+	ginkgo.It("force delete aio cluster and ensure cluster is deleted", func() {
+		ginkgo.By("force delete aio cluster by kcctl")
+		err := deleteClusterByKcctl(clu.Name)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("waiting for cluster to be deleted")
+		err = cluster.WaitForClusterNotFound(f.Client, clu.Name, f.Timeouts.ClusterDelete)
+		framework.ExpectNoError(err)
+	})
+})
+
+func deleteClusterByKcctl(clusterName string) error {
+	cmd := fmt.Sprintf("echo y | kcctl delete cluster %s -F", clusterName)
+	ec := cmdutil.NewExecCmd(context.TODO(), "bash", "-c", cmd)
+	return ec.Run()
+}


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```