### PR TITLE
test: add join、drain node e2e test

### DIFF
--- a/test/e2e/cluster/cri_registry.go
+++ b/test/e2e/cluster/cri_registry.go
@@ -2,15 +2,17 @@ package cluster
 
 import (
 	"context"
+	"net/url"
+
+	"github.com/onsi/ginkgo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubeclipper/kubeclipper/pkg/query"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	"github.com/kubeclipper/kubeclipper/test/e2e/project"
 	"github.com/kubeclipper/kubeclipper/test/framework"
 	"github.com/kubeclipper/kubeclipper/test/framework/cluster"
-	"github.com/onsi/ginkgo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"net/url"
 )
 
 var _ = SIGDescribe("[Slow] [Serial] Cri docker registry", func() {

--- a/test/e2e/cluster/delete_cluster.go
+++ b/test/e2e/cluster/delete_cluster.go
@@ -3,11 +3,13 @@ package cluster
 import (
 	"context"
 	"fmt"
+
+	"github.com/onsi/ginkgo"
+
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/cmdutil"
 	"github.com/kubeclipper/kubeclipper/test/framework"
 	"github.com/kubeclipper/kubeclipper/test/framework/cluster"
-	"github.com/onsi/ginkgo"
 )
 
 var _ = SIGDescribe("[Slow] [Serial] Force delete cluster", func() {

--- a/test/e2e/node/join_node.go
+++ b/test/e2e/node/join_node.go
@@ -1,0 +1,115 @@
+/*
+ *
+ *  * Copyright 2021 KubeClipper Authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package node
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubeclipper/kubeclipper/pkg/query"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
+	"github.com/kubeclipper/kubeclipper/test/e2e/cluster"
+
+	"github.com/onsi/ginkgo"
+
+	"github.com/kubeclipper/kubeclipper/test/framework"
+	fcluster "github.com/kubeclipper/kubeclipper/test/framework/cluster"
+)
+
+var _ = cluster.SIGDescribe("[Medium] [Serial] Join node", func() {
+	f := framework.NewDefaultFramework("node")
+	var nodeIP, nodeID string
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Check that there are enough available nodes")
+		nodes, err := f.Client.ListNodes(context.TODO(), kc.Queries{
+			Pagination:    query.NoPagination(),
+			LabelSelector: fmt.Sprintf("!%s", common.LabelNodeDisable),
+		})
+		framework.ExpectNoError(err)
+		if len(nodes.Items) == 0 {
+			framework.Failf("Not enough enabled nodes to test")
+		}
+		nodeID = nodes.Items[0].Name
+		nodeIP = nodes.Items[0].Status.Ipv4DefaultIP
+		framework.Logf("target node ip:[%s] id:[%s]\n", nodeIP, nodeID)
+	})
+
+	ginkgo.It("join node", func() {
+		ginkgo.By("drain node")
+		err := drainNode(nodeID)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("wait for node not found")
+		err = fcluster.WaitForNodeNotFound(f.Client, nodeIP, f.Timeouts.CommonTimeout)
+		framework.ExpectNoError(err)
+		framework.Logf("node %s drained\n", nodeIP)
+
+		ginkgo.By("join node")
+		err = joinAgentNode(nodeIP)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("wait for node join")
+		nodeID, err = fcluster.WaitForNodeJoin(f.Client, nodeIP, f.Timeouts.CommonTimeout)
+		framework.ExpectNoError(err)
+		framework.Logf("node %s registered，id is:%s\n", nodeIP, nodeID)
+	})
+})
+
+var _ = cluster.SIGDescribe("[Medium] [Serial] Drain node", func() {
+	f := framework.NewDefaultFramework("node")
+	var nodeIP, nodeID string
+
+	f.AddAfterEach("join node", func(f *framework.Framework, failed bool) {
+		ginkgo.By("join node")
+		err := joinAgentNode(nodeIP)
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.BeforeEach(func() {
+		ginkgo.By("Check that there are enough available nodes")
+		nodes, err := f.Client.ListNodes(context.TODO(), kc.Queries{
+			Pagination:    query.NoPagination(),
+			LabelSelector: fmt.Sprintf("!%s", common.LabelNodeDisable),
+		})
+		framework.ExpectNoError(err)
+		if len(nodes.Items) == 0 {
+			framework.Failf("Not enough enabled nodes to test")
+		}
+		nodeID = nodes.Items[0].Name
+		nodeIP = nodes.Items[0].Status.Ipv4DefaultIP
+		framework.Logf("target node ip:[%s] id:[%s]\n", nodeIP, nodeID)
+	})
+
+	ginkgo.It("drain node", func() {
+		ginkgo.By("drain node")
+		err := drainNode(nodeID)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("wait for node not found")
+		err = fcluster.WaitForNodeNotFound(f.Client, nodeIP, f.Timeouts.CommonTimeout)
+		framework.ExpectNoError(err)
+		framework.Logf("node %s drained\n", nodeIP)
+	})
+})
+
+func drainNode(nodeID string) error {
+	return runCmd(fmt.Sprintf("kcctl drain --agent %s", nodeID))
+}

--- a/test/framework/cluster/node.go
+++ b/test/framework/cluster/node.go
@@ -1,0 +1,69 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
+	"github.com/kubeclipper/kubeclipper/test/framework"
+)
+
+type nodeCondition func(nodes []corev1.Node) (bool, error)
+
+func waitForNodeCondition(c *kc.Client, nodeIP, conditionDesc string, timeout time.Duration, condition nodeCondition) error {
+	framework.Logf("Waiting up to %v for node %q to be %q", timeout, nodeIP, conditionDesc)
+	start := time.Now()
+	err := wait.PollImmediate(poll, timeout, func() (bool, error) {
+		nodes, apiErr := c.ListNodes(context.TODO(), kc.Queries{})
+		if apiErr != nil {
+			return handleWaitingAPIError(apiErr, true, "getting node %s", nodeIP)
+		}
+		ok, err := condition(nodes.Items)
+		if err != nil {
+			return false, err
+		}
+		framework.Logf("Node %q not registered, Elapsed: %v", nodeIP, time.Since(start))
+		return ok, nil
+	})
+	if err == nil {
+		return nil
+	}
+	if IsTimeout(err) {
+		return TimeoutError(fmt.Sprintf("timed out while waiting for node %s to be %s", nodeIP, conditionDesc))
+	}
+	return maybeTimeoutError(err, "waiting for node %s to be %s", nodeIP, conditionDesc)
+}
+
+func WaitForNodeJoin(c *kc.Client, nodeIP string, timeout time.Duration) (string, error) {
+	var nodeID string
+	err := waitForNodeCondition(c, nodeIP, "join", timeout, func(nodes []corev1.Node) (bool, error) {
+		for _, node := range nodes {
+			if node.Status.Ipv4DefaultIP == nodeIP {
+				nodeID = node.Name
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	return nodeID, err
+}
+
+func WaitForNodeNotFound(c *kc.Client, nodeID string, timeout time.Duration) error {
+	return waitForNodeCondition(c, nodeID, "not found", timeout, func(nodes []corev1.Node) (bool, error) {
+		for _, node := range nodes {
+			if node.Name == nodeID {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+}
+
+func IsNotFound(err error) bool {
+	return strings.Contains(err.Error(), "not found")
+}

--- a/test/framework/cluster/wait.go
+++ b/test/framework/cluster/wait.go
@@ -300,31 +300,6 @@ func WaitForCriRegistry(c *kc.Client, clusterName string, timeout time.Duration,
 	})
 }
 
-func WaitForNodeNotFound(c *kc.Client, nodeID string, timeout time.Duration) error {
-	node := &corev1.Node{}
-	err := wait.PollImmediate(poll, timeout, func() (done bool, err error) {
-		nodes, waitErr := c.DescribeNode(context.TODO(), nodeID)
-		if waitErr != nil {
-			if apierror.IsNotFound(waitErr) {
-				return true, nil
-			}
-			return handleWaitingAPIError(waitErr, false, "getting node %s", nodeID)
-		}
-		if len(nodes.Items) == 0 {
-			return true, nil
-		}
-		node = nodes.Items[0].DeepCopy()
-		return false, nil
-	})
-	if err == nil {
-		return nil
-	}
-	if IsTimeout(err) && node != nil {
-		return TimeoutError(fmt.Sprintf("timeout while waiting for node %s to be Not Found", nodeID), node)
-	}
-	return maybeTimeoutError(err, "waiting for node %s not found", nodeID)
-}
-
 func WaitForJoinNode(c *kc.Client, nodeIP string, timeout time.Duration) error {
 	node := &corev1.Node{}
 	query := kc.Queries{


### PR DESCRIPTION
Signed-off-by: lixd <xueduan.li@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```