### PR TITLE
chore: upgrade golangci-lint from v1.60.0 to v1.64.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test:
 .PHONY: format-deps checkfmt fmt goimports vet lint
 format-deps:
     ifeq (, $(shell which golangci-lint))
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.5
     endif
     ifeq (, $(shell which goimports))
 		go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
golangci-lint v1.60.0 does not support Go 1.24+ export data format (unsupported version: 2 typecheck errors). Upgrade to v1.64.5 which adds proper Go 1.24 support.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind flake
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
