### PR TITLE
fix: registry add insecure options

### DIFF
--- a/pkg/cli/registry/client/client.go
+++ b/pkg/cli/registry/client/client.go
@@ -33,7 +33,7 @@ func Push(file, registryStr string) error {
 			repository := tag.RepositoryStr()
 			target := fmt.Sprintf("%s/%s:%s", registryStr, repository, tag.TagStr())
 			logger.V(2).Infof("[%v/%v] push %s -> %s\n", i+1, len(manifest), t, target)
-			if err = crane.Push(img, target); err != nil {
+			if err = crane.Push(img, target, crane.Insecure); err != nil {
 				return errors.WithMessage(err, "push")
 			}
 
@@ -47,7 +47,7 @@ func Push(file, registryStr string) error {
 				repository = split[1]
 				target = fmt.Sprintf("%s/%s:%s", registryStr, repository, tag.TagStr())
 				logger.V(2).Infof("[%v/%v] push %s -> %s\n", i+1, len(manifest), t, target)
-				if err = crane.Push(img, target); err != nil {
+				if err = crane.Push(img, target, crane.Insecure); err != nil {
 					return errors.WithMessage(err, "push")
 				}
 			}
@@ -59,21 +59,21 @@ func Push(file, registryStr string) error {
 // Delete docker registry doesn't support tag deletion and we have to delete by digest
 // e.g.  crane delete --insecure "localhost:5000/caas4/nfsplugin@$(crane digest localhost:5000/caas4/nfsplugin:v4.1.0)"
 func Delete(registry, repository, tag string) error {
-	digest, err := crane.Digest(fmt.Sprintf("%s/%s:%s", registry, repository, tag))
+	digest, err := crane.Digest(fmt.Sprintf("%s/%s:%s", registry, repository, tag), crane.Insecure)
 	if err != nil {
 		return errors.WithMessage(err, "get digest")
 	}
-	return crane.Delete(fmt.Sprintf("%s/%s@%s", registry, repository, digest))
+	return crane.Delete(fmt.Sprintf("%s/%s@%s", registry, repository, digest), crane.Insecure)
 }
 
 // Catalog return repositories in registry.
 func Catalog(registry string) ([]string, error) {
-	return crane.Catalog(registry)
+	return crane.Catalog(registry, crane.Insecure)
 }
 
 // ListTags return repositories in registry.
 func ListTags(registry, repository string) ([]string, error) {
-	return crane.ListTags(fmt.Sprintf("%s/%s", registry, repository))
+	return crane.ListTags(fmt.Sprintf("%s/%s", registry, repository), crane.Insecure)
 }
 
 func pathOpener(path string) tarball.Opener {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #705

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```