### PR TITLE
fix: kcctl registry deploy bug

### DIFF
--- a/pkg/cli/registry/registry.go
+++ b/pkg/cli/registry/registry.go
@@ -807,7 +807,7 @@ func (o *RegistryOptions) loadImages() error {
 	// docker load images
 	// find /root/kc/pkg/kc/resource -name images.tar.gz | grep -v kc-extension | grep 'x86-64' | awk '{print}' | sed -r 's#(.*)#docker load -i \1#'
 	// TODO: for historical reasons and version stability, kcctl temporarily skips the load of the kc-extension image when deploying a private repository
-	hook := fmt.Sprintf("find %s/kc/resource -name images*.tar.gz ｜ grep -v kc-extension | grep '%s' | awk '{print}' | sed -r 's#(.*)#docker load -i \\1#'", config.DefaultPkgPath, o.Arch)
+	hook := fmt.Sprintf("find %s/kc/resource -name images*.tar.gz | grep -v kc-extension | grep '%s' | awk '{print}' | sed -r 's#(.*)#docker load -i \\1#'", config.DefaultPkgPath, o.Arch)
 	logger.V(3).Info("loadImages hook :", hook)
 	ret, err := sshutils.SSHCmdWithSudo(o.SSHConfig, o.Node, hook)
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
kcctl registry deploy bug
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @lixd 