### PR TITLE
fix: compatible cluster config v1beta4

### DIFF
--- a/pkg/scheme/core/v1/k8s/types.go
+++ b/pkg/scheme/core/v1/k8s/types.go
@@ -143,14 +143,14 @@ type ClusterConfiguration struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterConfigurationV1Beta4 contains cluster-wide configuration for a kubeadm cluster (v1beta4 API version)
-// The main difference from ClusterConfiguration is that Etcd uses LocalEtcdV2 which supports
-// ExtraArgs as an array format instead of a map.
+// The main difference from ClusterConfiguration is that Etcd uses EtcdV2 which supports
+// ExtraArgs as an array format in a nested local structure.
 type ClusterConfigurationV1Beta4 struct {
 	clusterConfigurationBase `json:",inline"`
 
 	// Etcd holds configuration for etcd.
 	// +optional
-	Etcd LocalEtcdV2 `json:"etcd,omitempty"`
+	Etcd EtcdV2 `json:"etcd,omitempty"`
 }
 
 // ControlPlaneComponent holds settings common to control plane component of the cluster
@@ -306,6 +306,13 @@ type LocalEtcd struct {
 	PeerCertSANs []string `json:"peerCertSANs,omitempty"`
 }
 
+// EtcdV2 holds configuration for etcd in v1beta4
+type EtcdV2 struct {
+	// Local provides configuration knobs for configuring the local etcd instance
+	// +optional
+	Local *LocalEtcdV2 `json:"local,omitempty"`
+}
+
 // LocalEtcdV2 support v1.beta4
 type LocalEtcdV2 struct {
 	// ImageMeta allows to customize the container used for etcd
@@ -332,8 +339,8 @@ type LocalEtcdV2 struct {
 }
 
 type ArgumentItem struct {
-	Name  string `yaml:"name"`
-	Value string `yaml:"value"`
+	Name  string `json:"name" yaml:"name"`
+	Value string `json:"value" yaml:"value"`
 }
 
 // ExternalEtcd describes an external etcd cluster.


### PR DESCRIPTION
Add EtcdV2 struct to properly represent the nested etcd configuration structure in kubeadm v1beta4. The etcd configuration has a nested structure: etcd.local.{dataDir,extraArgs,...}

Update ClusterConfigurationV1Beta4 to use EtcdV2 instead of LocalEtcdV2 directly, and add proper JSON tags to ArgumentItem fields for correct parsing of etcd extraArgs configuration.

This fixes issues with kubeadm v1beta4 configuration parsing where the etcd section structure was not properly represented.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #923

### Special notes for reviewers:

```
None
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
