### PR TITLE
fix: kubelet supports setting nodeip

### DIFF
--- a/pkg/scheme/core/v1/cluster_types.go
+++ b/pkg/scheme/core/v1/cluster_types.go
@@ -258,6 +258,7 @@ type Etcd struct {
 
 type Kubelet struct {
 	RootDir string `json:"rootDir" yaml:"rootDir"`
+	NodeIP  string `json:"nodeIP" yaml:"nodeIP"`
 }
 
 type KubeProxy struct {

--- a/pkg/scheme/core/v1/k8s/kubeadm_step.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_step.go
@@ -440,7 +440,7 @@ func (stepper *KubeadmConfig) JoinSteps(isControlPlane bool, nodes []v1.StepNode
 	}
 	step := v1.Step{
 		ID:         strutil.GetUUID(),
-		Name:       "renderMasterJoinConfig",
+		Name:       "renderWorkerJoinConfig",
 		Timeout:    metav1.Duration{Duration: 1 * time.Minute},
 		ErrIgnore:  false,
 		RetryTimes: 1,
@@ -456,7 +456,7 @@ func (stepper *KubeadmConfig) JoinSteps(isControlPlane bool, nodes []v1.StepNode
 		},
 	}
 	if isControlPlane {
-		step.Name = "renderWorkerJoinConfig"
+		step.Name = "renderMasterJoinConfig"
 	}
 	return []v1.Step{step}, nil
 

--- a/pkg/scheme/core/v1/k8s/template.go
+++ b/pkg/scheme/core/v1/k8s/template.go
@@ -99,6 +99,7 @@ nodeRegistration:
 {{end}}
   kubeletExtraArgs:
     root-dir: {{.Kubelet.RootDir}}
+    node-ip: {{.Kubelet.NodeIP}}
 `
 
 const KubeadmJoinTemplate = `apiVersion: kubeadm.k8s.io/{{.ClusterConfigAPIVersion}}
@@ -121,7 +122,8 @@ nodeRegistration:
   criSocket: /run/containerd/containerd.sock
 {{end}}
   kubeletExtraArgs:
-    root-dir: {{.Kubelet.RootDir}}`
+    root-dir: {{.Kubelet.RootDir}}
+    node-ip: {{.Kubelet.NodeIP}}`
 
 const lvscareV111 = `
 apiVersion: v1


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```