### PR TITLE
Fixed nil error log when unmarshal manifest.json

### DIFF
--- a/pkg/simple/downloader/downloader.go
+++ b/pkg/simple/downloader/downloader.go
@@ -296,9 +296,9 @@ func (dl *Downloader) getManifestElements(prefix string) (manifest []ManifestEle
 		return
 	}
 	if err = json.Unmarshal(data, &manifest); err != nil {
+		logger.Debugf("unmarshal [%s] file contents failed: %v", filePath, err)
 		return
 	}
-	logger.Debugf("unmarshal [%s] file contents failed: %v", filePath, err)
 	return
 }
 


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fixed nil error log when unmarshal manifest.json. For example:

```log
downloader.go:306        unmarshal [/opt/kc/manifest/containerd/1.6.4/amd64/config/manifest.json] file contents failed: <nil>
```

### Does this PR introduced a user-facing change?

```release-note
NONE
```