### PR TITLE
feat: persist registry config to avoid repeated --node and SSH flags

### DIFF
--- a/pkg/cli/registry/registry.go
+++ b/pkg/cli/registry/registry.go
@@ -67,9 +67,13 @@ const (
   # Push docker image to registry
   kcctl registry push --pk-file key --node 10.0.0.111 --pkg images.tar.gz
   # List repositories in docker registry
-  kcctl registry list --node 10.0.0.111  --type repository
+  kcctl registry list
+  # List repositories with explicit node
+  kcctl registry list --node 10.0.0.111
+  # List images
+  kcctl registry list --type image --name etcd
   # Delete docker image
-  kcctl registry delete --node 10.0.0.111  --name etcd --tag 1.5.1-0
+  kcctl registry delete --node 10.0.0.111 --name etcd --tag 1.5.1-0
 
   Please read 'kcctl registry -h' get more registry flags.`
 	deployLongDescription = `
@@ -89,11 +93,11 @@ const (
 	cleanExample = `
   # Clean docker registry
   kcctl registry clean --pk-file key --node 10.0.0.111
+  # Clean docker registry using saved config (node and SSH from registry-config.yaml)
+  kcctl registry clean
   # Clean docker registry, specify data directory.
   # If you used custom data directory when deploy,then must specify it in this cmd to clear data.
   kcctl registry clean --pk-file key --node 10.0.0.111 --registry-volume /opt/registry --data-root /var/lib/docker
-  # Clean docker registry
-  kcctl registry clean --pk-file key --node 10.0.0.111
   # Forced to clean docker registry
   kcctl registry clean --pk-file key --node 10.0.0.111  --force
 
@@ -105,24 +109,30 @@ const (
   # You can use [docker save  $images > images.tar] or [docker save  $images > images.tar && gzip -f images.tar]  to generate image pkg
   # example: docker save k8s.gcr.io/pause:3.2 k8s.gcr.io/coredns/coredns:1.6.7 > images.tar
   # example: docker save k8s.gcr.io/pause:3.2 k8s.gcr.io/coredns/coredns:1.6.7 > images.tar && gzip -f images.tar
-  kcctl registry push --pk-file key --node 10.0.0.111  --pkg images.tar
-  kcctl registry push --pk-file key --node 10.0.0.111  --pkg images.tar.gz
+  kcctl registry push --node 10.0.0.111 --pkg images.tar
+  kcctl registry push --node 10.0.0.111 --pkg images.tar.gz
+  # Push using saved config
+  kcctl registry push --pkg images.tar.gz
 
   Please read 'kcctl registry push -h' get more registry push flags.`
 	listLongDescription = `
   Lists docker repositories or images by flags.`
 	listExample = `
-  # Lists docker repositories
-  kcctl registry list --node 10.0.0.111  --type repository
+  # Lists docker repositories (uses saved config or --node)
+  kcctl registry list
+  # Lists docker repositories with explicit node
+  kcctl registry list --node 10.0.0.111
   # Lists docker images
-  kcctl registry list --node 10.0.0.111  --type image --name etcd 
+  kcctl registry list --type image --name etcd
 
   Please read 'kcctl registry list -h' get more registry list flags.`
 	deleteLongDescription = `
   Delete the docker image by name and tag.`
 	deleteExample = `
   # Delete docker image
-  kcctl registry delete --pk-file key --node 10.0.0.111  --name etcd --tag 3.5.1-0
+  kcctl registry delete --pk-file key --node 10.0.0.111 --name etcd --tag 3.5.1-0
+  # Delete using saved config
+  kcctl registry delete --name etcd --tag 3.5.1-0
 
   Please read 'kcctl registry delete -h' get more registry delete flags.`
 )
@@ -144,6 +154,13 @@ type RegistryOptions struct {
 	Number        int
 	SkipImageLoad bool
 	TagSuffix     string
+
+	// tracks which flags were explicitly set by the user
+	nodeChanged     bool
+	portChanged     bool
+	sshUserChanged  bool
+	pkFileChanged   bool
+	pkPasswdChanged bool
 }
 
 var (
@@ -190,6 +207,8 @@ func NewCmdRegistryDeploy(o *RegistryOptions) *cobra.Command {
 		Example:               deployExample,
 		Args:                  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			o.trackChangedFlags(cmd)
+			utils.CheckErr(o.Complete(cmd))
 			utils.CheckErr(o.ValidateArgsDeploy())
 			if !o.sudoPreCheck() {
 				return
@@ -213,13 +232,15 @@ func NewCmdRegistryDeploy(o *RegistryOptions) *cobra.Command {
 
 func NewCmdRegistryClean(o *RegistryOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "clean (--user | -u <user>) (--passwd <passwd>) (--pk-file <pk-file>) (--pk-passwd <pk-passwd>) (--node <node>)",
+		Use:                   "clean (--user | -u <user>) (--passwd <passwd>) (--pk-file <pk-file>) (--pk-passwd <pk-passwd>) [--node <node>]",
 		DisableFlagsInUseLine: true,
 		Short:                 "registry clean",
 		Long:                  cleanLongDescription,
 		Example:               cleanExample,
 		Args:                  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			o.trackChangedFlags(cmd)
+			utils.CheckErr(o.Complete(cmd))
 			utils.CheckErr(o.ValidateArgs())
 			if !o.sudoPreCheck() {
 				return
@@ -229,20 +250,21 @@ func NewCmdRegistryClean(o *RegistryOptions) *cobra.Command {
 	}
 
 	options.AddFlagsToSSH(o.SSHConfig, cmd.Flags())
-	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node.")
-	utils.CheckErr(cmd.MarkFlagRequired("node"))
+	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node. If not specified, uses the current registry from config.")
 	return cmd
 }
 
 func NewCmdRegistryPush(o *RegistryOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "push (--node <node>) (--pkg <pkg>) [--registry-port <registry-port>] [flags]",
+		Use:                   "push [--node <node>] (--pkg <pkg>) [--registry-port <registry-port>] [flags]",
 		DisableFlagsInUseLine: true,
 		Short:                 "registry push image",
 		Long:                  pushLongDescription,
 		Example:               pushExample,
 		Args:                  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			o.trackChangedFlags(cmd)
+			utils.CheckErr(o.Complete(cmd))
 			utils.CheckErr(o.ValidateArgsPush())
 			if !o.healthPreCheck() {
 				return
@@ -251,25 +273,26 @@ func NewCmdRegistryPush(o *RegistryOptions) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node.")
+	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node. If not specified, uses the current registry from config.")
 	cmd.Flags().StringVar(&o.Pkg, "pkg", o.Pkg, "docker images pkg,use `docker save $images > images.tar && gzip -f images.tar` to generate images.tar.gz")
 	cmd.Flags().StringVar(&o.TagSuffix, "tag-suffix", o.TagSuffix, "Append a suffix to the final image tag. For example, if the original image is library/busybox:1.36 and you set --tag-suffix=-amd64, the image will be pushed as library/busybox:1.36-amd64. Useful for creating architecture-specific tags in one shot.")
 	cmd.Flags().IntVar(&o.RegistryPort, "registry-port", o.RegistryPort, "registry port.")
 
-	utils.CheckErr(cmd.MarkFlagRequired("node"))
 	utils.CheckErr(cmd.MarkFlagRequired("pkg"))
 	return cmd
 }
 
 func NewCmdRegistryList(o *RegistryOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "list (--node <node>) (--name <name>) (--registry-port <registry-port>) (--type <type>) (--number <number>) [flags]list (--node <node>) (--name <name>) (--registry-port <registry-port>) (--type <type>) (--number <number>) [flags]",
+		Use:                   "list [--node <node>] [--name <name>] [--registry-port <registry-port>] [--type <type>] [--number <number>] [flags]",
 		DisableFlagsInUseLine: true,
 		Short:                 "registry list repository or image",
 		Long:                  listLongDescription,
 		Example:               listExample,
 		Args:                  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			o.trackChangedFlags(cmd)
+			utils.CheckErr(o.Complete(cmd))
 			utils.CheckErr(o.ValidateArgsList())
 			if !o.healthPreCheck() {
 				return
@@ -279,10 +302,10 @@ func NewCmdRegistryList(o *RegistryOptions) *cobra.Command {
 	}
 	o.PrintFlags.AddFlags(cmd)
 	options.AddFlagsToSSH(o.SSHConfig, cmd.Flags())
-	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node")
+	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node. If not specified, uses the current registry from config.")
 	cmd.Flags().IntVar(&o.RegistryPort, "registry-port", o.RegistryPort, "registry port")
 
-	cmd.Flags().StringVar(&o.Type, "type", o.Type, "image or repository")
+	cmd.Flags().StringVar(&o.Type, "type", o.Type, "image or repository (default: repository)")
 	cmd.Flags().StringVar(&o.Name, "name", o.Name, "image name")
 	cmd.Flags().IntVar(&o.Number, "number", o.Number, "number of entries in each response. It not present, all entries will be returned.")
 
@@ -293,19 +316,19 @@ func NewCmdRegistryList(o *RegistryOptions) *cobra.Command {
 		return o.listRepos(toComplete), cobra.ShellCompDirectiveNoFileComp
 	}))
 
-	utils.CheckErr(cmd.MarkFlagRequired("node"))
-	utils.CheckErr(cmd.MarkFlagRequired("type"))
 	return cmd
 }
 
 func NewCmdRegistryDelete(o *RegistryOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "delete (--pk-file <file path>) (--node <node>) (--name <name>) (--tag <tag>) [flags]delete (--pk-file <file path>) (--node <node>) (--name <name>)  (--tag <tag>) [flags]",
+		Use:                   "delete (--pk-file <file path>) [--node <node>] (--name <name>) (--tag <tag>) [flags]",
 		DisableFlagsInUseLine: true,
 		Short:                 "registry delete image",
 		Long:                  deleteLongDescription,
 		Example:               deleteExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			o.trackChangedFlags(cmd)
+			utils.CheckErr(o.Complete(cmd))
 			utils.CheckErr(o.ValidateArgsDelete(cmd))
 			if !o.healthPreCheck() {
 				return
@@ -316,7 +339,7 @@ func NewCmdRegistryDelete(o *RegistryOptions) *cobra.Command {
 
 	options.AddFlagsToSSH(o.SSHConfig, cmd.Flags())
 	cmd.Flags().IntVar(&o.RegistryPort, "registry-port", o.RegistryPort, "registry port")
-	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node.")
+	cmd.Flags().StringVar(&o.Node, "node", o.Node, "registry node. If not specified, uses the current registry from config.")
 	cmd.Flags().StringVar(&o.Name, "name", o.Name, "image name")
 	cmd.Flags().StringVar(&o.Tag, "tag", o.Tag, "image tag")
 
@@ -327,10 +350,37 @@ func NewCmdRegistryDelete(o *RegistryOptions) *cobra.Command {
 		return o.listTags(toComplete), cobra.ShellCompDirectiveNoFileComp
 	}))
 
-	utils.CheckErr(cmd.MarkFlagRequired("node"))
 	utils.CheckErr(cmd.MarkFlagRequired("name"))
 	utils.CheckErr(cmd.MarkFlagRequired("tag"))
 	return cmd
+}
+
+// trackChangedFlags records which flags were explicitly set by the user.
+func (o *RegistryOptions) trackChangedFlags(cmd *cobra.Command) {
+	o.nodeChanged = cmd.Flags().Changed("node")
+	o.portChanged = cmd.Flags().Changed("registry-port")
+	o.sshUserChanged = cmd.Flags().Changed("user")
+	o.pkFileChanged = cmd.Flags().Changed("pk-file")
+	o.pkPasswdChanged = cmd.Flags().Changed("pk-passwd")
+}
+
+// Complete loads registry config and fills in unset options from the matching registry entry.
+// When --node is specified, it looks up that node's entry; otherwise uses the current entry.
+func (o *RegistryOptions) Complete(_ *cobra.Command) error {
+	cfg, err := LoadRegistryConfig()
+	if err != nil {
+		return fmt.Errorf("load registry config: %w", err)
+	}
+	var entry *RegistryEntry
+	if o.nodeChanged && o.Node != "" {
+		entry = findRegistry(cfg, o.Node)
+	} else {
+		entry = GetCurrentRegistry(cfg)
+	}
+	if entry != nil {
+		applyEntryToOptions(o, entry, o.nodeChanged, o.portChanged, o.sshUserChanged, o.pkFileChanged, o.pkPasswdChanged)
+	}
+	return nil
 }
 
 func (o *RegistryOptions) healthPreCheck() bool {
@@ -342,18 +392,18 @@ func (o *RegistryOptions) sudoPreCheck() bool {
 }
 
 func (o *RegistryOptions) ValidateArgs() error {
+	if o.Node == "" {
+		return fmt.Errorf("--node must be specified, or run 'kcctl registry deploy' first to save registry config")
+	}
 	if o.SSHConfig.PkFile == "" && o.SSHConfig.Password == "" {
 		return fmt.Errorf("one of --pk-file or --passwd must be specified")
-	}
-	if o.Node == "" {
-		return fmt.Errorf("--node must be specified")
 	}
 	return nil
 }
 
 func (o *RegistryOptions) ValidateArgsPush() error {
 	if o.Node == "" {
-		return fmt.Errorf("--node must be specified")
+		return fmt.Errorf("--node must be specified, or run 'kcctl registry deploy' first to save registry config")
 	}
 	if o.Pkg == "" {
 		return fmt.Errorf("--pkg must be specified")
@@ -376,7 +426,7 @@ func (o *RegistryOptions) ValidateArgsDeploy() error {
 
 func (o *RegistryOptions) ValidateArgsList() error {
 	if o.Node == "" {
-		return fmt.Errorf("--node must be specified")
+		return fmt.Errorf("--node must be specified, or run 'kcctl registry deploy' first to save registry config")
 	}
 	if o.Type != "image" && o.Type != "repository" {
 		return fmt.Errorf("--type must be one of image,repository")
@@ -389,7 +439,7 @@ func (o *RegistryOptions) ValidateArgsList() error {
 
 func (o *RegistryOptions) ValidateArgsDelete(cmd *cobra.Command) error {
 	if o.Node == "" {
-		return fmt.Errorf("--node must be specified")
+		return fmt.Errorf("--node must be specified, or run 'kcctl registry deploy' first to save registry config")
 	}
 	if o.Name == "" {
 		return utils.UsageErrorf(cmd, "image name must be specified")
@@ -444,7 +494,7 @@ func (o *RegistryOptions) GetKcRegistryConfigTemplateContent() (string, error) {
 		return "", fmt.Errorf("template parse failed: %s", err.Error())
 	}
 
-	var data = make(map[string]interface{})
+	var data = make(map[string]any)
 	data["RegistryPort"] = o.RegistryPort
 	data["DataRoot"] = o.DataRoot
 	var buffer bytes.Buffer
@@ -473,8 +523,22 @@ func (o *RegistryOptions) Install() error {
 		return fmt.Errorf("remove pkg error: %s", err.Error())
 	}
 
+	// save registry config
+	if err := o.saveRegistryConfigAfterDeploy(); err != nil {
+		logger.Warnf("save registry config failed: %s", err.Error())
+	}
+
 	o.printUsage()
 	return nil
+}
+
+func (o *RegistryOptions) saveRegistryConfigAfterDeploy() error {
+	cfg, err := LoadRegistryConfig()
+	if err != nil {
+		return err
+	}
+	AddOrUpdateRegistry(cfg, newEntryFromOptions(o))
+	return SaveRegistryConfig(cfg)
 }
 
 func (o *RegistryOptions) printUsage() {
@@ -482,9 +546,9 @@ func (o *RegistryOptions) printUsage() {
 	usage1 := fmt.Sprintf("\t1. visit http://%s/v2/_catalog\n", o.registry())
 	usage2 := ""
 	if o.RegistryPort != 5000 {
-		usage2 = fmt.Sprintf("\t2. run cmd [kcctl registry list --node %s --registry-port %v --type repository]", o.Node, o.RegistryPort)
+		usage2 = fmt.Sprintf("\t2. run cmd [kcctl registry list --node %s --registry-port %v]", o.Node, o.RegistryPort)
 	} else {
-		usage2 = fmt.Sprintf("\t2. run cmd [kcctl registry list --node %s --type repository]", o.Node)
+		usage2 = "\t2. run cmd [kcctl registry list]"
 	}
 	fmt.Printf("\033[1;36;36m%s\033[0m\n", success+usage1+usage2)
 }
@@ -501,8 +565,23 @@ func (o *RegistryOptions) Uninstall() error {
 	if err != nil {
 		return err
 	}
+
+	// remove from registry config
+	if err := o.removeRegistryConfigAfterClean(); err != nil {
+		logger.Warnf("remove registry config failed: %s", err.Error())
+	}
+
 	logger.Info("registry uninstall successfully")
 	return nil
+}
+
+func (o *RegistryOptions) removeRegistryConfigAfterClean() error {
+	cfg, err := LoadRegistryConfig()
+	if err != nil {
+		return err
+	}
+	RemoveRegistry(cfg, o.Node)
+	return SaveRegistryConfig(cfg)
 }
 
 func (o *RegistryOptions) cleanRegistry() error {

--- a/pkg/cli/registry/registry.go
+++ b/pkg/cli/registry/registry.go
@@ -321,7 +321,7 @@ func NewCmdRegistryList(o *RegistryOptions) *cobra.Command {
 
 func NewCmdRegistryDelete(o *RegistryOptions) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:                   "delete (--pk-file <file path>) [--node <node>] (--name <name>) (--tag <tag>) [flags]",
+		Use:                   "delete [--node <node>] (--name <name>) (--tag <tag>) [flags]",
 		DisableFlagsInUseLine: true,
 		Short:                 "registry delete image",
 		Long:                  deleteLongDescription,

--- a/pkg/cli/registry/registry_config.go
+++ b/pkg/cli/registry/registry_config.go
@@ -1,0 +1,175 @@
+/*
+ *
+ *  * Copyright 2024 KubeClipper Authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package registry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/client-go/util/homedir"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubeclipper/kubeclipper/pkg/cli/config"
+	"github.com/kubeclipper/kubeclipper/pkg/cli/utils"
+)
+
+const DefaultRegistryConfigFile = "registry-config.yaml"
+
+type RegistrySSH struct {
+	User     string `json:"user" yaml:"user"`
+	PkFile   string `json:"pkFile,omitempty" yaml:"pkFile,omitempty"`
+	PkPasswd string `json:"pkPasswd,omitempty" yaml:"pkPasswd,omitempty"` // maps to sshutils.SSH.PkPassword
+}
+
+type RegistryEntry struct {
+	Node string      `json:"node" yaml:"node"`
+	Port int         `json:"port" yaml:"port"`
+	SSH  RegistrySSH `json:"ssh,omitempty" yaml:"ssh,omitempty"`
+}
+
+type RegistryConfig struct {
+	Current    string          `json:"current,omitempty" yaml:"current,omitempty"`
+	Registries []RegistryEntry `json:"registries,omitempty" yaml:"registries,omitempty"`
+}
+
+var registryConfigPath = func() string {
+	return filepath.Join(homedir.HomeDir(), config.DefaultConfigPath, DefaultRegistryConfigFile)
+}
+
+func LoadRegistryConfig() (*RegistryConfig, error) {
+	path := registryConfigPath()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &RegistryConfig{}, nil
+		}
+		return nil, fmt.Errorf("read registry config: %w", err)
+	}
+	cfg := &RegistryConfig{}
+	if err = yaml.Unmarshal(data, cfg); err != nil {
+		return nil, fmt.Errorf("parse registry config: %w", err)
+	}
+	return cfg, nil
+}
+
+func SaveRegistryConfig(cfg *RegistryConfig) error {
+	path := registryConfigPath()
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err = os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("create registry config dir: %w", err)
+		}
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal registry config: %w", err)
+	}
+	if err = utils.WriteToFile(path, data); err != nil {
+		return fmt.Errorf("write registry config: %w", err)
+	}
+	return nil
+}
+
+func GetCurrentRegistry(cfg *RegistryConfig) *RegistryEntry {
+	if cfg.Current == "" {
+		return nil
+	}
+	for i := range cfg.Registries {
+		if cfg.Registries[i].Node == cfg.Current {
+			return &cfg.Registries[i]
+		}
+	}
+	return nil
+}
+
+// findRegistry returns the registry entry matching the given node, or nil.
+func findRegistry(cfg *RegistryConfig, node string) *RegistryEntry {
+	for i := range cfg.Registries {
+		if cfg.Registries[i].Node == node {
+			return &cfg.Registries[i]
+		}
+	}
+	return nil
+}
+
+func AddOrUpdateRegistry(cfg *RegistryConfig, entry RegistryEntry) {
+	for i, r := range cfg.Registries {
+		if r.Node == entry.Node {
+			cfg.Registries[i] = entry
+			cfg.Current = entry.Node
+			return
+		}
+	}
+	cfg.Registries = append(cfg.Registries, entry)
+	cfg.Current = entry.Node
+}
+
+func RemoveRegistry(cfg *RegistryConfig, node string) {
+	for i, r := range cfg.Registries {
+		if r.Node == node {
+			cfg.Registries = append(cfg.Registries[:i], cfg.Registries[i+1:]...)
+			break
+		}
+	}
+	if cfg.Current == node {
+		cfg.Current = ""
+		if len(cfg.Registries) > 0 {
+			cfg.Current = cfg.Registries[0].Node
+		}
+	}
+}
+
+// newEntryFromOptions builds a RegistryEntry from the current RegistryOptions state.
+func newEntryFromOptions(o *RegistryOptions) RegistryEntry {
+	entry := RegistryEntry{
+		Node: o.Node,
+		Port: o.RegistryPort,
+	}
+	if o.SSHConfig != nil {
+		entry.SSH = RegistrySSH{
+			User:     o.SSHConfig.User,
+			PkFile:   o.SSHConfig.PkFile,
+			PkPasswd: o.SSHConfig.PkPassword,
+		}
+	}
+	return entry
+}
+
+// applyEntryToOptions fills RegistryOptions fields from a RegistryEntry for any unset values.
+// CLI-specified flags take precedence; config values only fill in gaps.
+func applyEntryToOptions(o *RegistryOptions, entry *RegistryEntry, nodeChanged, portChanged, sshUserChanged, pkFileChanged, pkPasswdChanged bool) {
+	if !nodeChanged && entry.Node != "" {
+		o.Node = entry.Node
+	}
+	if !portChanged && entry.Port != 0 {
+		o.RegistryPort = entry.Port
+	}
+	if o.SSHConfig != nil && entry.SSH.User != "" {
+		if !sshUserChanged && o.SSHConfig.User == "" {
+			o.SSHConfig.User = entry.SSH.User
+		}
+		if !pkFileChanged && o.SSHConfig.PkFile == "" && entry.SSH.PkFile != "" {
+			o.SSHConfig.PkFile = entry.SSH.PkFile
+		}
+		if !pkPasswdChanged && o.SSHConfig.PkPassword == "" && entry.SSH.PkPasswd != "" {
+			o.SSHConfig.PkPassword = entry.SSH.PkPasswd
+		}
+	}
+}

--- a/pkg/cli/registry/registry_config.go
+++ b/pkg/cli/registry/registry_config.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/kubeclipper/kubeclipper/pkg/cli/config"
-	"github.com/kubeclipper/kubeclipper/pkg/cli/utils"
 )
 
 const DefaultRegistryConfigFile = "registry-config.yaml"
@@ -81,7 +80,7 @@ func SaveRegistryConfig(cfg *RegistryConfig) error {
 	if err != nil {
 		return fmt.Errorf("marshal registry config: %w", err)
 	}
-	if err = utils.WriteToFile(path, data); err != nil {
+	if err = os.WriteFile(path, data, 0600); err != nil {
 		return fmt.Errorf("write registry config: %w", err)
 	}
 	return nil
@@ -161,8 +160,8 @@ func applyEntryToOptions(o *RegistryOptions, entry *RegistryEntry, nodeChanged, 
 	if !portChanged && entry.Port != 0 {
 		o.RegistryPort = entry.Port
 	}
-	if o.SSHConfig != nil && entry.SSH.User != "" {
-		if !sshUserChanged && o.SSHConfig.User == "" {
+	if o.SSHConfig != nil {
+		if !sshUserChanged && entry.SSH.User != "" {
 			o.SSHConfig.User = entry.SSH.User
 		}
 		if !pkFileChanged && o.SSHConfig.PkFile == "" && entry.SSH.PkFile != "" {

--- a/pkg/cli/registry/registry_config_test.go
+++ b/pkg/cli/registry/registry_config_test.go
@@ -338,6 +338,31 @@ func TestApplyEntryToOptions(t *testing.T) {
 			wantPkPasswd:    "otherpw",
 		},
 		{
+			name: "config user overrides default",
+			o: &RegistryOptions{
+				Node:         "",
+				RegistryPort: 0,
+				SSHConfig:    sshutils.NewSSH(), // User defaults to "root"
+			},
+			entry: &RegistryEntry{
+				Node: "10.0.0.1",
+				Port: 6666,
+				SSH: RegistrySSH{
+					User: "admin",
+				},
+			},
+			nodeChanged:     false,
+			portChanged:     false,
+			sshUserChanged:  false,
+			pkFileChanged:   false,
+			pkPasswdChanged: false,
+			wantNode:        "10.0.0.1",
+			wantPort:        6666,
+			wantSSHUser:     "admin",
+			wantPkFile:      "",
+			wantPkPasswd:    "",
+		},
+		{
 			name: "partial override - node from config, port from cli",
 			o: &RegistryOptions{
 				Node:         "",
@@ -408,6 +433,14 @@ func TestSaveAndLoadRegistryConfig(t *testing.T) {
 
 	if err := SaveRegistryConfig(cfg); err != nil {
 		t.Fatalf("SaveRegistryConfig failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "registry-config.yaml"))
+	if err != nil {
+		t.Fatalf("stat config file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("expected file permission 0600, got %04o", perm)
 	}
 
 	loaded, err := LoadRegistryConfig()

--- a/pkg/cli/registry/registry_config_test.go
+++ b/pkg/cli/registry/registry_config_test.go
@@ -1,0 +1,489 @@
+/*
+ *
+ *  * Copyright 2024 KubeClipper Authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
+)
+
+func TestGetCurrentRegistry(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *RegistryConfig
+		want *RegistryEntry
+	}{
+		{
+			name: "empty config",
+			cfg:  &RegistryConfig{},
+			want: nil,
+		},
+		{
+			name: "current not found in registries",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.1",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.2", Port: 5000},
+				},
+			},
+			want: nil,
+		},
+		{
+			name: "current found",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.2",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.1", Port: 5000},
+					{Node: "10.0.0.2", Port: 6666},
+				},
+			},
+			want: &RegistryEntry{Node: "10.0.0.2", Port: 6666},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetCurrentRegistry(tt.cfg)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("expected nil, got %+v", got)
+				}
+				return
+			}
+			if got.Node != tt.want.Node || got.Port != tt.want.Port {
+				t.Fatalf("expected %+v, got %+v", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestFindRegistry(t *testing.T) {
+	cfg := &RegistryConfig{
+		Registries: []RegistryEntry{
+			{Node: "10.0.0.1", Port: 5000},
+			{Node: "10.0.0.2", Port: 6666},
+		},
+	}
+	if e := findRegistry(cfg, "10.0.0.2"); e == nil || e.Port != 6666 {
+		t.Fatalf("expected port 6666, got %+v", e)
+	}
+	if e := findRegistry(cfg, "10.0.0.99"); e != nil {
+		t.Fatalf("expected nil, got %+v", e)
+	}
+}
+
+func TestAddOrUpdateRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *RegistryConfig
+		entry    RegistryEntry
+		wantLen  int
+		wantNode string
+	}{
+		{
+			name:     "add to empty",
+			cfg:      &RegistryConfig{},
+			entry:    RegistryEntry{Node: "10.0.0.1", Port: 5000},
+			wantLen:  1,
+			wantNode: "10.0.0.1",
+		},
+		{
+			name: "add new to existing",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.1",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.1", Port: 5000},
+				},
+			},
+			entry:    RegistryEntry{Node: "10.0.0.2", Port: 6666},
+			wantLen:  2,
+			wantNode: "10.0.0.2",
+		},
+		{
+			name: "update existing",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.1",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.1", Port: 5000},
+				},
+			},
+			entry:    RegistryEntry{Node: "10.0.0.1", Port: 6666},
+			wantLen:  1,
+			wantNode: "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			AddOrUpdateRegistry(tt.cfg, tt.entry)
+			if len(tt.cfg.Registries) != tt.wantLen {
+				t.Fatalf("expected %d registries, got %d", tt.wantLen, len(tt.cfg.Registries))
+			}
+			if tt.cfg.Current != tt.wantNode {
+				t.Fatalf("expected current=%s, got current=%s", tt.wantNode, tt.cfg.Current)
+			}
+			found := false
+			for _, r := range tt.cfg.Registries {
+				if r.Node == tt.entry.Node && r.Port == tt.entry.Port {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("entry %v not found in registries", tt.entry)
+			}
+		})
+	}
+}
+
+func TestRemoveRegistry(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        *RegistryConfig
+		removeNode string
+		wantLen    int
+		wantCurr   string
+	}{
+		{
+			name:       "remove from empty",
+			cfg:        &RegistryConfig{},
+			removeNode: "10.0.0.1",
+			wantLen:    0,
+			wantCurr:   "",
+		},
+		{
+			name: "remove current with others remaining",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.1",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.1", Port: 5000},
+					{Node: "10.0.0.2", Port: 5000},
+				},
+			},
+			removeNode: "10.0.0.1",
+			wantLen:    1,
+			wantCurr:   "10.0.0.2",
+		},
+		{
+			name: "remove only registry",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.1",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.1", Port: 5000},
+				},
+			},
+			removeNode: "10.0.0.1",
+			wantLen:    0,
+			wantCurr:   "",
+		},
+		{
+			name: "remove non-current",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.1",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.1", Port: 5000},
+					{Node: "10.0.0.2", Port: 5000},
+				},
+			},
+			removeNode: "10.0.0.2",
+			wantLen:    1,
+			wantCurr:   "10.0.0.1",
+		},
+		{
+			name: "remove nonexistent node",
+			cfg: &RegistryConfig{
+				Current: "10.0.0.1",
+				Registries: []RegistryEntry{
+					{Node: "10.0.0.1", Port: 5000},
+				},
+			},
+			removeNode: "10.0.0.99",
+			wantLen:    1,
+			wantCurr:   "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			RemoveRegistry(tt.cfg, tt.removeNode)
+			if len(tt.cfg.Registries) != tt.wantLen {
+				t.Fatalf("expected %d registries, got %d", tt.wantLen, len(tt.cfg.Registries))
+			}
+			if tt.cfg.Current != tt.wantCurr {
+				t.Fatalf("expected current=%s, got current=%s", tt.wantCurr, tt.cfg.Current)
+			}
+		})
+	}
+}
+
+func TestNewEntryFromOptions(t *testing.T) {
+	o := &RegistryOptions{
+		Node:         "10.0.0.1",
+		RegistryPort: 6666,
+		SSHConfig: &sshutils.SSH{
+			User:       "root",
+			PkFile:     "/path/to/key",
+			PkPassword: "secret",
+		},
+	}
+
+	entry := newEntryFromOptions(o)
+	if entry.Node != "10.0.0.1" {
+		t.Fatalf("expected node=10.0.0.1, got %s", entry.Node)
+	}
+	if entry.Port != 6666 {
+		t.Fatalf("expected port=6666, got %d", entry.Port)
+	}
+	if entry.SSH.User != "root" {
+		t.Fatalf("expected ssh.user=root, got %s", entry.SSH.User)
+	}
+	if entry.SSH.PkFile != "/path/to/key" {
+		t.Fatalf("expected ssh.pkFile=/path/to/key, got %s", entry.SSH.PkFile)
+	}
+	if entry.SSH.PkPasswd != "secret" {
+		t.Fatalf("expected ssh.pkPasswd=secret, got %s", entry.SSH.PkPasswd)
+	}
+}
+
+func TestApplyEntryToOptions(t *testing.T) {
+	tests := []struct {
+		name            string
+		o               *RegistryOptions
+		entry           *RegistryEntry
+		nodeChanged     bool
+		portChanged     bool
+		sshUserChanged  bool
+		pkFileChanged   bool
+		pkPasswdChanged bool
+		wantNode        string
+		wantPort        int
+		wantSSHUser     string
+		wantPkFile      string
+		wantPkPasswd    string
+	}{
+		{
+			name: "fill all from entry",
+			o: &RegistryOptions{
+				Node:         "",
+				RegistryPort: 0,
+				SSHConfig:    sshutils.NewSSH(),
+			},
+			entry: &RegistryEntry{
+				Node: "10.0.0.1",
+				Port: 6666,
+				SSH: RegistrySSH{
+					User:     "root",
+					PkFile:   "/key",
+					PkPasswd: "pw",
+				},
+			},
+			nodeChanged:     false,
+			portChanged:     false,
+			sshUserChanged:  false,
+			pkFileChanged:   false,
+			pkPasswdChanged: false,
+			wantNode:        "10.0.0.1",
+			wantPort:        6666,
+			wantSSHUser:     "root",
+			wantPkFile:      "/key",
+			wantPkPasswd:    "pw",
+		},
+		{
+			name: "cli flags override config",
+			o: &RegistryOptions{
+				Node:         "10.0.0.2",
+				RegistryPort: 5000,
+				SSHConfig: &sshutils.SSH{
+					User:       "ubuntu",
+					PkFile:     "/other",
+					PkPassword: "otherpw",
+				},
+			},
+			entry: &RegistryEntry{
+				Node: "10.0.0.1",
+				Port: 6666,
+				SSH: RegistrySSH{
+					User:     "root",
+					PkFile:   "/key",
+					PkPasswd: "pw",
+				},
+			},
+			nodeChanged:     true,
+			portChanged:     true,
+			sshUserChanged:  true,
+			pkFileChanged:   true,
+			pkPasswdChanged: true,
+			wantNode:        "10.0.0.2",
+			wantPort:        5000,
+			wantSSHUser:     "ubuntu",
+			wantPkFile:      "/other",
+			wantPkPasswd:    "otherpw",
+		},
+		{
+			name: "partial override - node from config, port from cli",
+			o: &RegistryOptions{
+				Node:         "",
+				RegistryPort: 5000,
+				SSHConfig:    sshutils.NewSSH(),
+			},
+			entry: &RegistryEntry{
+				Node: "10.0.0.1",
+				Port: 6666,
+			},
+			nodeChanged:  false,
+			portChanged:  true,
+			wantNode:     "10.0.0.1",
+			wantPort:     5000,
+			wantSSHUser:  sshutils.NewSSH().User,
+			wantPkFile:   "",
+			wantPkPasswd: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applyEntryToOptions(tt.o, tt.entry, tt.nodeChanged, tt.portChanged, tt.sshUserChanged, tt.pkFileChanged, tt.pkPasswdChanged)
+			if tt.o.Node != tt.wantNode {
+				t.Errorf("node: expected %s, got %s", tt.wantNode, tt.o.Node)
+			}
+			if tt.o.RegistryPort != tt.wantPort {
+				t.Errorf("port: expected %d, got %d", tt.wantPort, tt.o.RegistryPort)
+			}
+			if tt.o.SSHConfig != nil {
+				if tt.o.SSHConfig.User != tt.wantSSHUser {
+					t.Errorf("ssh user: expected %s, got %s", tt.wantSSHUser, tt.o.SSHConfig.User)
+				}
+				if tt.o.SSHConfig.PkFile != tt.wantPkFile {
+					t.Errorf("pkFile: expected %s, got %s", tt.wantPkFile, tt.o.SSHConfig.PkFile)
+				}
+				if tt.o.SSHConfig.PkPassword != tt.wantPkPasswd {
+					t.Errorf("pkPasswd: expected %s, got %s", tt.wantPkPasswd, tt.o.SSHConfig.PkPassword)
+				}
+			}
+		})
+	}
+}
+
+func TestSaveAndLoadRegistryConfig(t *testing.T) {
+	dir := t.TempDir()
+	origPath := registryConfigPath
+	registryConfigPath = func() string { return filepath.Join(dir, "registry-config.yaml") }
+	defer func() { registryConfigPath = origPath }()
+
+	cfg := &RegistryConfig{
+		Current: "10.0.0.1",
+		Registries: []RegistryEntry{
+			{
+				Node: "10.0.0.1",
+				Port: 5000,
+				SSH: RegistrySSH{
+					User:   "root",
+					PkFile: "/home/user/.ssh/id_rsa",
+				},
+			},
+			{
+				Node: "10.0.0.2",
+				Port: 6666,
+			},
+		},
+	}
+
+	if err := SaveRegistryConfig(cfg); err != nil {
+		t.Fatalf("SaveRegistryConfig failed: %v", err)
+	}
+
+	loaded, err := LoadRegistryConfig()
+	if err != nil {
+		t.Fatalf("LoadRegistryConfig failed: %v", err)
+	}
+
+	if loaded.Current != cfg.Current {
+		t.Fatalf("current: expected %s, got %s", cfg.Current, loaded.Current)
+	}
+	if len(loaded.Registries) != len(cfg.Registries) {
+		t.Fatalf("registries count: expected %d, got %d", len(cfg.Registries), len(loaded.Registries))
+	}
+	for i, want := range cfg.Registries {
+		got := loaded.Registries[i]
+		if got.Node != want.Node || got.Port != want.Port {
+			t.Fatalf("registry[%d]: expected %+v, got %+v", i, want, got)
+		}
+		if got.SSH.User != want.SSH.User || got.SSH.PkFile != want.SSH.PkFile {
+			t.Fatalf("registry[%d].SSH: expected %+v, got %+v", i, want.SSH, got.SSH)
+		}
+	}
+}
+
+func TestLoadRegistryConfigNotExist(t *testing.T) {
+	dir := t.TempDir()
+	origPath := registryConfigPath
+	registryConfigPath = func() string { return filepath.Join(dir, "nonexistent.yaml") }
+	defer func() { registryConfigPath = origPath }()
+
+	cfg, err := LoadRegistryConfig()
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got: %v", err)
+	}
+	if cfg.Current != "" {
+		t.Fatalf("expected empty current, got %s", cfg.Current)
+	}
+	if len(cfg.Registries) != 0 {
+		t.Fatalf("expected empty registries, got %d", len(cfg.Registries))
+	}
+}
+
+func TestLoadRegistryConfigInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	os.WriteFile(path, []byte("{{invalid yaml"), 0644)
+
+	origPath := registryConfigPath
+	registryConfigPath = func() string { return path }
+	defer func() { registryConfigPath = origPath }()
+
+	_, err := LoadRegistryConfig()
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestRoundTripEmptyConfig(t *testing.T) {
+	dir := t.TempDir()
+	origPath := registryConfigPath
+	registryConfigPath = func() string { return filepath.Join(dir, "registry-config.yaml") }
+	defer func() { registryConfigPath = origPath }()
+
+	cfg := &RegistryConfig{}
+	if err := SaveRegistryConfig(cfg); err != nil {
+		t.Fatalf("SaveRegistryConfig failed: %v", err)
+	}
+
+	loaded, err := LoadRegistryConfig()
+	if err != nil {
+		t.Fatalf("LoadRegistryConfig failed: %v", err)
+	}
+	if loaded.Current != "" {
+		t.Fatalf("expected empty current, got %s", loaded.Current)
+	}
+	if len(loaded.Registries) != 0 {
+		t.Fatalf("expected empty registries, got %d", len(loaded.Registries))
+	}
+}


### PR DESCRIPTION
Save registry info (node, port, SSH) to ~/.kc/registry-config.yaml after deploy, and auto-fill subcommands from config when flags are not specified. CLI flags take precedence over config values.

- Add registry-config.yaml with current pointer and multi-registry support
- Make --node optional for clean/push/list/delete (still required for deploy)
- Remove --type MarkFlagRequired, default to "repository"
- Auto-save config on deploy, auto-remove on clean
- Add unit tests for config CRUD and file I/O

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #791

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
