### PR TITLE
Fixed error SystemdCgroup runc config of containerd

### DIFF
--- a/pkg/utils/cgroups/systemd.go
+++ b/pkg/utils/cgroups/systemd.go
@@ -1,0 +1,23 @@
+package cgroups
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	isRunningSystemdOnce sync.Once
+	isRunningSystemd     bool
+)
+
+// IsRunningSystemd checks whether the host was booted with systemd as its init
+// system. This functions similarly to systemd's `sd_booted(3)`: internally, it
+// checks whether /run/systemd/system/ exists and is a directory.
+// http://www.freedesktop.org/software/systemd/man/sd_booted.html
+func IsRunningSystemd() bool {
+	isRunningSystemdOnce.Do(func() {
+		fi, err := os.Lstat("/run/systemd/system")
+		isRunningSystemd = err == nil && fi.IsDir()
+	})
+	return isRunningSystemd
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fixed error `SystemdCgroup` runc config of containerd.

```toml
          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
            BinaryName = ""
            CriuImagePath = ""
            CriuPath = ""
            CriuWorkPath = ""
            IoGid = 0
            IoUid = 0
            NoNewKeyring = false
            NoPivotRoot = false
            Root = ""
            ShimCgroup = ""
            SystemdCgroup = true
```

> reference: <https://github.com/containerd/containerd/blob/main/docs/cri/config.md#cgroup-driver>

### Does this PR introduced a user-facing change?

```release-note
NONE
```