### PR TITLE
fix: modify marked words and project exist check api

### DIFF
--- a/pkg/cli/cluster/cluster_upgrade.go
+++ b/pkg/cli/cluster/cluster_upgrade.go
@@ -177,7 +177,7 @@ func (c *ClusterUpgradeOpts) checkVersionExist() error {
 		}
 	}
 	if !versions.Has(c.Version) {
-		return fmt.Errorf("version [%s] you specify does not exist", c.Version)
+		return fmt.Errorf("version [%s] you specify is not avalible", c.Version)
 	}
 	return nil
 }

--- a/pkg/simple/client/kc/api.go
+++ b/pkg/simple/client/kc/api.go
@@ -150,7 +150,7 @@ func (cli *Client) DescribeCluster(ctx context.Context, name string) (*ClustersL
 }
 
 func (cli *Client) DescribeClusterInProject(ctx context.Context, projectName, clusterName string) (*ClustersList, error) {
-	serverResp, err := cli.get(ctx, fmt.Sprintf("%s/%s/cluster/%s", clusterInProjectPath, projectName, clusterName), nil, nil)
+	serverResp, err := cli.get(ctx, fmt.Sprintf("%s/%s/clusters/%s", clusterInProjectPath, projectName, clusterName), nil, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return nil, err
@@ -449,7 +449,7 @@ func (cli *Client) UpgradeCluster(ctx context.Context, cluName string, upgradeCl
 }
 
 func (cli *Client) UpgradeClusterInProject(ctx context.Context, proName, cluName string, upgradeCluster *corev1.ClusterUpgrade) error {
-	resp, err := cli.post(ctx, fmt.Sprintf("%s/%s/cluster/%s/upgrade", clusterInProjectPath, proName, cluName), nil, upgradeCluster, nil)
+	resp, err := cli.post(ctx, fmt.Sprintf("%s/%s/clusters/%s/upgrade", clusterInProjectPath, proName, cluName), nil, upgradeCluster, nil)
 	defer ensureReaderClosed(resp)
 	return err
 }


### PR DESCRIPTION
Signed-off-by: xu.jingwen <xu.jingwen@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```