### PR TITLE
ci: update default version from v1.4.1 to v1.5.0

### DIFF
--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -192,7 +192,7 @@ func (d *DeployOptions) Complete() error {
 		if v == "" {
 			v, ok = strutil.ParseGitDescribeInfo(version.Get().GitVersion)
 			if !ok {
-				v = "v1.4.1"
+				v = "v1.5.0"
 			}
 		}
 		d.deployConfig.Pkg = fmt.Sprintf(defaultPkg, v, runtime.GOARCH)

--- a/scripts/get-kubeclipper.sh
+++ b/scripts/get-kubeclipper.sh
@@ -49,7 +49,7 @@ DOWNLOAD_URL="https://oss.kubeclipper.io/kc"
 BIN_DIR="/usr/local/bin"
 
 if [[ -z "${KC_VERSION}" ]]; then
-  KC_VERSION="v1.4.1"
+  KC_VERSION="v1.5.0"
 fi
 info "The ${KC_VERSION} version will be installed"
 


### PR DESCRIPTION
Update the default version references in:
- scripts/get-kubeclipper.sh: Set KC_VERSION default to v1.5.0
- pkg/cli/deploy/deploy.go: Set fallback version to v1.5.0

This prepares for the upcoming v1.5.0 release.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
