### PR TITLE
fix: get resourceVersion before edit cluster

### DIFF
--- a/test/api/backup_recovery_cluster/create_cluster_backup.yaml
+++ b/test/api/backup_recovery_cluster/create_cluster_backup.yaml
@@ -161,6 +161,13 @@ tests:
     response_json_paths:
       $.status.phase: "Running"
 
+  - name: get_cluster_detail_1
+    url: /api/core.kubeclipper.io/v1/clusters/test
+    method: GET
+    request_headers:
+      Authorization: Bearer $HISTORY['user_login'].$RESPONSE['$.access_token']
+    status: 200
+
   - name: edit_cluster_to_select_s3_backup_space
     url: /apis/api/core.kubeclipper.io/v1/clusters/test
     method: PUT
@@ -178,7 +185,7 @@ tests:
           kubeclipper.io/offline: ""
         finalizers:
           - finalizer.cluster.kubeclipper.io
-        resourceVersion: $HISTORY['get_cluster_detail'].$RESPONSE['$.metadata.resourceVersion']
+        resourceVersion: $HISTORY['get_cluster_detail_1'].$RESPONSE['$.metadata.resourceVersion']
       masters:
         - id: $HISTORY['get_node_list'].$RESPONSE['$.items[0].metadata.name']
           containerRuntime:

--- a/test/api/list.yaml
+++ b/test/api/list.yaml
@@ -44,7 +44,7 @@ apitest:
             api_number: 2
         - create_cluster_backup:
             file_name: create_cluster_backup.yaml
-            number: 10
+            number: 11
             api_number: 4
         - get_cluster_backup:
             file_name: get_cluster_backup.yaml


### PR DESCRIPTION
Signed-off-by: cmycoups chen.mengyun@99cloud.net

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```