### PR TITLE
fix: add port availability precheck before deployment

### DIFF
--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -329,12 +329,16 @@ var (
 
 func precheckPortFunc(port int, serviceName string) precheckFunc {
 	return func(sshConfig *sshutils.SSH, host string) error {
-		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host,
-			"command -v ss >/dev/null 2>&1 && ss -tlnp || (command -v netstat >/dev/null 2>&1 && netstat -tlnp)")
+		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, "ss -tlnp")
 		if err != nil {
-			return fmt.Errorf("check port %d on %s failed: %w", port, host, err)
+			ret, err = sshutils.SSHCmdWithSudo(sshConfig, host, "netstat -tlnp")
+			if err != nil {
+				return fmt.Errorf("check port %d on %s failed: %w", port, host, err)
+			}
 		}
-		if strings.Contains(ret.StdoutToString(""), fmt.Sprintf(":%d ", port)) {
+		output := ret.StdoutToString("")
+		if strings.Contains(output, fmt.Sprintf(":%d ", port)) ||
+			strings.Contains(output, fmt.Sprintf(":%d\t", port)) {
 			return fmt.Errorf("port %d is already in use on %s, required by %s", port, host, serviceName)
 		}
 		return nil
@@ -432,21 +436,25 @@ func (d *DeployOptions) precheckTimeLag() bool {
 }
 
 func (d *DeployOptions) precheckPorts() bool {
-	// Check if port detection tools are available on all server nodes.
+	var hasTools bool
 	toolCheck := func(sshConfig *sshutils.SSH, host string) error {
-		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host,
-			"command -v ss >/dev/null 2>&1 && echo ss || (command -v netstat >/dev/null 2>&1 && echo netstat)")
+		_, err := sshutils.SSHCmdWithSudo(sshConfig, host, "which ss")
 		if err != nil {
-			return fmt.Errorf("check port tool on %s failed: %w", host, err)
+			_, err = sshutils.SSHCmdWithSudo(sshConfig, host, "which netstat")
+			if err != nil {
+				return fmt.Errorf("port check tool (ss or netstat) not found on %s, "+
+					"skip port availability check, deployment may fail if port is occupied", host)
+			}
 		}
-		if ret.StdoutToString("") == "" {
-			return fmt.Errorf("port check tool (ss or netstat) not found on %s, "+
-				"skip port availability check, deployment may fail if port is occupied", host)
-		}
+		hasTools = true
 		return nil
 	}
 	if !d.precheckService("PORT-TOOL", d.deployConfig.ServerIPs, toolCheck) {
 		return false
+	}
+	if !hasTools {
+		logger.Warn("Port check tools are missing on some nodes, skipping port availability checks.")
+		return true
 	}
 
 	serverPorts := []struct {

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -327,11 +327,8 @@ var (
 	}
 )
 
-func precheckPortFunc(port int, serviceName string, hostsWithTool *sync.Map) precheckFunc {
+func precheckPortFunc(port int, serviceName string) precheckFunc {
 	return func(sshConfig *sshutils.SSH, host string) error {
-		if _, ok := hostsWithTool.Load(host); !ok {
-			return nil
-		}
 		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, "ss -tlnp")
 		if err != nil {
 			ret, err = sshutils.SSHCmdWithSudo(sshConfig, host, "netstat -tlnp")
@@ -439,7 +436,6 @@ func (d *DeployOptions) precheckTimeLag() bool {
 }
 
 func (d *DeployOptions) precheckPorts() bool {
-	var hostsWithTool sync.Map
 	toolCheck := func(sshConfig *sshutils.SSH, host string) error {
 		_, err := sshutils.SSHCmdWithSudo(sshConfig, host, "which ss")
 		if err != nil {
@@ -449,20 +445,10 @@ func (d *DeployOptions) precheckPorts() bool {
 					"skip port availability check, deployment may fail if port is occupied", host)
 			}
 		}
-		hostsWithTool.Store(host, true)
 		return nil
 	}
 	if !d.precheckService("PORT-TOOL", d.deployConfig.ServerIPs, toolCheck) {
 		return false
-	}
-	hasAnyTool := false
-	hostsWithTool.Range(func(_, _ interface{}) bool {
-		hasAnyTool = true
-		return false
-	})
-	if !hasAnyTool {
-		logger.Warn("Port check tools are missing on all nodes, skipping port availability checks.")
-		return true
 	}
 
 	serverPorts := []struct {
@@ -483,7 +469,7 @@ func (d *DeployOptions) precheckPorts() bool {
 		if !d.precheckService(
 			fmt.Sprintf("PORT-%d(%s)", p.port, p.name),
 			d.deployConfig.ServerIPs,
-			precheckPortFunc(p.port, p.name, &hostsWithTool),
+			precheckPortFunc(p.port, p.name),
 		) {
 			return false
 		}

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -327,6 +327,20 @@ var (
 	}
 )
 
+func precheckPortFunc(port int, serviceName string) precheckFunc {
+	return func(sshConfig *sshutils.SSH, host string) error {
+		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host,
+			"command -v ss >/dev/null 2>&1 && ss -tlnp || (command -v netstat >/dev/null 2>&1 && netstat -tlnp)")
+		if err != nil {
+			return fmt.Errorf("check port %d on %s failed: %w", port, host, err)
+		}
+		if strings.Contains(ret.StdoutToString(""), fmt.Sprintf(":%d ", port)) {
+			return fmt.Errorf("port %d is already in use on %s, required by %s", port, host, serviceName)
+		}
+		return nil
+	}
+}
+
 func generateCommonPreCheckFunc(name string) precheckFunc {
 	return func(sshConfig *sshutils.SSH, host string) error {
 		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, fmt.Sprintf("systemctl --all --type service | grep %s | wc -l", name))
@@ -417,6 +431,49 @@ func (d *DeployOptions) precheckTimeLag() bool {
 	return utils.AskForConfirmation()
 }
 
+func (d *DeployOptions) precheckPorts() bool {
+	// Check if port detection tools are available on all server nodes.
+	toolCheck := func(sshConfig *sshutils.SSH, host string) error {
+		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host,
+			"command -v ss >/dev/null 2>&1 && echo ss || (command -v netstat >/dev/null 2>&1 && echo netstat)")
+		if err != nil {
+			return fmt.Errorf("check port tool on %s failed: %w", host, err)
+		}
+		if ret.StdoutToString("") == "" {
+			return fmt.Errorf("port check tool (ss or netstat) not found on %s, skip port availability check, deployment may fail if port is occupied", host)
+		}
+		return nil
+	}
+	if !d.precheckService("PORT-TOOL", d.deployConfig.ServerIPs, toolCheck) {
+		return false
+	}
+
+	serverPorts := []struct {
+		port int
+		name string
+	}{
+		{d.deployConfig.EtcdConfig.ClientPort, "kc-etcd-client"},
+		{d.deployConfig.EtcdConfig.PeerPort, "kc-etcd-peer"},
+		{d.deployConfig.EtcdConfig.MetricsPort, "kc-etcd-metrics"},
+		{d.deployConfig.ServerPort, "kc-server"},
+		{d.deployConfig.StaticServerPort, "kc-server-static"},
+		{d.deployConfig.MQ.Port, "kc-mq"},
+		{d.deployConfig.MQ.ClusterPort, "kc-mq-cluster"},
+		{d.deployConfig.ConsolePort, "kc-console"},
+	}
+
+	for _, p := range serverPorts {
+		if !d.precheckService(
+			fmt.Sprintf("PORT-%d(%s)", p.port, p.name),
+			d.deployConfig.ServerIPs,
+			precheckPortFunc(p.port, p.name),
+		) {
+			return false
+		}
+	}
+	return true
+}
+
 func (d *DeployOptions) preCheck() bool {
 	if !d.precheckService("kc-etcd", d.deployConfig.ServerIPs, precheckKcEtcdFunc) {
 		return false
@@ -428,6 +485,9 @@ func (d *DeployOptions) preCheck() bool {
 		return false
 	}
 	if !d.precheckTimeLag() {
+		return false
+	}
+	if !d.precheckPorts() {
 		return false
 	}
 	if !d.precheckService("NTP", d.allNodes, precheckNtpFunc) {

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -440,7 +440,8 @@ func (d *DeployOptions) precheckPorts() bool {
 			return fmt.Errorf("check port tool on %s failed: %w", host, err)
 		}
 		if ret.StdoutToString("") == "" {
-			return fmt.Errorf("port check tool (ss or netstat) not found on %s, skip port availability check, deployment may fail if port is occupied", host)
+			return fmt.Errorf("port check tool (ss or netstat) not found on %s, "+
+				"skip port availability check, deployment may fail if port is occupied", host)
 		}
 		return nil
 	}

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -327,8 +327,11 @@ var (
 	}
 )
 
-func precheckPortFunc(port int, serviceName string) precheckFunc {
+func precheckPortFunc(port int, serviceName string, hostsWithTool *sync.Map) precheckFunc {
 	return func(sshConfig *sshutils.SSH, host string) error {
+		if _, ok := hostsWithTool.Load(host); !ok {
+			return nil
+		}
 		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, "ss -tlnp")
 		if err != nil {
 			ret, err = sshutils.SSHCmdWithSudo(sshConfig, host, "netstat -tlnp")
@@ -436,7 +439,7 @@ func (d *DeployOptions) precheckTimeLag() bool {
 }
 
 func (d *DeployOptions) precheckPorts() bool {
-	var hasTools bool
+	var hostsWithTool sync.Map
 	toolCheck := func(sshConfig *sshutils.SSH, host string) error {
 		_, err := sshutils.SSHCmdWithSudo(sshConfig, host, "which ss")
 		if err != nil {
@@ -446,14 +449,19 @@ func (d *DeployOptions) precheckPorts() bool {
 					"skip port availability check, deployment may fail if port is occupied", host)
 			}
 		}
-		hasTools = true
+		hostsWithTool.Store(host, true)
 		return nil
 	}
 	if !d.precheckService("PORT-TOOL", d.deployConfig.ServerIPs, toolCheck) {
 		return false
 	}
-	if !hasTools {
-		logger.Warn("Port check tools are missing on some nodes, skipping port availability checks.")
+	hasAnyTool := false
+	hostsWithTool.Range(func(_, _ interface{}) bool {
+		hasAnyTool = true
+		return false
+	})
+	if !hasAnyTool {
+		logger.Warn("Port check tools are missing on all nodes, skipping port availability checks.")
 		return true
 	}
 
@@ -475,7 +483,7 @@ func (d *DeployOptions) precheckPorts() bool {
 		if !d.precheckService(
 			fmt.Sprintf("PORT-%d(%s)", p.port, p.name),
 			d.deployConfig.ServerIPs,
-			precheckPortFunc(p.port, p.name),
+			precheckPortFunc(p.port, p.name, &hostsWithTool),
 		) {
 			return false
 		}

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -436,11 +436,18 @@ func (d *DeployOptions) precheckTimeLag() bool {
 }
 
 func (d *DeployOptions) precheckPorts() bool {
+	var (
+		missingToolHosts = make(map[string]bool)
+		mu               sync.Mutex
+	)
 	toolCheck := func(sshConfig *sshutils.SSH, host string) error {
 		_, err := sshutils.SSHCmdWithSudo(sshConfig, host, "which ss")
 		if err != nil {
 			_, err = sshutils.SSHCmdWithSudo(sshConfig, host, "which netstat")
 			if err != nil {
+				mu.Lock()
+				missingToolHosts[host] = true
+				mu.Unlock()
 				return fmt.Errorf("port check tool (ss or netstat) not found on %s, "+
 					"skip port availability check, deployment may fail if port is occupied", host)
 			}
@@ -460,16 +467,36 @@ func (d *DeployOptions) precheckPorts() bool {
 		{d.deployConfig.EtcdConfig.MetricsPort, "kc-etcd-metrics"},
 		{d.deployConfig.ServerPort, "kc-server"},
 		{d.deployConfig.StaticServerPort, "kc-server-static"},
-		{d.deployConfig.MQ.Port, "kc-mq"},
-		{d.deployConfig.MQ.ClusterPort, "kc-mq-cluster"},
 		{d.deployConfig.ConsolePort, "kc-console"},
+	}
+	if !d.deployConfig.MQ.External {
+		serverPorts = append(serverPorts,
+			struct {
+				port int
+				name string
+			}{d.deployConfig.MQ.Port, "kc-mq"},
+			struct {
+				port int
+				name string
+			}{d.deployConfig.MQ.ClusterPort, "kc-mq-cluster"},
+		)
 	}
 
 	for _, p := range serverPorts {
 		if !d.precheckService(
 			fmt.Sprintf("PORT-%d(%s)", p.port, p.name),
 			d.deployConfig.ServerIPs,
-			precheckPortFunc(p.port, p.name),
+			func(port int, svc string) precheckFunc {
+				return func(sshConfig *sshutils.SSH, host string) error {
+					mu.Lock()
+					missing := missingToolHosts[host]
+					mu.Unlock()
+					if missing {
+						return nil
+					}
+					return precheckPortFunc(port, svc)(sshConfig, host)
+				}
+			}(p.port, p.name),
 		) {
 			return false
 		}


### PR DESCRIPTION
When a required port is occupied, kc-server fails to start with a misleading "context deadline exceeded" timeout error. This adds port availability checks into the existing preCheck() framework, providing clear error messages that identify which port is occupied and which service needs it.

- Add precheckPortFunc using ss (preferred) with netstat fallback
- Add PORT-TOOL precheck for tool availability detection
- Check all 8 server ports from deployConfig (respects CLI overrides)
- Prompt user with yes/no when tools are missing

Closes #961

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #961

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
