### PR TITLE
fix: add namespace when create/update

### DIFF
--- a/pkg/models/cluster/cluster.go
+++ b/pkg/models/cluster/cluster.go
@@ -21,6 +21,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"sort"
 	"strings"
 
@@ -76,6 +77,7 @@ func NewClusterOperator(clusterStorage, nodeStorage, regionStorage, backupStorag
 }
 
 func (c *clusterOperator) UpdateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
+	ctx = genericapirequest.WithNamespace(ctx, cluster.Namespace)
 	obj, wasCreated, err := c.clusterStorage.Update(ctx, cluster.Name, rest.DefaultUpdatedObjectInfo(cluster),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -88,6 +90,7 @@ func (c *clusterOperator) UpdateCluster(ctx context.Context, cluster *v1.Cluster
 }
 
 func (c *clusterOperator) UpdateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	ctx = genericapirequest.WithNamespace(ctx, node.Namespace)
 	obj, wasCreated, err := c.nodeStorage.Update(ctx, node.Name, rest.DefaultUpdatedObjectInfo(node),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -113,6 +116,7 @@ func (c *clusterOperator) ListClusterEx(ctx context.Context, query *query.Query)
 }
 
 func (c *clusterOperator) CreateCluster(ctx context.Context, cluster *v1.Cluster) (*v1.Cluster, error) {
+	ctx = genericapirequest.WithNamespace(ctx, cluster.Namespace)
 	obj, err := c.clusterStorage.Create(ctx, cluster, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -181,6 +185,7 @@ func (c *clusterOperator) DeleteNode(ctx context.Context, name string) error {
 }
 
 func (c *clusterOperator) CreateNode(ctx context.Context, node *v1.Node) (*v1.Node, error) {
+	ctx = genericapirequest.WithNamespace(ctx, node.Namespace)
 	obj, err := c.nodeStorage.Create(ctx, node, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -218,6 +223,7 @@ func (c *clusterOperator) WatchRegions(ctx context.Context, query *query.Query) 
 }
 
 func (c *clusterOperator) CreateRegion(ctx context.Context, region *v1.Region) (*v1.Region, error) {
+	ctx = genericapirequest.WithNamespace(ctx, region.Namespace)
 	obj, err := c.regionStorage.Create(ctx, region, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -233,6 +239,7 @@ func (c *clusterOperator) DeleteRegion(ctx context.Context, name string) error {
 }
 
 func (c *clusterOperator) CreateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
+	ctx = genericapirequest.WithNamespace(ctx, backup.Namespace)
 	obj, err := c.backupStorage.Create(ctx, backup, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -280,6 +287,7 @@ func (c *clusterOperator) ListBackupEx(ctx context.Context, query *query.Query) 
 }
 
 func (c *clusterOperator) UpdateBackup(ctx context.Context, backup *v1.Backup) (*v1.Backup, error) {
+	ctx = genericapirequest.WithNamespace(ctx, backup.Namespace)
 	obj, existed, err := c.backupStorage.Update(ctx, backup.Name, rest.DefaultUpdatedObjectInfo(backup),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -324,6 +332,7 @@ func (c *clusterOperator) ListBackupPointEx(ctx context.Context, query *query.Qu
 }
 
 func (c *clusterOperator) CreateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+	ctx = genericapirequest.WithNamespace(ctx, backupPoint.Namespace)
 	obj, err := c.backupPointStorage.Create(ctx, backupPoint, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -332,6 +341,7 @@ func (c *clusterOperator) CreateBackupPoint(ctx context.Context, backupPoint *v1
 }
 
 func (c *clusterOperator) UpdateBackupPoint(ctx context.Context, backupPoint *v1.BackupPoint) (*v1.BackupPoint, error) {
+	ctx = genericapirequest.WithNamespace(ctx, backupPoint.Namespace)
 	obj, existed, err := c.backupPointStorage.Update(ctx, backupPoint.Name, rest.DefaultUpdatedObjectInfo(backupPoint),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -384,6 +394,7 @@ func (c *clusterOperator) ListCronBackupEx(ctx context.Context, query *query.Que
 }
 
 func (c *clusterOperator) CreateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
+	ctx = genericapirequest.WithNamespace(ctx, cronBackup.Namespace)
 	obj, err := c.cronBackupStorage.Create(ctx, cronBackup, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -392,6 +403,7 @@ func (c *clusterOperator) CreateCronBackup(ctx context.Context, cronBackup *v1.C
 }
 
 func (c *clusterOperator) UpdateCronBackup(ctx context.Context, cronBackup *v1.CronBackup) (*v1.CronBackup, error) {
+	ctx = genericapirequest.WithNamespace(ctx, cronBackup.Namespace)
 	obj, existed, err := c.cronBackupStorage.Update(ctx, cronBackup.Name, rest.DefaultUpdatedObjectInfo(cronBackup),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -454,6 +466,7 @@ func (c *clusterOperator) GetDomainEx(ctx context.Context, name string, resource
 }
 
 func (c *clusterOperator) CreateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
+	ctx = genericapirequest.WithNamespace(ctx, domain.Namespace)
 	obj, err := c.dnsStorage.Create(ctx, domain, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -462,6 +475,7 @@ func (c *clusterOperator) CreateDomain(ctx context.Context, domain *v1.Domain) (
 }
 
 func (c *clusterOperator) UpdateDomain(ctx context.Context, domain *v1.Domain) (*v1.Domain, error) {
+	ctx = genericapirequest.WithNamespace(ctx, domain.Namespace)
 	obj, creating, err := c.dnsStorage.Update(ctx, domain.Name, rest.DefaultUpdatedObjectInfo(domain),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -714,6 +728,7 @@ func (c *clusterOperator) GetTemplateEx(ctx context.Context, name string, resour
 }
 
 func (c *clusterOperator) CreateTemplate(ctx context.Context, template *v1.Template) (*v1.Template, error) {
+	ctx = genericapirequest.WithNamespace(ctx, template.Namespace)
 	obj, err := c.templateStorage.Create(ctx, template, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -722,6 +737,7 @@ func (c *clusterOperator) CreateTemplate(ctx context.Context, template *v1.Templ
 }
 
 func (c *clusterOperator) UpdateTemplate(ctx context.Context, template *v1.Template) (*v1.Template, error) {
+	ctx = genericapirequest.WithNamespace(ctx, template.Namespace)
 	obj, creating, err := c.templateStorage.Update(ctx, template.Name, rest.DefaultUpdatedObjectInfo(template),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -802,6 +818,7 @@ func (c *clusterOperator) ListCloudProvidersEx(ctx context.Context, query *query
 }
 
 func (c *clusterOperator) CreateCloudProvider(ctx context.Context, CloudProvider *v1.CloudProvider) (*v1.CloudProvider, error) {
+	ctx = genericapirequest.WithNamespace(ctx, CloudProvider.Namespace)
 	obj, err := c.cloudProviderStorage.Create(ctx, CloudProvider, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -810,6 +827,7 @@ func (c *clusterOperator) CreateCloudProvider(ctx context.Context, CloudProvider
 }
 
 func (c *clusterOperator) UpdateCloudProvider(ctx context.Context, CloudProvider *v1.CloudProvider) (*v1.CloudProvider, error) {
+	ctx = genericapirequest.WithNamespace(ctx, CloudProvider.Namespace)
 	obj, wasCreated, err := c.cloudProviderStorage.Update(ctx, CloudProvider.Name, rest.DefaultUpdatedObjectInfo(CloudProvider),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -879,6 +897,7 @@ func (c *clusterOperator) ListRegistriesEx(ctx context.Context, query *query.Que
 }
 
 func (c *clusterOperator) CreateRegistry(ctx context.Context, r *v1.Registry) (*v1.Registry, error) {
+	ctx = genericapirequest.WithNamespace(ctx, r.Namespace)
 	obj, err := c.registryStorage.Create(ctx, r, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -887,6 +906,7 @@ func (c *clusterOperator) CreateRegistry(ctx context.Context, r *v1.Registry) (*
 }
 
 func (c *clusterOperator) UpdateRegistry(ctx context.Context, r *v1.Registry) (*v1.Registry, error) {
+	ctx = genericapirequest.WithNamespace(ctx, r.Namespace)
 	obj, wasCreated, err := c.registryStorage.Update(ctx, r.Name, rest.DefaultUpdatedObjectInfo(r),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/models/core/configmap.go
+++ b/pkg/models/core/configmap.go
@@ -20,6 +20,7 @@ package core
 
 import (
 	"context"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -81,6 +82,7 @@ func (o operator) ListConfigMapsEx(ctx context.Context, query *query.Query) (*mo
 }
 
 func (o operator) CreateConfigMap(ctx context.Context, configmap *v1.ConfigMap) (*v1.ConfigMap, error) {
+	ctx = genericapirequest.WithNamespace(ctx, configmap.Namespace)
 	obj, err := o.cmStorage.Create(ctx, configmap, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -89,6 +91,7 @@ func (o operator) CreateConfigMap(ctx context.Context, configmap *v1.ConfigMap) 
 }
 
 func (o operator) UpdateConfigMap(ctx context.Context, configmap *v1.ConfigMap) (*v1.ConfigMap, error) {
+	ctx = genericapirequest.WithNamespace(ctx, configmap.Namespace)
 	obj, wasCreated, err := o.cmStorage.Update(ctx, configmap.Name, rest.DefaultUpdatedObjectInfo(configmap),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/models/iam/iam.go
+++ b/pkg/models/iam/iam.go
@@ -20,6 +20,7 @@ package iam
 
 import (
 	"context"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -92,6 +93,7 @@ func (i *iamOperator) GetUser(ctx context.Context, name string) (*iamv1.User, er
 }
 
 func (i *iamOperator) CreateUser(ctx context.Context, user *iamv1.User) (*iamv1.User, error) {
+	ctx = genericapirequest.WithNamespace(ctx, user.Namespace)
 	obj, err := i.userStorage.Create(ctx, user, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -100,6 +102,7 @@ func (i *iamOperator) CreateUser(ctx context.Context, user *iamv1.User) (*iamv1.
 }
 
 func (i *iamOperator) UpdateUser(ctx context.Context, user *iamv1.User) (*iamv1.User, error) {
+	ctx = genericapirequest.WithNamespace(ctx, user.Namespace)
 	obj, wasCreated, err := i.userStorage.Update(ctx, user.Name, rest.DefaultUpdatedObjectInfo(user),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -314,6 +317,7 @@ func (i *iamOperator) GetRole(ctx context.Context, name string) (*iamv1.GlobalRo
 }
 
 func (i *iamOperator) CreateRole(ctx context.Context, role *iamv1.GlobalRole) (*iamv1.GlobalRole, error) {
+	ctx = genericapirequest.WithNamespace(ctx, role.Namespace)
 	obj, err := i.roleStorage.Create(ctx, role, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -322,6 +326,7 @@ func (i *iamOperator) CreateRole(ctx context.Context, role *iamv1.GlobalRole) (*
 }
 
 func (i *iamOperator) UpdateRole(ctx context.Context, role *iamv1.GlobalRole) (*iamv1.GlobalRole, error) {
+	ctx = genericapirequest.WithNamespace(ctx, role.Namespace)
 	obj, wasCreated, err := i.roleStorage.Update(ctx, role.Name, rest.DefaultUpdatedObjectInfo(role),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -370,6 +375,7 @@ func (i *iamOperator) GetRoleBinding(ctx context.Context, name string) (*iamv1.G
 }
 
 func (i *iamOperator) CreateRoleBinding(ctx context.Context, role *iamv1.GlobalRoleBinding) (*iamv1.GlobalRoleBinding, error) {
+	ctx = genericapirequest.WithNamespace(ctx, role.Namespace)
 	obj, err := i.roleBindingStorage.Create(ctx, role, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -378,6 +384,7 @@ func (i *iamOperator) CreateRoleBinding(ctx context.Context, role *iamv1.GlobalR
 }
 
 func (i *iamOperator) UpdateRoleBinding(ctx context.Context, role *iamv1.GlobalRoleBinding) (*iamv1.GlobalRoleBinding, error) {
+	ctx = genericapirequest.WithNamespace(ctx, role.Namespace)
 	obj, wasCreated, err := i.roleBindingStorage.Update(ctx, role.Name, rest.DefaultUpdatedObjectInfo(role),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {
@@ -427,6 +434,7 @@ func (i *iamOperator) GetToken(ctx context.Context, name string) (*iamv1.Token, 
 }
 
 func (i *iamOperator) CreateToken(ctx context.Context, token *iamv1.Token) (*iamv1.Token, error) {
+	ctx = genericapirequest.WithNamespace(ctx, token.Namespace)
 	obj, err := i.tokenStorage.Create(ctx, token, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -435,6 +443,7 @@ func (i *iamOperator) CreateToken(ctx context.Context, token *iamv1.Token) (*iam
 }
 
 func (i *iamOperator) UpdateToken(ctx context.Context, token *iamv1.Token) (*iamv1.Token, error) {
+	ctx = genericapirequest.WithNamespace(ctx, token.Namespace)
 	obj, wasCreated, err := i.tokenStorage.Update(ctx, token.Name, rest.DefaultUpdatedObjectInfo(token),
 		nil, nil, false, &metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/models/operation/operation.go
+++ b/pkg/models/operation/operation.go
@@ -20,6 +20,7 @@ package operation
 
 import (
 	"context"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/kubeclipper/kubeclipper/pkg/models"
 
@@ -74,6 +75,7 @@ func (l *operationOperator) GetOperation(ctx context.Context, name string) (*v1.
 }
 
 func (l *operationOperator) CreateOperation(ctx context.Context, operation *v1.Operation) (*v1.Operation, error) {
+	ctx = genericapirequest.WithNamespace(ctx, operation.Namespace)
 	obj, err := l.storage.Create(ctx, operation, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -82,6 +84,7 @@ func (l *operationOperator) CreateOperation(ctx context.Context, operation *v1.O
 }
 
 func (l *operationOperator) UpdateOperation(ctx context.Context, operation *v1.Operation) (*v1.Operation, error) {
+	ctx = genericapirequest.WithNamespace(ctx, operation.Namespace)
 	obj, wasCreated, err := l.storage.Update(ctx, operation.Name, rest.DefaultUpdatedObjectInfo(operation), nil, nil, false, &metav1.UpdateOptions{})
 	if wasCreated {
 		logger.Debug("operation not exist, use create instead of update", zap.String("name", operation.Name))

--- a/pkg/models/platform/platformsetting.go
+++ b/pkg/models/platform/platformsetting.go
@@ -20,6 +20,7 @@ package platform
 
 import (
 	"context"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,6 +70,7 @@ func (p *platformOperator) GetPlatformSetting(ctx context.Context) (*v1.Platform
 }
 
 func (p *platformOperator) CreatePlatformSetting(ctx context.Context, platformSetting *v1.PlatformSetting) (*v1.PlatformSetting, error) {
+	ctx = genericapirequest.WithNamespace(ctx, platformSetting.Namespace)
 	obj, err := p.storage.Create(ctx, platformSetting, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
@@ -77,6 +79,7 @@ func (p *platformOperator) CreatePlatformSetting(ctx context.Context, platformSe
 }
 
 func (p *platformOperator) UpdatePlatformSetting(ctx context.Context, platformSetting *v1.PlatformSetting) (*v1.PlatformSetting, error) {
+	ctx = genericapirequest.WithNamespace(ctx, platformSetting.Namespace)
 	obj, wasCreated, err := p.storage.Update(ctx, platformSetting.Name, rest.DefaultUpdatedObjectInfo(platformSetting), nil, nil, false, &metav1.UpdateOptions{})
 	if wasCreated {
 		logger.Debug("platform not exist, use create instead of update", zap.String("name", platformSetting.Name))
@@ -100,6 +103,7 @@ func (p *platformOperator) GetEvent(ctx context.Context, name string) (*v1.Event
 }
 
 func (p *platformOperator) CreateEvent(ctx context.Context, Event *v1.Event) (*v1.Event, error) {
+	ctx = genericapirequest.WithNamespace(ctx, Event.Namespace)
 	obj, err := p.eventStorage.Create(ctx, Event, nil, &metav1.CreateOptions{})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake

### What this PR does / why we need it:
add namespace when create/update,for upgrade k8s api
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
add namespace when create/update,for upgrade k8s api
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```