### PR TITLE
fix: preserve existing containerd config when updating registry auth

### DIFF
--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -331,8 +331,11 @@ func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Cont
 				continue
 			}
 			if hostTree.Has("auth") {
-				hostTree.Delete("auth")
-				logger.Infof("removed registry auth config for %s", host)
+				if err := hostTree.Delete("auth"); err != nil {
+					logger.Warnf("failed to delete auth for %s: %s", host, err)
+				} else {
+					logger.Infof("removed registry auth config for %s", host)
+				}
 			}
 		}
 	}

--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -273,11 +273,6 @@ func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Cont
 		return nil
 	}
 
-	// If no RegistryWithAuth to configure, nothing to do
-	if len(runnable.RegistryWithAuth) == 0 {
-		return nil
-	}
-
 	// Load existing config.toml
 	conf, err := toml.LoadFile(configPath)
 	if err != nil {
@@ -311,6 +306,35 @@ func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Cont
 			return fmt.Errorf("failed to create configs tree: %w", treeErr)
 		}
 		registryToml.Set("configs", configsTree)
+	}
+
+	configsTree, ok := registryToml.Get("configs").(*toml.Tree)
+	if !ok {
+		return fmt.Errorf("unexpected type at registry.configs in containerd config")
+	}
+
+	// Build set of hosts that should have auth configured
+	authHosts := make(map[string]struct{}, len(runnable.RegistryWithAuth))
+	for _, reg := range runnable.RegistryWithAuth {
+		if reg.Host != "" && reg.RegistryAuth != nil {
+			authHosts[reg.Host] = struct{}{}
+		}
+	}
+
+	// Remove auth entries for hosts no longer in the registry list.
+	// Access host subtrees via conf.GetPath (not configsTree.Get) because
+	// go-toml's Get treats dots in key names as path separators.
+	for _, host := range configsTree.Keys() {
+		if _, want := authHosts[host]; !want {
+			hostTree, ok := conf.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", host}).(*toml.Tree)
+			if !ok {
+				continue
+			}
+			if hostTree.Has("auth") {
+				hostTree.Delete("auth")
+				logger.Infof("removed registry auth config for %s", host)
+			}
+		}
 	}
 
 	// For each RegistryWithAuth, build an auth Tree and set only the auth subsection

--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -255,12 +255,98 @@ func (runnable *ContainerdRunnable) setupContainerdConfig(ctx context.Context, d
 	if err := os.MkdirAll(containerdDefaultConfigDir, 0755); err != nil {
 		return err
 	}
-	// render config.toml
+	// First-time install: full template rendering to generate complete config.toml
 	if err := fileutil.WriteFileWithContext(ctx, cf, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644, runnable.renderTo, dryRun); err != nil {
 		return err
 	}
+
 	// render certs.d
 	return runnable.renderRegistryConfig(dryRun)
+}
+
+// mergeRegistryAuthIntoConfig selectively updates only the registry.configs.auth section
+// in the existing config.toml, preserving all other configuration such as nvidia runtime
+// settings or manual user edits.
+// Follows the same pattern as addOrRemoveContainerdInsecureRegistry in pkg/component/utils/registry.go.
+func (runnable *ContainerdRunnable) mergeRegistryAuthIntoConfig(ctx context.Context, configPath string, dryRun bool) error {
+	if dryRun {
+		return nil
+	}
+
+	// If no RegistryWithAuth to configure, nothing to do
+	if len(runnable.RegistryWithAuth) == 0 {
+		return nil
+	}
+
+	// Load existing config.toml
+	conf, err := toml.LoadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// File doesn't exist: fallback to full template rendering
+			logger.Infof("containerd config not found, generating full config")
+			return fileutil.WriteFileWithContext(ctx, configPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644, runnable.renderTo, dryRun)
+		}
+		return fmt.Errorf("failed to load containerd config: %w", err)
+	}
+
+	// Ensure plugins."io.containerd.grpc.v1.cri".registry.configs path exists
+	registryPath := []string{"plugins", "io.containerd.grpc.v1.cri", "registry"}
+	if conf.GetPath(registryPath) == nil {
+		configsTree, treeErr := toml.TreeFromMap(map[string]interface{}{})
+		if treeErr != nil {
+			return fmt.Errorf("failed to create configs tree: %w", treeErr)
+		}
+		conf.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs"}, configsTree)
+	}
+
+	registryTree := conf.GetPath(registryPath)
+	registryToml, ok := registryTree.(*toml.Tree)
+	if !ok {
+		return fmt.Errorf("unexpected type at registry path in containerd config")
+	}
+
+	if !registryToml.Has("configs") {
+		configsTree, treeErr := toml.TreeFromMap(map[string]interface{}{})
+		if treeErr != nil {
+			return fmt.Errorf("failed to create configs tree: %w", treeErr)
+		}
+		registryToml.Set("configs", configsTree)
+	}
+
+	// For each RegistryWithAuth, build an auth Tree and set only the auth subsection
+	for _, reg := range runnable.RegistryWithAuth {
+		if reg.Host == "" || reg.RegistryAuth == nil {
+			continue
+		}
+		authTree, treeErr := toml.TreeFromMap(map[string]interface{}{
+			"username":      reg.RegistryAuth.Username,
+			"password":      reg.RegistryAuth.Password,
+			"auth":          "",
+			"identitytoken": "",
+		})
+		if treeErr != nil {
+			return fmt.Errorf("failed to create auth tree for %s: %w", reg.Host, treeErr)
+		}
+		conf.SetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", reg.Host, "auth"}, authTree)
+		logger.Infof("updated registry auth config for %s", reg.Host)
+	}
+
+	// Serialize and write back, preserving file mode
+	data, err := conf.ToTomlString()
+	if err != nil {
+		return fmt.Errorf("failed to serialize containerd config: %w", err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to stat containerd config: %w", err)
+	}
+
+	if err = os.WriteFile(configPath, []byte(data), info.Mode()); err != nil {
+		return fmt.Errorf("failed to write containerd config: %w", err)
+	}
+
+	return nil
 }
 
 func (runnable *ContainerdRunnable) enableContainerdService(ctx context.Context, dryRun bool) error {
@@ -356,13 +442,13 @@ func (c *ContainerdRegistryConfigure) Install(ctx context.Context, opts componen
 		}
 	}
 
-	// 2. render config.toml
+	// 2. selectively merge registry auth into config.toml
 	cf := filepath.Join(containerdDefaultConfigDir, "config.toml")
 	if err = os.MkdirAll(containerdDefaultConfigDir, 0755); err != nil {
 		logger.Errorf("mkdir containerd config dir: %s failed:%s", cf, err)
 	}
-	if err = fileutil.WriteFileWithContext(ctx, cf, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644, c.ContainerdRunnable.renderTo, false); err != nil {
-		logger.Errorf("render containerd config: %s failed:%s", cf, err)
+	if err = c.ContainerdRunnable.mergeRegistryAuthIntoConfig(ctx, cf, false); err != nil {
+		logger.Errorf("merge registry auth into containerd config: %s failed:%s", cf, err)
 	}
 	// restart containerd
 	if err = systemctl.ReloadDeamon(ctx); err != nil {

--- a/pkg/scheme/core/v1/cri/containerd_test.go
+++ b/pkg/scheme/core/v1/cri/containerd_test.go
@@ -370,7 +370,28 @@ root = "/var/lib/containerd"
 func TestMergeRegistryAuthIntoConfig_NoAuthEntries(t *testing.T) {
 	dir := t.TempDir()
 	configPath := filepath.Join(dir, "config.toml")
-	err := os.WriteFile(configPath, []byte("root = \"/var/lib/containerd\"\n"), 0644)
+	existingConfig := `root = "/var/lib/containerd"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.2"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."stale-registry.local"]
+
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."stale-registry.local".auth]
+            username = "olduser"
+            password = "oldpass"
+            auth = ""
+            identitytoken = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+`
+	err := os.WriteFile(configPath, []byte(existingConfig), 0644)
 	require.NoError(t, err)
 
 	runnable := &ContainerdRunnable{
@@ -382,9 +403,15 @@ func TestMergeRegistryAuthIntoConfig_NoAuthEntries(t *testing.T) {
 	err = runnable.mergeRegistryAuthIntoConfig(context.Background(), configPath, false)
 	require.NoError(t, err)
 
-	data, err := os.ReadFile(configPath)
+	result, err := toml.LoadFile(configPath)
 	require.NoError(t, err)
-	assert.Equal(t, "root = \"/var/lib/containerd\"\n", string(data))
+
+	// Stale auth should be removed
+	authPath := []string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", "stale-registry.local", "auth"}
+	assert.Nil(t, result.GetPath(authPath), "stale auth should be removed when no RegistryWithAuth")
+
+	// Other config preserved
+	assert.Equal(t, "registry.k8s.io/pause:3.2", result.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}))
 }
 
 func TestMergeRegistryAuthIntoConfig_FileNotExist(t *testing.T) {
@@ -416,6 +443,81 @@ func TestMergeRegistryAuthIntoConfig_FileNotExist(t *testing.T) {
 
 	_, err = os.Stat(configPath)
 	assert.NoError(t, err, "config file should be created when it doesn't exist")
+}
+
+func TestMergeRegistryAuthIntoConfig_RemoveStaleAuth(t *testing.T) {
+	existingConfig := `root = "/var/lib/containerd"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.2"
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "nvidia"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          runtime_type = "io.containerd.runc.v2"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."old-registry.local"]
+
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."old-registry.local".auth]
+            username = "olduser"
+            password = "oldpass"
+            auth = ""
+            identitytoken = ""
+
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."new-registry.local"]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+`
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte(existingConfig), 0644)
+	require.NoError(t, err)
+
+	runnable := &ContainerdRunnable{
+		Base: Base{
+			RegistryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "new-registry.local",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "newuser",
+						Password: "newpass",
+					},
+				},
+			},
+		},
+	}
+
+	err = runnable.mergeRegistryAuthIntoConfig(context.Background(), configPath, false)
+	require.NoError(t, err)
+
+	result, err := toml.LoadFile(configPath)
+	require.NoError(t, err)
+
+	// Old auth should be removed
+	oldAuthPath := []string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", "old-registry.local", "auth"}
+	assert.Nil(t, result.GetPath(oldAuthPath), "stale auth for old-registry.local should be removed")
+
+	// New auth should be added
+	newAuthPath := []string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", "new-registry.local", "auth"}
+	newAuthTree := result.GetPath(newAuthPath)
+	require.NotNil(t, newAuthTree, "auth for new-registry.local should be added")
+	newAuthToml, ok := newAuthTree.(*toml.Tree)
+	require.True(t, ok)
+	assert.Equal(t, "newuser", newAuthToml.Get("username"))
+	assert.Equal(t, "newpass", newAuthToml.Get("password"))
+
+	// nvidia runtime preserved (sandbox_image as proxy check, nvidia options.BinaryName not in this test config)
+	assert.Equal(t, "registry.k8s.io/pause:3.2", result.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"}))
+	assert.Equal(t, "nvidia", result.GetPath([]string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "default_runtime_name"}))
 }
 
 func TestMergeRegistryAuthIntoConfig_DryRun(t *testing.T) {

--- a/pkg/scheme/core/v1/cri/containerd_test.go
+++ b/pkg/scheme/core/v1/cri/containerd_test.go
@@ -20,12 +20,14 @@ package cri
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -174,4 +176,273 @@ func TestContainerdRegistryRender(t *testing.T) {
 	hostConfig, err := os.ReadFile(filepath.Join(dir, "docker.io", "hosts.toml"))
 	require.NoError(t, err)
 	assert.Equal(t, exp, string(hostConfig))
+}
+
+func TestMergeRegistryAuthIntoConfig(t *testing.T) {
+	baseConfig := `disabled_plugins = []
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.2"
+
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      default_runtime_name = "nvidia"
+
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia]
+          runtime_type = "io.containerd.runc.v2"
+
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.nvidia.options]
+            BinaryName = "/usr/bin/nvidia-container-runtime"
+            SystemdCgroup = true
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+`
+
+	tests := []struct {
+		name              string
+		existingConfig    string
+		registryWithAuth  []v1.RegistrySpec
+		wantAuthHosts     []string
+		wantAuthUsername  map[string]string
+		wantAuthPassword  map[string]string
+		wantPreservePath  []string
+		wantPreserveValue string
+	}{
+		{
+			name:           "add new auth preserves nvidia runtime",
+			existingConfig: baseConfig,
+			registryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "registry.example.com",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "admin",
+						Password: "s3cret",
+					},
+				},
+			},
+			wantAuthHosts:     []string{"registry.example.com"},
+			wantAuthUsername:  map[string]string{"registry.example.com": "admin"},
+			wantAuthPassword:  map[string]string{"registry.example.com": "s3cret"},
+			wantPreservePath:  []string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "runtimes", "nvidia", "options", "BinaryName"},
+			wantPreserveValue: "/usr/bin/nvidia-container-runtime",
+		},
+		{
+			name: "update existing auth preserves other sections",
+			existingConfig: `disabled_plugins = []
+root = "/var/lib/containerd"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.2"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+
+      [plugins."io.containerd.grpc.v1.cri".registry.configs]
+
+        [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.example.com"]
+
+          [plugins."io.containerd.grpc.v1.cri".registry.configs."registry.example.com".auth]
+            username = "olduser"
+            password = "oldpass"
+            auth = ""
+            identitytoken = ""
+
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+`,
+			registryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "registry.example.com",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "newuser",
+						Password: "newpass",
+					},
+				},
+			},
+			wantAuthHosts:     []string{"registry.example.com"},
+			wantAuthUsername:  map[string]string{"registry.example.com": "newuser"},
+			wantAuthPassword:  map[string]string{"registry.example.com": "newpass"},
+			wantPreservePath:  []string{"plugins", "io.containerd.grpc.v1.cri", "sandbox_image"},
+			wantPreserveValue: "registry.k8s.io/pause:3.2",
+		},
+		{
+			name: "add auth when configs section is empty",
+			existingConfig: `root = "/var/lib/containerd"
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.2"
+
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+`,
+			registryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "my-registry.local",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "testuser",
+						Password: "testpass",
+					},
+				},
+			},
+			wantAuthHosts:     []string{"my-registry.local"},
+			wantAuthUsername:  map[string]string{"my-registry.local": "testuser"},
+			wantAuthPassword:  map[string]string{"my-registry.local": "testpass"},
+			wantPreservePath:  []string{"root"},
+			wantPreserveValue: "/var/lib/containerd",
+		},
+		{
+			name:           "multiple registry auth entries",
+			existingConfig: baseConfig,
+			registryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "registry1.example.com",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "user1",
+						Password: "pass1",
+					},
+				},
+				{
+					Host: "registry2.example.com",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "user2",
+						Password: "pass2",
+					},
+				},
+			},
+			wantAuthHosts:     []string{"registry1.example.com", "registry2.example.com"},
+			wantAuthUsername:  map[string]string{"registry1.example.com": "user1", "registry2.example.com": "user2"},
+			wantAuthPassword:  map[string]string{"registry1.example.com": "pass1", "registry2.example.com": "pass2"},
+			wantPreservePath:  []string{"plugins", "io.containerd.grpc.v1.cri", "containerd", "default_runtime_name"},
+			wantPreserveValue: "nvidia",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.toml")
+			err := os.WriteFile(configPath, []byte(tt.existingConfig), 0644)
+			require.NoError(t, err)
+
+			runnable := &ContainerdRunnable{
+				Base: Base{
+					RegistryWithAuth: tt.registryWithAuth,
+				},
+			}
+
+			err = runnable.mergeRegistryAuthIntoConfig(context.Background(), configPath, false)
+			require.NoError(t, err)
+
+			result, err := toml.LoadFile(configPath)
+			require.NoError(t, err)
+
+			for _, host := range tt.wantAuthHosts {
+				authPath := []string{"plugins", "io.containerd.grpc.v1.cri", "registry", "configs", host, "auth"}
+				authTree := result.GetPath(authPath)
+				require.NotNil(t, authTree, "expected auth config for %s", host)
+
+				authToml, ok := authTree.(*toml.Tree)
+				require.True(t, ok, "auth section for %s should be a TOML tree", host)
+
+				assert.Equal(t, tt.wantAuthUsername[host], authToml.Get("username"), "username mismatch for %s", host)
+				assert.Equal(t, tt.wantAuthPassword[host], authToml.Get("password"), "password mismatch for %s", host)
+				assert.NotNil(t, authToml.Get("auth"), "auth field should exist for %s", host)
+				assert.NotNil(t, authToml.Get("identitytoken"), "identitytoken field should exist for %s", host)
+			}
+
+			preservedValue := result.GetPath(tt.wantPreservePath)
+			assert.Equal(t, tt.wantPreserveValue, preservedValue,
+				"preserved value at %v should remain unchanged", tt.wantPreservePath)
+		})
+	}
+}
+
+func TestMergeRegistryAuthIntoConfig_NoAuthEntries(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	err := os.WriteFile(configPath, []byte("root = \"/var/lib/containerd\"\n"), 0644)
+	require.NoError(t, err)
+
+	runnable := &ContainerdRunnable{
+		Base: Base{
+			RegistryWithAuth: []v1.RegistrySpec{},
+		},
+	}
+
+	err = runnable.mergeRegistryAuthIntoConfig(context.Background(), configPath, false)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, "root = \"/var/lib/containerd\"\n", string(data))
+}
+
+func TestMergeRegistryAuthIntoConfig_FileNotExist(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	runnable := &ContainerdRunnable{
+		Base: Base{
+			Version:     "1.6.4",
+			DataRootDir: "/var/lib/containerd",
+			RegistryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "registry.example.com",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "admin",
+						Password: "s3cret",
+					},
+				},
+			},
+		},
+		KubeVersion:         "1.23.6",
+		PauseVersion:        "3.2",
+		RegistryConfigDir:   "/etc/containerd/certs.d",
+		EnableSystemdCgroup: "true",
+	}
+
+	err := runnable.mergeRegistryAuthIntoConfig(context.Background(), configPath, false)
+	require.NoError(t, err)
+
+	_, err = os.Stat(configPath)
+	assert.NoError(t, err, "config file should be created when it doesn't exist")
+}
+
+func TestMergeRegistryAuthIntoConfig_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+	originalContent := "root = \"/var/lib/containerd\"\n"
+	err := os.WriteFile(configPath, []byte(originalContent), 0644)
+	require.NoError(t, err)
+
+	runnable := &ContainerdRunnable{
+		Base: Base{
+			RegistryWithAuth: []v1.RegistrySpec{
+				{
+					Host: "registry.example.com",
+					RegistryAuth: &v1.RegistryAuth{
+						Username: "admin",
+						Password: "s3cret",
+					},
+				},
+			},
+		},
+	}
+
+	err = runnable.mergeRegistryAuthIntoConfig(context.Background(), configPath, true)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, originalContent, string(data))
 }


### PR DESCRIPTION
ContainerdRegistryConfigure.Install() used to overwrite the entire config.toml via template rendering with O_TRUNC, which destroyed modifications made by nvidia gpu operator or manual user edits.

Replace the full overwrite with selective TOML merging that only updates the registry.configs.{host}.auth section while preserving all other configuration.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
