### PR TITLE
fix: kcctl deploy fails when deploy-config configmap already exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ tools/kcctldocs-gen/generators/build/
 tools/kcctldocs-gen/generators/includes/
 tools/kcctldocs-gen/generators/manifest.json
 
-openspec/
-.claude/
+# Local kcctl binary
 /kcctl
+
+# OpenSpec change tracking
+openspec/
+
+# Claude Code
+.claude/

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -969,9 +969,21 @@ func uploadDeployConfig(client *kc.Client, deployConfig *options.DeployConfig) {
 			constatns.DeployConfigConfigMapKey: string(dcData),
 		},
 	}
-	_, err = client.CreateConfigMap(context.TODO(), dc)
-	if err != nil {
-		logger.Fatal(err)
+	// Check if configmap already exists (e.g., from a previous deploy attempt)
+	existing, err := client.DescribeConfigMap(context.TODO(), constatns.DeployConfigConfigMapName)
+	if err == nil && len(existing.Items) > 0 {
+		cm := existing.Items[0]
+		if cm.Data == nil {
+			cm.Data = make(map[string]string)
+		}
+		cm.Data[constatns.DeployConfigConfigMapKey] = string(dcData)
+		if _, err = client.UpdateConfigMap(context.TODO(), &cm); err != nil {
+			logger.Fatalf("update deploy-config failed: %v", err)
+		}
+		return
+	}
+	if _, err = client.CreateConfigMap(context.TODO(), dc); err != nil {
+		logger.Fatalf("create deploy-config failed: %v", err)
 	}
 }
 


### PR DESCRIPTION
Change uploadDeployConfig to CreateOrUpdate semantics: try Create first, if it fails (configmap already exists in etcd from a previous deploy), fall back to Describe + Update instead of fatal.

Closes: #944

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #944 

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
