### PR TITLE
update k8s cluster service and pod cidr

### DIFF
--- a/pkg/apis/core/v1/schema_test.go
+++ b/pkg/apis/core/v1/schema_test.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"fmt"
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	"reflect"
 	"testing"
 
@@ -82,8 +83,8 @@ var (
 		},
 		Networking: v1.Networking{
 			IPFamily:      v1.IPFamilyIPv4,
-			Services:      v1.NetworkRanges{CIDRBlocks: []string{"10.96.0.0/16"}},
-			Pods:          v1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/24"}},
+			Services:      v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterServiceSubnet}},
+			Pods:          v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterPodSubnet}},
 			DNSDomain:     "cluster.local",
 			ProxyMode:     "ipvs",
 			WorkerNodeVip: "169.254.169.100",

--- a/pkg/apis/core/v1/utils_test.go
+++ b/pkg/apis/core/v1/utils_test.go
@@ -21,6 +21,7 @@ package v1
 import (
 	"context"
 	"encoding/json"
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -77,8 +78,8 @@ var (
 		},
 		Networking: v1.Networking{
 			IPFamily:      v1.IPFamilyIPv4,
-			Services:      v1.NetworkRanges{CIDRBlocks: []string{"10.96.0.0/16"}},
-			Pods:          v1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/24"}},
+			Services:      v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterServiceSubnet}},
+			Pods:          v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterPodSubnet}},
 			DNSDomain:     "cluster.local",
 			ProxyMode:     "ipvs",
 			WorkerNodeVip: "169.254.169.100",

--- a/pkg/cli/create/create_cluster.go
+++ b/pkg/cli/create/create_cluster.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	"net"
 	"os"
 	"strings"
@@ -341,8 +342,8 @@ func (l *CreateClusterOptions) newCluster() *v1.Cluster {
 		ContainerRuntime:  v1.ContainerRuntime{},
 		Networking: v1.Networking{
 			IPFamily:      v1.IPFamilyIPv4,
-			Services:      v1.NetworkRanges{CIDRBlocks: []string{"10.96.0.0/16"}},
-			Pods:          v1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/24"}},
+			Services:      v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterServiceSubnet}},
+			Pods:          v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterPodSubnet}},
 			DNSDomain:     "cluster.local",
 			ProxyMode:     "ipvs",
 			WorkerNodeVip: "169.254.169.100",

--- a/pkg/constatns/constats.go
+++ b/pkg/constatns/constats.go
@@ -13,3 +13,8 @@ const (
 	KcEtcdCertsConfigMapName = "kc-etcd"
 	KcNatsCertsConfigMapName = "kc-nats"
 )
+
+const (
+	ClusterServiceSubnet = "10.96.0.0/12"
+	ClusterPodSubnet     = "172.25.0.0/16"
+)

--- a/pkg/scheme/core/v1/cni/calico_test.go
+++ b/pkg/scheme/core/v1/cni/calico_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 )
 
@@ -19,7 +20,7 @@ func TestCNI_renderCalicoTo(t *testing.T) {
 			stepper: CalicoRunnable{
 				BaseCni{
 					DualStack:   false,
-					PodIPv4CIDR: "172.25.0.0/24",
+					PodIPv4CIDR: constatns.ClusterPodSubnet,
 					PodIPv6CIDR: "aaa:bbb",
 					CNI: v1.CNI{
 						LocalRegistry: "172.0.0.1:5000",

--- a/pkg/scheme/core/v1/k8s/kubeadm_test.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_test.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 )
 
@@ -65,8 +66,8 @@ func TestKubeadmConfig_renderTo(t *testing.T) {
 				Etcd:                    v1.Etcd{DataDir: "/var/lib/etcd"},
 				Networking: v1.Networking{
 					IPFamily:      v1.IPFamilyIPv4,
-					Services:      v1.NetworkRanges{CIDRBlocks: []string{"10.96.0.0/16"}},
-					Pods:          v1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/24"}},
+					Services:      v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterServiceSubnet}},
+					Pods:          v1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterPodSubnet}},
 					DNSDomain:     "cluster.local",
 					ProxyMode:     "ipvs",
 					WorkerNodeVip: "8.8.8.8",

--- a/test/e2e/cluster/utils.go
+++ b/test/e2e/cluster/utils.go
@@ -23,9 +23,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	apierror "github.com/kubeclipper/kubeclipper/pkg/errors"
 	"github.com/kubeclipper/kubeclipper/pkg/query"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
@@ -33,6 +31,8 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
 	"github.com/kubeclipper/kubeclipper/test/framework"
 	"github.com/kubeclipper/kubeclipper/test/framework/cluster"
+	"github.com/onsi/ginkgo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type Setter func(cluster *corev1.Cluster)
@@ -126,8 +126,8 @@ func initCluster() *corev1.Cluster {
 		},
 		Networking: corev1.Networking{
 			IPFamily:      corev1.IPFamilyIPv4,
-			Services:      corev1.NetworkRanges{CIDRBlocks: []string{"10.96.0.0/16"}},
-			Pods:          corev1.NetworkRanges{CIDRBlocks: []string{"172.25.0.0/24"}},
+			Services:      corev1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterServiceSubnet}},
+			Pods:          corev1.NetworkRanges{CIDRBlocks: []string{constatns.ClusterPodSubnet}},
 			DNSDomain:     "cluster.local",
 			ProxyMode:     "ipvs",
 			WorkerNodeVip: "169.254.169.100",

--- a/test/framework/test_context.go
+++ b/test/framework/test_context.go
@@ -20,14 +20,15 @@ package framework
 
 import (
 	"flag"
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 
 	"github.com/onsi/ginkgo/config"
 )
 
 const (
 	defaultHost          = "http://127.0.0.1:8080"
-	defaultServiceSubnet = "10.96.0.0/16"
-	defaultPodSubnet     = "172.25.0.0/24"
+	defaultServiceSubnet = constatns.ClusterServiceSubnet
+	defaultPodSubnet     = constatns.ClusterPodSubnet
 	defaultLocalRegistry = "127.0.0.1:5000"
 	defaultWorkerNodeVip = "169.254.169.100"
 )
@@ -59,9 +60,9 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 	flag.StringVar(&TestContext.Host, "server-address", defaultHost,
 		"Ki Server API Server IP/DNS, default 127.0.0.1:8080")
 	flag.StringVar(&TestContext.ServiceSubnet, "svc-subnet", defaultServiceSubnet,
-		"cluster svc sub net, default 10.96.0.0/16")
+		"cluster svc sub net, default 10.96.0.0/12")
 	flag.StringVar(&TestContext.PodSubnet, "pod-subnet", defaultPodSubnet,
-		"cluster pod sub net, default 172.25.0.0/24")
+		"cluster pod sub net, default 172.25.0.0/16")
 	flag.StringVar(&TestContext.LocalRegistry, "registry", defaultLocalRegistry,
 		"cri image registry addr, default 127.0.0.1:5000")
 	flag.StringVar(&TestContext.WorkerNodeVip, "vip", defaultWorkerNodeVip,


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind design
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
update k8s cluster service and pod cidr
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lixd 