### PR TITLE
fix: specify kubelet data dir for calico installation

### DIFF
--- a/pkg/scheme/core/v1/cni/calico.go
+++ b/pkg/scheme/core/v1/cni/calico.go
@@ -68,6 +68,7 @@ type CalicoRunnable struct {
 	BaseCni
 	NodeAddressDetectionV4 NodeAddressDetection
 	NodeAddressDetectionV6 NodeAddressDetection
+	KubeletDataDir         string
 }
 
 func (runnable *CalicoRunnable) Type() string {
@@ -89,6 +90,7 @@ func (runnable *CalicoRunnable) InitStep(metadata *component.ExtraMetadata, cni 
 		ipv6 = networking.Pods.CIDRBlocks[1]
 	}
 	stepper.CNI = *cni
+	stepper.KubeletDataDir = metadata.KubeletDataDir
 	stepper.LocalRegistry = cni.LocalRegistry
 	stepper.BaseCni.Type = "calico"
 	stepper.Version = cni.Version

--- a/pkg/scheme/core/v1/cni/calico_template.go
+++ b/pkg/scheme/core/v1/cni/calico_template.go
@@ -17924,6 +17924,7 @@ spec:
 
 const calicoV3261 = `installation:
   registry: {{with .CNI.LocalRegistry}}{{.}}{{end}}
+  kubeletVolumePluginPath: {{ if .KubeletDataDir }}{{ .KubeletDataDir }}{{ else }}/var/lib/kubelet{{ end }}
   cni:
     type: Calico
     ipam:


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

### What this PR does / why we need it:
when change kubelet root dir,specify to calico
### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #878

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```