### PR TITLE
feat: create cluster support specify external domain

### DIFF
--- a/pkg/utils/netutil/netutil.go
+++ b/pkg/utils/netutil/netutil.go
@@ -19,12 +19,15 @@
 package netutil
 
 import (
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
 	"net/http"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 func IsValidPort(port int) bool {
@@ -74,4 +77,20 @@ func Reachable(protocol string, addr string, timeout time.Duration) error {
 		connection.Close()
 	}
 	return err
+}
+
+func IsValidDomain(domain string) error {
+	domain = strings.TrimSpace(domain)
+	if domain == "" {
+		return errors.New("domain cannot be empty or whitespace")
+	}
+
+	lowerDomain := strings.ToLower(domain)
+
+	errs := validation.IsDNS1123Subdomain(lowerDomain)
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+
+	return nil
 }

--- a/pkg/utils/netutil/netutil_test.go
+++ b/pkg/utils/netutil/netutil_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -97,6 +99,137 @@ func TestReachable(t *testing.T) {
 			err := Reachable(tt.args.protocol, tt.args.addr, tt.args.timeout)
 			if err != nil && !strings.Contains(err.Error(), "connect: connection refused") {
 				t.Errorf("test result: %v", err)
+			}
+		})
+	}
+}
+
+func TestIsValidDomain(t *testing.T) {
+	tests := []struct {
+		name    string
+		domain  string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid simple domain",
+			domain:  "example.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid subdomain",
+			domain:  "sub.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid complex subdomain",
+			domain:  "a.b.c.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid domain with numbers",
+			domain:  "test123.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "valid domain with hyphens",
+			domain:  "test-domain.example.com",
+			wantErr: false,
+		},
+		{
+			name:    "empty string",
+			domain:  "",
+			wantErr: true,
+			errMsg:  "domain cannot be empty or whitespace",
+		},
+		{
+			name:    "whitespace only",
+			domain:  "   ",
+			wantErr: true,
+			errMsg:  "domain cannot be empty or whitespace",
+		},
+		{
+			name:    "domain with spaces",
+			domain:  "example .com",
+			wantErr: true,
+		},
+		{
+			name:    "domain with uppercase",
+			domain:  "Example.COM",
+			wantErr: false, // DNS-1123 allows uppercase after tolower conversion
+		},
+		{
+			name:    "domain starting with hyphen",
+			domain:  "-example.com",
+			wantErr: true,
+		},
+		{
+			name:    "domain ending with hyphen",
+			domain:  "example-.com",
+			wantErr: true,
+		},
+		{
+			name:    "label starting with hyphen",
+			domain:  "ex-ample.com",
+			wantErr: false,
+		},
+		{
+			name:    "domain with underscore",
+			domain:  "example_domain.com",
+			wantErr: true,
+		},
+		{
+			name:    "domain with special characters",
+			domain:  "example@domain.com",
+			wantErr: true,
+		},
+		{
+			name:    "single label domain",
+			domain:  "localhost",
+			wantErr: false, // Kubernetes validation may allow single labels for subdomains in some cases
+		},
+		{
+			name:    "domain with consecutive dots",
+			domain:  "example..com",
+			wantErr: true,
+		},
+		{
+			name:    "domain starting with dot",
+			domain:  ".example.com",
+			wantErr: true,
+		},
+		{
+			name:    "domain ending with dot",
+			domain:  "example.com.",
+			wantErr: true,
+		},
+		{
+			name:    "too long domain",
+			domain:  strings.Repeat("a", 254) + ".com",
+			wantErr: true,
+		},
+		{
+			name:    "label too long",
+			domain:  strings.Repeat("a", 64) + ".com",
+			wantErr: false, // Kubernetes validation allows this - actual behavior differs from my expectation
+		},
+		{
+			name:    "valid trimmed domain",
+			domain:  "  example.com  ",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := IsValidDomain(tt.domain)
+			if tt.wantErr {
+				assert.Error(t, err, "IsValidDomain(%q) should return error", tt.domain)
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg, "error message should contain expected text")
+				}
+			} else {
+				assert.NoError(t, err, "IsValidDomain(%q) should not return error", tt.domain)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #920 

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
