### PR TITLE
feat: add Calico v3.31.5 support

### DIFF
--- a/pkg/scheme/core/v1/cni/calico.go
+++ b/pkg/scheme/core/v1/cni/calico.go
@@ -214,6 +214,8 @@ func (runnable *CalicoRunnable) CalicoTemplate() (string, error) {
 		return calicoV3261, nil
 	case "v3.29.6":
 		return calicoV3296, nil
+	case "v3.31.5":
+		return calicoV3315, nil
 	}
 	return "", fmt.Errorf("calico dose not support version: %s", runnable.Version)
 }

--- a/pkg/scheme/core/v1/cni/calico_template.go
+++ b/pkg/scheme/core/v1/cni/calico_template.go
@@ -18113,3 +18113,137 @@ calicoctl:
 kubernetesServiceEndpoint:
   host: ""
   port: "6443"`
+const calicoV3315 = `installation:
+  enabled: true
+  kubernetesProvider: ""
+  registry: {{with .CNI.LocalRegistry}}{{.}}{{end}}
+  kubeletVolumePluginPath: "None"
+  imagePullSecrets: []
+  cni:
+    type: Calico
+    ipam:
+      type: Calico
+  calicoNetwork:
+    {{if eq .CNI.Calico.Mode "BGP"}}
+    bgp: Enabled
+    {{else}}
+    bgp: Disabled
+    {{end}}
+    # Iptables, BPF
+    linuxDataplane: Iptables
+    mtu: {{.CNI.Calico.MTU}}
+    nodeAddressAutodetectionV4:
+      {{if eq .NodeAddressDetectionV4.Type "first-found"}}
+      firstFound: true
+      {{else if eq .NodeAddressDetectionV4.Type "interface"}}
+      interface: {{.NodeAddressDetectionV4.Value}}
+      {{else if eq .NodeAddressDetectionV4.Type "skip-interface"}}
+      skipInterface: {{.NodeAddressDetectionV4.Value}}
+      {{else if eq .NodeAddressDetectionV4.Type "can-reach"}}
+      canReach: {{.NodeAddressDetectionV4.Value}}
+      {{end}}
+    {{if .DualStack}}
+    nodeAddressAutodetectionV6:
+      {{if eq .NodeAddressDetectionV6.Type "first-found"}}
+      firstFound: true
+      {{else if eq .NodeAddressDetectionV6.Type "interface"}}
+      interface: {{.NodeAddressDetectionV6.Value}}
+      {{else if eq .NodeAddressDetectionV6.Type "skip-interface"}}
+      skipInterface: {{.NodeAddressDetectionV6.Value}}
+      {{else if eq .NodeAddressDetectionV6.Type "can-reach"}}
+      canReach: {{.NodeAddressDetectionV6.Value}}
+      {{end}}
+    {{end}}
+    ipPools:
+      - blockSize: 26
+        cidr: {{.PodIPv4CIDR}}
+        {{if eq .CNI.Calico.Mode "Overlay-IPIP-All"}}
+        encapsulation: IPIP
+        {{else if eq .CNI.Calico.Mode "Overlay-IPIP-Cross-Subnet"}}
+        encapsulation: IPIPCrossSubnet
+        {{else if eq .CNI.Calico.Mode "Overlay-Vxlan-All"}}
+        encapsulation: VXLAN
+        {{else if eq .CNI.Calico.Mode "Overlay-Vxlan-Cross-Subnet"}}
+        encapsulation: VXLANCrossSubnet
+        {{else}}
+        encapsulation: None
+        {{end}}
+        natOutgoing: Enabled
+        nodeSelector: all()
+      {{if .DualStack}}
+      - blockSize: 122
+        cidr: {{.PodIPv6CIDR}}
+        encapsulation: None
+        natOutgoing: Enabled
+        nodeSelector: all()
+      {{end}}
+
+apiServer:
+  enabled: true
+
+goldmane:
+  enabled: false
+
+whisker:
+  enabled: false
+
+defaultFelixConfiguration:
+  enabled: false
+
+certs:
+  node:
+    key:
+    cert:
+    commonName:
+  typha:
+    key:
+    cert:
+    commonName:
+    caBundle:
+
+manageCRDs: true
+
+# Resource requests and limits for the tigera/operator pod
+resources: {}
+
+# Common labels for all resources created by this chart
+additionalLabels: {}
+
+# Tolerations for the tigera/operator pod
+tolerations:
+- effect: NoExecute
+  operator: Exists
+- effect: NoSchedule
+  operator: Exists
+
+# NodeSelector for the tigera/operator pod
+nodeSelector:
+  kubernetes.io/os: linux
+
+# Affinity for the tigera/operator pod
+affinity: {}
+
+# PriorityClassName for the tigera/operator pod
+priorityClassName: ""
+
+# Custom annotations for the tigera/operator pod
+podAnnotations: {}
+
+# Custom labels for the tigera/operator pod
+podLabels: {}
+
+# Custom DNS configuration for the tigera/operator pod
+dnsConfig: {}
+
+tigeraOperator:
+  image: tigera/operator
+  version: v1.40.8
+  registry: {{with .CNI.LocalRegistry}}{{.}}{{else}}quay.io{{end}}
+calicoctl:
+  image: {{with .CNI.LocalRegistry}}{{.}}{{else}}quay.io{{end}}/calico/ctl
+  tag: v3.31.5
+
+# Optionally configure the host and port used to access the Kubernetes API server
+kubernetesServiceEndpoint:
+  host: ""
+  port: "6443"`

--- a/pkg/scheme/core/v1/cni/calico_test.go
+++ b/pkg/scheme/core/v1/cni/calico_test.go
@@ -188,6 +188,9 @@ func TestCNI_renderCalicoTo(t *testing.T) {
 				if !strings.Contains(output, "goldmane") {
 					t.Errorf("rendered template should contain goldmane section, got: %s", output)
 				}
+				if !strings.Contains(output, "whisker") {
+					t.Errorf("rendered template should contain whisker section, got: %s", output)
+				}
 			}
 			t.Log(output)
 		})

--- a/pkg/scheme/core/v1/cni/calico_test.go
+++ b/pkg/scheme/core/v1/cni/calico_test.go
@@ -122,6 +122,29 @@ func TestCNI_renderCalicoTo(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "v3.31.5",
+			stepper: CalicoRunnable{
+				KubeletDataDir: "/var/lib/kubelet",
+				BaseCni: BaseCni{
+					DualStack:   true,
+					PodIPv4CIDR: constatns.ClusterPodSubnet,
+					PodIPv6CIDR: "fd00::/64",
+					CNI: v1.CNI{
+						LocalRegistry: "172.0.0.1:5000",
+						Type:          "calico",
+						Version:       "v3.31.5",
+						Calico: &v1.Calico{
+							IPv4AutoDetection: "interface=eth0",
+							IPv6AutoDetection: "interface=eth0",
+							Mode:              "Overlay-Vxlan-All",
+							IPManger:          true,
+							MTU:               1440,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt.stepper.NodeAddressDetectionV4 = ParseNodeAddressDetection(tt.stepper.Calico.IPv4AutoDetection)
@@ -150,6 +173,20 @@ func TestCNI_renderCalicoTo(t *testing.T) {
 				}
 				if !strings.Contains(output, "v3.29.6") {
 					t.Errorf("rendered template should contain calicoctl version v3.29.6, got: %s", output)
+				}
+			}
+			if tt.name == "v3.31.5" {
+				if !strings.Contains(output, "v1.40.8") {
+					t.Errorf("rendered template should contain tigera operator version v1.40.8, got: %s", output)
+				}
+				if !strings.Contains(output, "v3.31.5") {
+					t.Errorf("rendered template should contain calicoctl version v3.31.5, got: %s", output)
+				}
+				if !strings.Contains(output, `kubeletVolumePluginPath: "None"`) {
+					t.Errorf("rendered template should contain kubeletVolumePluginPath None, got: %s", output)
+				}
+				if !strings.Contains(output, "goldmane") {
+					t.Errorf("rendered template should contain goldmane section, got: %s", output)
 				}
 			}
 			t.Log(output)


### PR DESCRIPTION
Add calicoV3315 template constant based on calicoV3296 with:
- tigera-operator v1.40.8
- calicoctl image from quay.io/calico/ctl with tag v3.31.5
- kubeletVolumePluginPath: "None" (CSI disabled by default)
- goldmane/whisker disabled
- certs section and manageCRDs: true

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
calico upgrade to v3.31.5
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->


```docs
None
```
