### PR TITLE
fix: cron-backup check cluster-apiserver bug

### DIFF
--- a/pkg/controller/cronbackupcontroller/controller.go
+++ b/pkg/controller/cronbackupcontroller/controller.go
@@ -338,8 +338,21 @@ func (r *CronBackupReconciler) createBackup(log logger.Logging, cronBackup *v1.C
 
 	steps := make([]v1.Step, 0)
 	var actBackup *k8s.ActBackup
+	var masters component.NodeList
+	for _, no := range nodeList {
+		masters = append(masters, component.Node{
+			ID:       no.Name,
+			IPv4:     no.Status.Ipv4DefaultIP,
+			NodeIPv4: no.Status.NodeIpv4DefaultIP,
+			Region:   no.Labels[common.LabelTopologyRegion],
+			Hostname: no.Labels[common.LabelHostname],
+			Role:     no.Labels[common.LabelNodeRole],
+			//Disable:  no.Labels[common.LabelNodeDisable]
+		})
+	}
 	meta := component.ExtraMetadata{
 		ClusterName: c.Name,
+		Masters:     masters,
 	}
 	meta.Masters = append(meta.Masters, component.Node{ID: backup.PreferredNode})
 	ctx := component.WithExtraMetadata(context.TODO(), meta)


### PR DESCRIPTION
Signed-off-by: zhuzhenfan <981189503@qq.com>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:
cron-backup check cluster-apiserver bug
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@x893675 @Metrora 