### PR TITLE
fix: cluster upgrade patch version check error

### DIFF
--- a/pkg/cli/cluster/cluster_upgrade.go
+++ b/pkg/cli/cluster/cluster_upgrade.go
@@ -107,7 +107,7 @@ func (c *ClusterUpgradeOpts) Validates() error {
 	}
 	clu := clusterList.Items[0]
 	if c.Version <= clu.KubernetesVersion {
-		return fmt.Errorf("your current version [%s] <= the version [%s] you specify", clu.KubernetesVersion, c.Version)
+		return fmt.Errorf("your current version [%s] is lower than the version [%s] you specify", clu.KubernetesVersion, c.Version)
 	}
 
 	return c.checkVersionSpan(&clu)
@@ -160,7 +160,7 @@ func (c *ClusterUpgradeOpts) checkVersionExist() error {
 func (c *ClusterUpgradeOpts) checkVersionSpan(clu *corev1.Cluster) error {
 	currentVersion := strings.Split(clu.KubernetesVersion[1:], ".")
 	targetVersion := strings.Split(c.Version[1:], ".")
-	for index := 0; index < len(targetVersion); index++ {
+	for index := 0; index < len(targetVersion)-1; index++ {
 		a, err := strconv.Atoi(targetVersion[index])
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: xu.jingwen <xu.jingwen@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```