### PR TITLE
fix: kcctl create cluster --calico.ipv4-auto-detection flag checkfmt …

### DIFF
--- a/pkg/cli/create/create_cluster.go
+++ b/pkg/cli/create/create_cluster.go
@@ -269,7 +269,7 @@ func (l *CreateClusterOptions) ValidateArgs(cmd *cobra.Command) error {
 	if len(l.Masters)%2 == 0 {
 		return utils.UsageErrorf(cmd, "master node must be odd")
 	}
-	if l.IPv4AutoDetection != "" && !autodetection.CheckMethod(l.IPv4AutoDetection) {
+	if l.IPv4AutoDetection != "" && !autodetection.CheckCalicoMethod(l.IPv4AutoDetection) {
 		return utils.UsageErrorf(cmd, "unsupported ip detect method, support [first-found,interface=xxx,can-reach=xxx] now")
 	}
 	if l.Name == "" {

--- a/pkg/cli/create/create_cluster.go
+++ b/pkg/cli/create/create_cluster.go
@@ -23,6 +23,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/autodetection"
 	"net"
 	"os"
 	"strings"
@@ -133,9 +134,8 @@ type CreateClusterOptions struct {
 }
 
 var (
-	allowedCRI               = sets.NewString("containerd", "docker")
-	allowedCNI               = sets.NewString("calico")
-	allowedIPDetectionMethod = sets.NewString("first-found", "can-reach", "interface")
+	allowedCRI = sets.NewString("containerd", "docker")
+	allowedCNI = sets.NewString("calico")
 )
 
 func NewCreateClusterOptions(streams options.IOStreams) *CreateClusterOptions {
@@ -266,11 +266,11 @@ func (l *CreateClusterOptions) ValidateArgs(cmd *cobra.Command) error {
 	if !allowedCNI.Has(l.CNI) {
 		return utils.UsageErrorf(cmd, "unsupported cni,support %v now", allowedCNI.List())
 	}
-	if !allowedIPDetectionMethod.Has(l.IPv4AutoDetection) {
-		return utils.UsageErrorf(cmd, "unsupported pod ip detection method, support %v now", allowedIPDetectionMethod.List())
-	}
 	if len(l.Masters)%2 == 0 {
 		return utils.UsageErrorf(cmd, "master node must be odd")
+	}
+	if l.IPv4AutoDetection != "" && !autodetection.CheckMethod(l.IPv4AutoDetection) {
+		return utils.UsageErrorf(cmd, "unsupported ip detect method, support [first-found,interface=xxx,can-reach=xxx] now")
 	}
 	if l.Name == "" {
 		return utils.UsageErrorf(cmd, "cluster name must be specified")

--- a/pkg/utils/autodetection/method.go
+++ b/pkg/utils/autodetection/method.go
@@ -34,6 +34,7 @@ const (
 	MethodFirst     = "first-found"
 	MethodInterface = "interface="
 	MethodCidr      = "cidr="
+	MethodCanReach  = "can-reach="
 )
 
 const (
@@ -46,7 +47,7 @@ func CheckMethod(method string) bool {
 		return true
 	}
 
-	return strings.HasPrefix(method, MethodInterface) || strings.HasPrefix(method, MethodCidr)
+	return strings.HasPrefix(method, MethodInterface) || strings.HasPrefix(method, MethodCidr) || strings.HasPrefix(method, MethodCanReach)
 }
 
 // AutoDetectCIDR auto-detects the IP and Network using the requested detection method.

--- a/pkg/utils/autodetection/method.go
+++ b/pkg/utils/autodetection/method.go
@@ -47,7 +47,15 @@ func CheckMethod(method string) bool {
 		return true
 	}
 
-	return strings.HasPrefix(method, MethodInterface) || strings.HasPrefix(method, MethodCidr) || strings.HasPrefix(method, MethodCanReach)
+	return strings.HasPrefix(method, MethodInterface) || strings.HasPrefix(method, MethodCidr)
+}
+
+func CheckCalicoMethod(method string) bool {
+	if method == "" || method == MethodFirst {
+		return true
+	}
+
+	return strings.HasPrefix(method, MethodInterface) || strings.HasPrefix(method, MethodCanReach)
 }
 
 // AutoDetectCIDR auto-detects the IP and Network using the requested detection method.


### PR DESCRIPTION
…error

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```