### PR TITLE
add pkg flag for join cmd

### DIFF
--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -85,6 +85,8 @@ type JoinOptions struct {
 	floatIPs   []string // format: ip:floatIP,e.g. 192.168.10.11:172.20.149.199
 	ipDetect   string
 	parseAgent options.Agents
+
+	Pkg string `json:"pkg" yaml:"pkg,omitempty"`
 }
 
 func NewJoinOptions(streams options.IOStreams) *JoinOptions {
@@ -239,14 +241,18 @@ func (c *JoinOptions) preCheckKcAgent(ip string) bool {
 }
 
 func (c *JoinOptions) agentNodeFiles(node string, metadata options.Metadata) error {
+	pkg := c.deployConfig.Pkg
+	if c.Pkg != "" {
+		pkg = c.Pkg
+	}
 	// send agent binary
 	hook := fmt.Sprintf("rm -rf %s && tar -xvf %s -C %s && cp -rf %s /usr/local/bin/",
 		filepath.Join(config.DefaultPkgPath, "kc"),
-		filepath.Join(config.DefaultPkgPath, path.Base(c.deployConfig.Pkg)),
+		filepath.Join(config.DefaultPkgPath, path.Base(pkg)),
 		config.DefaultPkgPath,
 		filepath.Join(config.DefaultPkgPath, "kc/bin/kubeclipper-agent"))
 	logger.V(3).Info("join agent node hook:", hook)
-	err := utils.SendPackageV2(c.deployConfig.SSHConfig, c.deployConfig.Pkg, []string{node}, config.DefaultPkgPath, nil, &hook)
+	err := utils.SendPackageV2(c.deployConfig.SSHConfig, pkg, []string{node}, config.DefaultPkgPath, nil, &hook)
 	if err != nil {
 		return errors.Wrap(err, "SendPackageV2")
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind optimize
### What this PR does / why we need it:

manual cherry-pick #577 

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```