### PR TITLE
docs: add TODO for deprecated containerd registry.configs.*.auth

### DIFF
--- a/pkg/scheme/core/v1/container_registry_types.go
+++ b/pkg/scheme/core/v1/container_registry_types.go
@@ -46,6 +46,17 @@ type RegistrySpec struct {
 	RegistryAuth *RegistryAuth `json:"auth,omitempty"`
 }
 
+// RegistryAuth holds credentials for authenticating with a container registry.
+//
+// TODO: registry.configs.*.auth is deprecated since containerd 2.1. The Transfer Service
+// (default since containerd 2.1) does not support inline auth in config.toml and will
+// automatically fall back to Local Pull Mode with a warning. hosts.toml has no auth field,
+// and containerd recommends using Kubernetes ImagePullSecrets instead. There is no removal
+// timeline yet — containerd says it won't be removed "until a suitable secret management
+// alternative is available as a plugin". Once we migrate auth to the Kubernetes layer
+// (ImagePullSecrets), this struct and all code paths that write registry.configs.*.auth
+// should be removed.
+// Ref: https://github.com/containerd/containerd/blob/main/docs/cri/registry.md
 type RegistryAuth struct {
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`


### PR DESCRIPTION
Add deprecation notice to RegistryAuth struct documenting that registry.configs.*.auth is deprecated since containerd 2.1, where the Transfer Service does not support inline auth and falls back to Local Pull Mode with a warning.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
