### PR TITLE
feat: registry support tag-suffix

### DIFF
--- a/pkg/cli/registry/client/client.go
+++ b/pkg/cli/registry/client/client.go
@@ -32,7 +32,7 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/cli/logger"
 )
 
-func Push(file, registryStr string) error {
+func Push(file, registryStr, tagSuffix string) error {
 	manifest, err := tarball.LoadManifest(pathOpener(file))
 	if err != nil {
 		return errors.WithMessage(err, "load manifest")
@@ -49,7 +49,7 @@ func Push(file, registryStr string) error {
 			}
 			// push to specify registry
 			repository := tag.RepositoryStr()
-			target := fmt.Sprintf("%s/%s:%s", registryStr, repository, tag.TagStr())
+			target := fmt.Sprintf("%s/%s:%s%s", registryStr, repository, tag.TagStr(), tagSuffix)
 			logger.V(2).Infof("[%v/%v] push %s -> %s\n", i+1, len(manifest), t, target)
 			if err = crane.Push(img, target, crane.Insecure); err != nil {
 				return errors.WithMessage(err, "push")
@@ -63,7 +63,7 @@ func Push(file, registryStr string) error {
 			split := strings.Split(repository, "/")
 			if len(split) == 2 && split[0] == "library" {
 				repository = split[1]
-				target = fmt.Sprintf("%s/%s:%s", registryStr, repository, tag.TagStr())
+				target = fmt.Sprintf("%s/%s:%s%s", registryStr, repository, tag.TagStr(), tagSuffix)
 				logger.V(2).Infof("[%v/%v] push %s -> %s\n", i+1, len(manifest), t, target)
 				if err = crane.Push(img, target, crane.Insecure); err != nil {
 					return errors.WithMessage(err, "push")


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

### Special notes for reviewers:
```
None
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note
None
```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```