### PR TITLE
fix: optimize the kcctl upgrade and resource error print

### DIFF
--- a/pkg/cli/resource/resource.go
+++ b/pkg/cli/resource/resource.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/kubeclipper/kubeclipper/pkg/scheme"
 
-	"github.com/kubeclipper/kubeclipper/pkg/utils/cmdutil"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/httputil"
 
 	"github.com/spf13/cobra"
@@ -408,12 +407,20 @@ func (o *ResourceOptions) ResourcePush() error {
 		return err
 	}
 	if _, ok := httputil.IsURL(o.Pkg); !ok {
-		ec, err := cmdutil.RunCmd(false, "tar", "-tf", o.Pkg)
+		ls, err := sshutils.RunCmdAsSSH(fmt.Sprintf("ls -l %s", o.Pkg))
 		if err != nil {
 			return err
 		}
-		if !strings.Contains(ec.StdOut(), fmt.Sprintf("%s/%s", version, arch)) {
-			return fmt.Errorf("package structure(%s) Non-standard. standard : 'version/arch/file' example: v4.0.2/amd64/images.tar.gz", ec.StdOut())
+		if ls.Stderr != "" {
+			return fmt.Errorf("%s file does not exist", o.Pkg)
+		}
+
+		tar, err := sshutils.RunCmdAsSSH(fmt.Sprintf("tar -tf %s", o.Pkg))
+		if err != nil {
+			return err
+		}
+		if !strings.Contains(tar.Stdout, fmt.Sprintf("%s/%s", version, arch)) {
+			return fmt.Errorf("package structure(%s) Non-standard. standard : 'version/arch/file' example: v4.0.2/amd64/images.tar.gz", tar.Stdout)
 		}
 	}
 

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -14,10 +14,9 @@ import (
 
 	"github.com/kubeclipper/kubeclipper/pkg/cli/deploy"
 
-	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
-	"github.com/kubeclipper/kubeclipper/pkg/utils/cmdutil"
-
 	"github.com/spf13/cobra"
+
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
 	"github.com/kubeclipper/kubeclipper/pkg/cli/config"
@@ -176,11 +175,11 @@ func (o *UpgradeOptions) checkBinary() error {
 	if o.component == options.UpgradeAll || o.component == options.UpgradeConsole {
 		return fmt.Errorf("can not upgrade kc and console using binary file")
 	}
-	cmd, err := cmdutil.RunCmd(false, "file", o.pkg)
+	cmd, err := sshutils.RunCmdAsSSH(fmt.Sprintf("file %s", o.pkg))
 	if err != nil {
 		return err
 	}
-	if !strings.Contains(cmd.StdOut(), "ELF") {
+	if !strings.Contains(cmd.Stdout, "ELF") {
 		return fmt.Errorf("pkg [%s] is not a binary file", o.pkg)
 	}
 	dir := filepath.Dir(o.pkg)


### PR DESCRIPTION
Signed-off-by: qinyer <qy913726062@gmail.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```