### PR TITLE
Output raw std error after executing cmd failed

### DIFF
--- a/pkg/utils/cmdutil/cmdutil.go
+++ b/pkg/utils/cmdutil/cmdutil.go
@@ -91,7 +91,8 @@ func RunCmdWithContext(ctx context.Context, dryRun bool, command string, args ..
 	//	}
 	//}()
 	if err = ec.Run(); err != nil {
-		logger.Error("run command failed: "+err.Error(), zap.String("cmd", ec.String()))
+		// e.g. run command failed(exit status 1): ${raw_std_error}
+		logger.Errorf("run command failed(%v): %s", err, ec.StdErr(), zap.String("cmd", ec.String()))
 		return ec, err
 	}
 	return ec, nil

--- a/pkg/utils/cmdutil/command.go
+++ b/pkg/utils/cmdutil/command.go
@@ -70,14 +70,7 @@ func (ec *ExecCmd) Run() error {
 		return errors.New("exec: already started")
 	}
 	ec.Cmd.Env = os.Environ()
-	if err := ec.Cmd.Run(); err != nil {
-		// errs = append(errs, err)
-		// command runs and exits with a non-zero exit status
-		// put it into stderr
-		_, _ = ec.stdErrBuf.WriteString(err.Error())
-		return err
-	}
-	return nil
+	return ec.Cmd.Run()
 }
 
 // Marshal merges stdout & stderr and returns bytes slice


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What this PR does / why we need it:

Show raw std error in log after executing cmd failed. It's helpful.

Before:

```log
run command failed: exit status 1
```

After:

```log
run command failed(exit status 1): foo bar baz
```

### Does this PR introduced a user-facing change?

```release-note
NONE
```