### PR TITLE
fix: correct error handling and resource leaks across multiple packages

### DIFF
--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -1044,7 +1044,7 @@ func uploadCerts(client *kc.Client) {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	etcdhealthcheckkey, err := os.ReadFile(fmt.Sprintf("%s/kube-etcd-healthcheck-client.crt", etcdPath))
+	etcdhealthcheckkey, err := os.ReadFile(fmt.Sprintf("%s/kube-etcd-healthcheck-client.key", etcdPath))
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/pkg/controller/cluster_status.go
+++ b/pkg/controller/cluster_status.go
@@ -112,7 +112,7 @@ func (s *ClusterStatusMon) monitorClusterStatus() {
 		if err != nil {
 			s.log.Error("get k8s cluster healthz failed", zap.Error(err))
 			s.updateClusterComponentStatus(clu.Name, "kubernetes", "kubernetes", v1.ComponentUnKnown)
-			return
+			continue
 		}
 		if "ok" == string(content) {
 			s.updateClusterComponentStatus(clu.Name, "kubernetes", "kubernetes", v1.ComponentHealthy)
@@ -236,7 +236,7 @@ func (s *ClusterStatusMon) GetCertificationFromKC(clu *v1.Cluster) ([]v1.Certifi
 	splitRes := strings.Split(string(res), "\n\n")
 	if len(splitRes) != 3 {
 		logger.Errorf("read cluster certs error")
-		return nil, err
+		return nil, fmt.Errorf("unexpected cert check output format: expected 3 sections, got %d", len(splitRes))
 	}
 	crts := strings.Split(splitRes[1], "\n")
 	cas := strings.Split(splitRes[2], "\n")
@@ -246,7 +246,7 @@ func (s *ClusterStatusMon) GetCertificationFromKC(clu *v1.Cluster) ([]v1.Certifi
 		expire, parErr := time.Parse("Jan 02, 2006 15:04 MST", strings.Join(crt[1:6], " "))
 		if parErr != nil {
 			s.log.Warn("get cluster failed when get cluster ca expiration time", zap.String("cluster", clu.Name))
-			return nil, err
+			return nil, parErr
 		}
 		certification = append(certification, v1.Certification{
 			Name:           crt[0],
@@ -259,7 +259,7 @@ func (s *ClusterStatusMon) GetCertificationFromKC(clu *v1.Cluster) ([]v1.Certifi
 		expire, parErr := time.Parse("Jan 02, 2006 15:04 MST", strings.Join(crt[1:6], " "))
 		if parErr != nil {
 			s.log.Warn("get cluster failed when get cluster cert expiration time", zap.String("cluster", clu.Name))
-			return nil, err
+			return nil, parErr
 		}
 		certification = append(certification, v1.Certification{
 			Name:           crt[0],

--- a/pkg/service/delivery/delivery.go
+++ b/pkg/service/delivery/delivery.go
@@ -160,7 +160,7 @@ func (s *Service) stepStatusChannelController() {
 		if status.DryRun {
 			logger.Debug("dry run update step status", zap.String("op", status.OperationIdentity),
 				zap.String("step", status.OperationCondition.StepID), zap.Any("step_status", status.OperationCondition))
-			return
+			continue
 		}
 		// TODO: 简化更新,允许强制更新?
 		for i := 0; i < updateOperationStatusRetry; i++ {

--- a/pkg/simple/backupstore/filesystem.go
+++ b/pkg/simple/backupstore/filesystem.go
@@ -86,6 +86,7 @@ func (fs *FilesystemStore) Download(ctx context.Context, fileName string, w io.W
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	write := bufio.NewWriter(w)
 


### PR DESCRIPTION
- cluster_status: return parErr instead of err in cert parsing, add meaningful error for unexpected output format, use continue instead of return in monitor loop to prevent single cluster failure from stopping all monitoring
- deploy: fix etcd healthcheck key file path (.crt -> .key)
- delivery: use continue instead of return for dry-run to avoid stopping the step status controller
- backupstore: add defer f.Close() to prevent file handle leak in Download

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
