### PR TITLE
Fixed nil pointer when getting nodes status

### DIFF
--- a/pkg/scheme/core/v1/k8s/kubeadm.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm.go
@@ -852,10 +852,8 @@ func (stepper *Health) NewInstance() component.ObjectMeta {
 }
 
 func (stepper *Health) Install(ctx context.Context, opts component.Options) (b []byte, err error) {
-	if stepper.Clientset == nil {
-		if stepper.Clientset, err = utils.BuildKubeClientset(DefaultKubeConfigPath); err != nil {
-			return nil, fmt.Errorf("failed to create clientset: %v", err)
-		}
+	if stepper.Clientset, err = utils.BuildKubeClientset(DefaultKubeConfigPath); err != nil {
+		return nil, fmt.Errorf("failed to create clientset: %v", err)
 	}
 
 	for _, fn := range []func(ctx context.Context, opts component.Options) error{stepper.allNodesReady, stepper.kubeSystemPodsReady} {


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fixed nil pointer when getting nodes status by forcely new clientset.

### Does this PR introduced a user-facing change?

```release-note
NONE
```