### PR TITLE
add describe/update cluster e2e test

### DIFF
--- a/test/e2e/cluster/spec.go
+++ b/test/e2e/cluster/spec.go
@@ -401,6 +401,48 @@ var _ = SIGDescribe("[Serial]", func() {
 		framework.ExpectNoError(ws.Close())
 	})
 
+	ginkgo.It("[Slow] [AIO] [Describe] should get cluster info", func() {
+		clusterName = "e2e-aio-describe"
+		clu := baseCluster.DeepCopy()
+
+		nodes := beforeEachCheckNodeEnough(f, 1)
+		InitClusterWithSetter(clu, []Setter{SetClusterName(clusterName),
+			SetClusterNodes([]string{nodes[0]}, nil),
+		})
+		ginkgo.By("create aio cluster")
+		beforeEachCreateCluster(f, clu)()
+
+		ginkgo.By("get cluster description")
+		_, err := f.KcClient().DescribeCluster(context.TODO(), clusterName)
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("[Slow] [AIO] [Update] should update cluster", func() {
+		clusterName = "e2e-aio-update"
+		clu := baseCluster.DeepCopy()
+
+		nodes := beforeEachCheckNodeEnough(f, 1)
+		InitClusterWithSetter(clu, []Setter{SetClusterName(clusterName),
+			SetClusterNodes([]string{nodes[0]}, nil),
+		})
+		ginkgo.By("create aio cluster")
+		beforeEachCreateCluster(f, clu)()
+
+		ginkgo.By("update cluster")
+
+		clu.Annotations[common.AnnotationDescription] = "test-des"
+		err := f.KcClient().UpdateCluster(context.TODO(), clu)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("check whether the cluster is updated")
+		clus, err := f.KcClient().DescribeCluster(context.TODO(), clusterName)
+		framework.ExpectNoError(err)
+
+		value, ok := clus.Items[0].Annotations[common.AnnotationDescription]
+		if !ok || value != "test-des" {
+			framework.ExpectNoError(fmt.Errorf("update cluster %s failed", clusterName))
+		}
+	})
 })
 
 func UpdateCert(f *framework.Framework, clusterName string) error {


### PR DESCRIPTION
Signed-off-by: Liucw <liu.chuwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubeclipper/kubeclipper/issues/75

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@lixd @x893675 