### PR TITLE
optimize kcctl get cluster output

### DIFF
--- a/pkg/simple/client/kc/scheme.go
+++ b/pkg/simple/client/kc/scheme.go
@@ -20,6 +20,7 @@ package kc
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 
@@ -132,10 +133,21 @@ func (n *ClustersList) JSONPrint() ([]byte, error) {
 }
 
 func (n *ClustersList) TablePrint() ([]string, [][]string) {
-	headers := []string{"name", "create_timestamp"}
+	headers := []string{"name", "region", "master_count", "worker_count", "status", "apiserver_certs_expiration", "create_timestamp"}
 	var data [][]string
 	for _, cluster := range n.Items {
+		var ace string
+		for _, cert := range cluster.Status.Certifications {
+			if cert.Name == "apiserver" {
+				ace = cert.ExpirationTime.String()
+			}
+		}
 		data = append(data, []string{cluster.Name,
+			cluster.Labels[common.LabelTopologyRegion],
+			strconv.FormatInt(int64(len(cluster.Masters)), 10),
+			strconv.FormatInt(int64(len(cluster.Workers)), 10),
+			string(cluster.Status.Phase),
+			ace,
 			cluster.CreationTimestamp.String()})
 	}
 	return headers, data

--- a/pkg/simple/client/kc/scheme_test.go
+++ b/pkg/simple/client/kc/scheme_test.go
@@ -422,57 +422,6 @@ func TestClustersList_JSONPrint(t *testing.T) {
 	}
 }
 
-func TestClustersList_TablePrint(t *testing.T) {
-	type fields struct {
-		Items      []corev1.Cluster
-		TotalCount int
-	}
-	tests := []struct {
-		name   string
-		fields fields
-		want   []string
-		want1  [][]string
-	}{
-		{
-			name: "base",
-			fields: fields{
-				Items: []corev1.Cluster{
-					{
-						ObjectMeta: v1.ObjectMeta{
-							Name: "cluster1",
-						},
-					},
-					{
-						ObjectMeta: v1.ObjectMeta{
-							Name: "cluster2",
-						},
-					},
-				},
-			},
-			want: []string{"name", "create_timestamp"},
-			want1: [][]string{
-				{"cluster1", "0001-01-01 00:00:00 +0000 UTC"},
-				{"cluster2", "0001-01-01 00:00:00 +0000 UTC"},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			n := &ClustersList{
-				Items:      tt.fields.Items,
-				TotalCount: tt.fields.TotalCount,
-			}
-			got, got1 := n.TablePrint()
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("TablePrint() got = %v, want %v", got, tt.want)
-			}
-			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("TablePrint() got1 = %v, want %v", got1, tt.want1)
-			}
-		})
-	}
-}
-
 func TestRoleList_YAMLPrint(t *testing.T) {
 	type fields struct {
 		Items      []iamv1.GlobalRole


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind optimize

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
none
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```