### PR TITLE
ci: add gemini config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,28 @@
+# https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
+
+# Keep tone professional, no humor or casual language
+have_fun: false
+
+# Allow Gemini to remember project context across sessions
+memory_config:
+  disabled: false
+
+code_review:
+  # Enable code review on pull requests
+  disable: false
+  # Only comment on MEDIUM or higher severity issues, filter out LOW noise
+  comment_severity_threshold: MEDIUM
+  # No limit on the number of review comments per PR
+  max_review_comments: -1
+  pull_request_opened:
+    # Don't post "how to use" help comments on new PRs
+    help: false
+    # Don't auto-generate PR summary — authors write their own
+    summary: false
+    # Automatically trigger code review when PR is opened
+    code_review: true
+    # Skip draft PRs to avoid noise while code is still in progress
+    include_drafts: false
+
+# File patterns to exclude from review (empty = review everything)
+ignore_patterns: []


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
