### PR TITLE
fix: systemctl add fallback to  compatible old version

### DIFF
--- a/pkg/utils/systemctl/fallback.go
+++ b/pkg/utils/systemctl/fallback.go
@@ -1,0 +1,58 @@
+package systemctl
+
+import (
+	"context"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+
+	"github.com/kubeclipper/kubeclipper/pkg/logger"
+)
+
+// ListUnitsByNamesContextFallback 兼容旧版本 systemd
+// Issue: https://github.com/coreos/go-systemd/issues/223
+func ListUnitsByNamesContextFallback(ctx context.Context, conn *dbus.Conn, name string) ([]dbus.UnitStatus, error) {
+	var fallback bool
+	list := make([]dbus.UnitStatus, 0)
+	units, err := conn.ListUnitsByNamesContext(ctx, []string{name})
+	if err != nil {
+		fallback = true
+		logger.Debugf("ListUnitsByNames is not implemented in your systemd version (requires at least systemd 230), fallback to ListUnits: %v", err)
+		// 注意：这个方法不会返回全部的 unit, disabled and inactive will thus not be returned.
+		units, err = conn.ListUnitsContext(ctx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for _, unit := range units {
+		if unit.Name == name {
+			list = append(list, unit)
+		}
+	}
+
+	// grab data on subscribed units that didn't show up in ListUnits in fallback mode, most
+	// likely due to being inactive
+	if fallback {
+		// 因此对于旧版本的环境：我们要在根据 name 查询一次
+		us, err := getUnitState(ctx, conn, name)
+		if err != nil {
+			return nil, err
+		}
+		list = append(list, *us)
+	}
+
+	return list, nil
+}
+
+func getUnitState(ctx context.Context, d *dbus.Conn, name string) (*dbus.UnitStatus, error) {
+	info, err := d.GetUnitPropertiesContext(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &dbus.UnitStatus{
+		Name:        name,
+		LoadState:   info["LoadState"].(string),
+		ActiveState: info["ActiveState"].(string),
+		SubState:    info["SubState"].(string),
+	}, nil
+}

--- a/pkg/utils/systemctl/systemctl.go
+++ b/pkg/utils/systemctl/systemctl.go
@@ -38,7 +38,7 @@ const (
 // lookupUnitStatus returns the status of the unit if it exists.
 // equivalent to `systemctl show <unit-name> --property=ActiveState`
 func lookupUnitStatus(ctx context.Context, conn *dbus.Conn, name string) (*dbus.UnitStatus, error) {
-	units, err := conn.ListUnitsByNamesContext(ctx, []string{name})
+	units, err := ListUnitsByNamesContextFallback(ctx, conn, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup unit %s: %w", name, err)
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #788

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```