### PR TITLE
use externalip in kubeconfig when cluster externalip is valid

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -604,8 +604,12 @@ func (h *handler) GetKubeConfig(request *restful.Request, response *restful.Resp
 			restplus.HandleInternalError(response, request, err)
 			return
 		}
+		var externalAddress string
+		if clu.Labels != nil {
+			externalAddress = clu.Labels[common.LabelExternalIP]
+		}
 
-		kubeConfig, err := k8s.GetKubeConfig(context.TODO(), extraMeta.ClusterName, masters[0], h.delivery)
+		kubeConfig, err := k8s.GetKubeConfig(context.TODO(), extraMeta.ClusterName, masters[0], externalAddress, h.delivery)
 		if err != nil {
 			restplus.HandleInternalError(response, request, err)
 			return

--- a/pkg/scheme/core/v1/k8s/kubeadm_step.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_step.go
@@ -551,7 +551,7 @@ func (stepper *ClusterNode) InitStepper(c *v1.Cluster, metadata *component.Extra
 	return stepper
 }
 
-func GetKubeConfig(ctx context.Context, name string, node component.Node, deliveryCmd service.CmdDelivery) (string, error) {
+func GetKubeConfig(ctx context.Context, name string, node component.Node, externalAddress string, deliveryCmd service.CmdDelivery) (string, error) {
 	content, err := deliveryCmd.DeliverCmd(ctx, node.ID, []string{"cat", "/etc/kubernetes/admin.conf"}, 3*time.Minute)
 	if err != nil {
 		logger.Errorf(" cat kubeConfig error: %s", err.Error())
@@ -567,7 +567,11 @@ func GetKubeConfig(ctx context.Context, name string, node component.Node, delive
 		return "", err
 	}
 
-	kubeConfig.Clusters[name].Server = fmt.Sprintf("https://%s:6443", node.NodeIPv4)
+	if externalAddress != "" {
+		kubeConfig.Clusters[name].Server = fmt.Sprintf("https://%s:6443", externalAddress)
+	} else {
+		kubeConfig.Clusters[name].Server = fmt.Sprintf("https://%s:6443", node.NodeIPv4)
+	}
 	config, err := clientcmd.Write(kubeConfig)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind optimize

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```