### PR TITLE
add online install cluster test spec

### DIFF
--- a/test/e2e/acl/external_user.go
+++ b/test/e2e/acl/external_user.go
@@ -1,5 +1,0 @@
-package acl
-
-//var _ = SIGDescribe("[Fast] [Serial] external users", func() {
-//
-//})

--- a/test/e2e/cluster/registry.go
+++ b/test/e2e/cluster/registry.go
@@ -3,11 +3,13 @@ package cluster
 import (
 	"context"
 	"fmt"
+
+	"github.com/onsi/ginkgo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
 	"github.com/kubeclipper/kubeclipper/test/framework"
-	"github.com/onsi/ginkgo"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 )

--- a/test/e2e/cluster/spec.go
+++ b/test/e2e/cluster/spec.go
@@ -42,6 +42,17 @@ var _ = SIGDescribe("[Serial]", func() {
 		ginkgo.By("create aio cluster")
 		beforeEachCreateCluster(f, baseCluster)()
 	})
+
+	ginkgo.It("[Slow] [AIO] [online] should create a aio minimal kubernetes cluster online", func() {
+		clusterName = "e2e-aio-online"
+		clu := baseCluster.DeepCopy()
+		nodes := beforeEachCheckNodeEnough(f, 1)
+		InitClusterWithSetter(clu, []Setter{SetClusterName(clusterName),
+			SetOnlineInstall(),
+			SetClusterNodes([]string{nodes[0]}, nil)})
+		ginkgo.By("create aio cluster")
+		beforeEachCreateCluster(f, clu)()
+	})
 	// other test case for 1 master 1 worker or 1 master 2 worker
 
 	// TODO: spoilt, need fix

--- a/test/e2e/cluster/utils.go
+++ b/test/e2e/cluster/utils.go
@@ -56,6 +56,15 @@ func SetDockerRuntime() Setter {
 	}
 }
 
+func SetOnlineInstall() Setter {
+	return func(c *corev1.Cluster) {
+		if c.Annotations == nil {
+			c.Annotations = make(map[string]string, 0)
+		}
+		c.Annotations[common.AnnotationOffline] = "false"
+	}
+}
+
 func SetClusterName(name string) Setter {
 	return func(c *corev1.Cluster) {
 		c.Name = name

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
-	_ "github.com/kubeclipper/kubeclipper/test/e2e/acl"
 	_ "github.com/kubeclipper/kubeclipper/test/e2e/cluster"
+	_ "github.com/kubeclipper/kubeclipper/test/e2e/iam"
 	_ "github.com/kubeclipper/kubeclipper/test/e2e/node"
 	_ "github.com/kubeclipper/kubeclipper/test/e2e/region"
 	"github.com/kubeclipper/kubeclipper/test/framework"

--- a/test/e2e/iam/framework.go
+++ b/test/e2e/iam/framework.go
@@ -16,11 +16,11 @@
  *
  */
 
-package acl
+package iam
 
 import "github.com/onsi/ginkgo"
 
 // SIGDescribe annotates the test with the SIG label.
 func SIGDescribe(text string, body func()) bool {
-	return ginkgo.Describe("[sig-acl] "+text, body)
+	return ginkgo.Describe("[sig-iam] "+text, body)
 }

--- a/test/e2e/iam/role.go
+++ b/test/e2e/iam/role.go
@@ -1,4 +1,4 @@
-package acl
+package iam
 
 import (
 	"context"

--- a/test/e2e/iam/user.go
+++ b/test/e2e/iam/user.go
@@ -1,4 +1,4 @@
-package acl
+package iam
 
 import (
 	"context"


### PR DESCRIPTION
Signed-off-by: x893675 <x893675@icloud.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/area testing

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```