### PR TITLE
fix: modify kc-console ca delivery node

### DIFF
--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -812,7 +812,7 @@ func (d *DeployOptions) sendConsoleCert(contents []certutils.Config, pki string)
 	for _, content := range contents {
 		err := utils.SendPackageV2(d.deployConfig.SSHConfig,
 			path.Join(content.Path, content.BaseName+".crt"),
-			d.deployConfig.Agents.ListIP(),
+			d.deployConfig.ServerIPs,
 			filepath.Join(options.DefaultKcConsoleConfigPath, pki), nil, nil)
 		if err != nil {
 			return err

--- a/test/e2e/cluster/cluster_aio_cert.go
+++ b/test/e2e/cluster/cluster_aio_cert.go
@@ -76,7 +76,7 @@ var _ = SIGDescribe("[Slow] [Serial] Update Cert", func() {
 
 	})
 
-	ginkgo.It("should create a AIO minimal kubernetes cluster and update cert when ensure cluster is running.", func() {
+	ginkgo.It("should create a aio minimal kubernetes cluster and update cert when ensure cluster is running.", func() {
 		ginkgo.By("create aio cluster")
 
 		clus, err := f.Client.CreateCluster(context.TODO(), initAIOCluster(clusterName, nodeID))


### PR DESCRIPTION
Signed-off-by: xu.jingwen <xu.jingwen@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```