### PR TITLE
feat: support delegate CloudProvider when delete cluster

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -1288,6 +1288,13 @@
           },
           {
             "type": "boolean",
+            "default": false,
+            "description": "deleting machines directly by the cloud provider, skipping the operation of deleting the cluster and deleting only the data",
+            "name": "delegateToCloudProvider",
+            "in": "query"
+          },
+          {
+            "type": "boolean",
             "description": "dry run delete clusters",
             "name": "dryRun",
             "in": "query"

--- a/pkg/apis/core/v1/registry.go
+++ b/pkg/apis/core/v1/registry.go
@@ -123,6 +123,8 @@ func SetupWebService(h *handler) *restful.WebService {
 		Param(webservice.PathParameter("name", "cluster name")).
 		Param(webservice.QueryParameter(query.ParameterForce, "force delete cluster, will ignore operation error").
 			Required(false).DataType("boolean").DefaultValue("false")).
+		Param(webservice.QueryParameter("delegateToCloudProvider", "deleting machines directly by the cloud provider, skipping the operation of deleting the cluster and deleting only the data").
+			Required(false).DataType("boolean").DefaultValue("false")).
 		Param(webservice.QueryParameter(query.ParamDryRun, "dry run delete clusters").
 			Required(false).DataType("boolean")).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), nil))


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:


Add feature for integrate with with IAAS. when delegateToCloudProvider set true,  iaas delete vm directly. kc should  skip delete operations and delete cluster and node data only

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lixd 