### PR TITLE
feat(precheck): add node IP and role to precheck error messages

### DIFF
--- a/docs/superpowers/plans/2026-06-04-precheck-error-clarity.md
+++ b/docs/superpowers/plans/2026-06-04-precheck-error-clarity.md
@@ -1,0 +1,164 @@
+---
+change: precheck-node-error-clarity
+design-doc: docs/superpowers/specs/2026-06-04-precheck-error-clarity-design.md
+base-ref: d3f44c92997da6cfdefff94fc0b3fe3a4666a7b1
+---
+
+## Implementation Plan
+
+### T1: Add `nodeRole(ip string) string` method
+
+**File**: `pkg/cli/deploy/deploy.go`
+
+Add method to `DeployOptions`:
+
+```go
+func (d *DeployOptions) nodeRole(ip string) string {
+    isServer := false
+    isAgent := false
+    for _, s := range d.deployConfig.ServerIPs {
+        if s == ip { isServer = true; break }
+    }
+    for _, a := range d.deployConfig.Agents.ListIP() {
+        if a == ip { isAgent = true; break }
+    }
+    switch {
+    case isServer && isAgent: return "server+agent"
+    case isServer: return "server"
+    case isAgent: return "agent"
+    default: return ""
+    }
+}
+```
+
+No imports needed — only uses existing fields.
+
+### T2: Refactor `precheckService` — structured collection + grouped output
+
+**File**: `pkg/cli/deploy/deploy.go`
+
+1. Add `nodeError` struct near `precheckFunc`:
+
+```go
+type nodeError struct {
+    host string
+    err  error
+}
+```
+
+2. Replace `precheckService` implementation:
+   - Change `chan error` to `[]nodeError` (slice, not channel — we drain after `wg.Wait()`)
+   - Collect `nodeError{host, err}` per node via goroutine (with mutex)
+   - After `wg.Wait()`, group by `err.Error()`: `map[string][]string` (key=message, value=node refs)
+   - Output each group: message line, then indented node refs
+   - Node ref format: `[<role>@<ip>]` (using `d.nodeRole(host)`)
+   - If `nodeRole` returns `""`, use `[<ip>]` as fallback
+
+Output example:
+```
+============>NTP PRECHECK FAILED!
+chronyd or ntpd service not running, may cause service internal error:
+  - [server@10.0.0.2]
+  - [agent@10.0.0.5]
+```
+
+3. Preserve existing behavior: `PRECHECK OK/FAILED` markers, `AssumeYes` handling, confirmation prompt.
+
+### T3: Update `precheckTimeLag` — structured lag collection
+
+**File**: `pkg/cli/deploy/deploy.go`
+
+1. Add `timeLagError` struct:
+
+```go
+type timeLagError struct {
+    host string
+    lag  float64
+}
+```
+
+2. Replace `chan struct{}` with `[]timeLagError` (mutex-protected slice)
+3. Collect per-node lag data when `math.Abs(diff) > 5`
+4. Also collect nodes that fail SSH or parsing (append with `lag: 0` and log the reason separately)
+5. On failure, output merged format:
+
+```
+===========>TIME-LAG PRECHECK FAILED!
+time lag exceeds 5s threshold:
+  - [server@10.0.0.2] 7.8s
+  - [agent@10.0.0.5] -6.3s
+```
+
+6. Preserve existing `PRECHECK OK` message for success case.
+
+### T4: Update `sudo.MultiNIC` — replace CmdBatch with custom concurrent collection
+
+**File**: `pkg/cli/sudo/sudo.go`
+
+1. Remove `errorMultiNIC` variable
+2. Replace `sshutils.CmdBatch` call with goroutines + WaitGroup:
+   - Iterate `allNodes`, launch goroutine per node
+   - Each goroutine: run `ip a|grep ": "|awk {'print $2'}|sed 's/://'`, check iface count
+   - Collect multi-NIC nodes into `[]string` (mutex-protected)
+3. On failure, output merged format:
+
+```
+===========>ipDetect PRECHECK FAILED!
+node has multiple network interfaces, --ip-detect not specified (default: first-found may choose wrong interface):
+  - [agent@10.0.0.5]
+  - [agent@10.0.0.8]
+```
+
+4. Role is always `"agent"` since MultiNIC only checks agent nodes — pass role as parameter or hardcode.
+5. Preserve existing `AssumeYes` handling and confirmation prompt.
+
+### T5: Adjust `precheckPortFunc` error messages
+
+**File**: `pkg/cli/deploy/deploy.go`
+
+1. Port-in-use error — remove host from message:
+   - Before: `"port %d is already in use on %s, required by %s"`
+   - After: `"port %d is already in use, required by %s"`
+2. Tool-missing error in `precheckPorts`:
+   - Before: `"port check tool (ss or netstat) not found on %s, skip port availability check, deployment may fail if port is occupied"`
+   - After: `"port check tool (ss or netstat) not found, skip port availability check, deployment may fail if port is occupied"`
+3. Port check SSH failure — remove host from message:
+   - Before: `"check port %d on %s failed: %w"`
+   - After: `"check port %d failed: %w"`
+
+Role and IP annotation handled by `precheckService` (T2).
+
+### T6: Unit tests for `nodeRole`
+
+**File**: `pkg/cli/deploy/deploy_test.go` (new)
+
+Table-driven tests covering:
+- Server-only IP → `"server"`
+- Agent-only IP → `"agent"`
+- AIO IP (in both ServerIPs and Agents) → `"server+agent"`
+- Unknown IP → `""`
+- Multiple servers and agents
+
+### T7: Build verification
+
+```bash
+go build ./cmd/kcctl
+go vet ./pkg/cli/deploy/ ./pkg/cli/sudo/
+```
+
+## Execution Order
+
+T1 → T2 → T3 → T5 → T4 → T6 → T7
+
+T1 is a prerequisite for T2/T3 (they call `nodeRole`). T5 removes host from port error messages so T2's grouping works correctly. T4 is independent but follows the same pattern. T6 depends on T1. T7 is final validation.
+
+## Commit Strategy
+
+One commit per task, message prefixed with change name:
+- `feat(precheck): add nodeRole method to DeployOptions`
+- `feat(precheck): refactor precheckService with structured error collection and grouped output`
+- `feat(precheck): refactor precheckTimeLag with structured lag collection`
+- `feat(precheck): adjust precheckPortFunc error messages for grouping`
+- `feat(precheck): refactor MultiNIC with custom concurrent collection`
+- `test(precheck): add unit tests for nodeRole method`
+- `chore(precheck): verify build passes`

--- a/docs/superpowers/specs/2026-06-04-precheck-error-clarity-design.md
+++ b/docs/superpowers/specs/2026-06-04-precheck-error-clarity-design.md
@@ -1,0 +1,145 @@
+---
+comet_change: precheck-node-error-clarity
+role: technical-design
+canonical_spec: openspec
+---
+
+## Overview
+
+Optimize precheck error messages in `kcctl deploy` to include node IP and role (server/agent), using a merged display format for multi-node failures.
+
+## Architecture Decision
+
+Adopt a minimal-invasion approach: `precheckFunc` signature remains unchanged, returning error messages without host info. Role annotation is handled uniformly by `precheckService` at the caller level.
+
+## Design Details
+
+### 1. nodeRole method
+
+Add `nodeRole(ip string) string` to `DeployOptions`:
+
+```go
+func (d *DeployOptions) nodeRole(ip string) string {
+    isServer := false
+    isAgent := false
+    for _, s := range d.deployConfig.ServerIPs {
+        if s == ip { isServer = true; break }
+    }
+    for _, a := range d.deployConfig.Agents.ListIP() {
+        if a == ip { isAgent = true; break }
+    }
+    switch {
+    case isServer && isAgent: return "server+agent"
+    case isServer: return "server"
+    case isAgent: return "agent"
+    default: return ""
+    }
+}
+```
+
+### 2. precheckService refactor
+
+Replace `chan error` with structured collection and grouped output:
+
+```go
+type nodeError struct {
+    host string
+    err  error
+}
+```
+
+- Collect `nodeError{host, err}` per node via goroutines
+- Group by `err.Error()`: `map[string][]string` (key=message, value=node refs like `[server@10.0.0.1]`)
+- Output grouped format:
+  ```
+  ============>NTP PRECHECK FAILED!
+  chronyd or ntpd service not running, may cause service internal error:
+    - [server@10.0.0.2]
+    - [agent@10.0.0.5]
+  ```
+- `PRECHECK OK/FAILED` markers unchanged for backward compatibility
+
+### 3. precheckTimeLag refactor
+
+Replace `chan struct{}` with structured error collection:
+
+```go
+type timeLagError struct {
+    host string
+    lag  float64
+}
+```
+
+- Collect per-node lag data for nodes exceeding 5s threshold
+- On failure, output grouped format:
+  ```
+  ============>TIME-LAG PRECHECK FAILED!
+  time lag exceeds 5s threshold:
+    - [server@10.0.0.2] 7.8s
+    - [agent@10.0.0.5] -6.3s
+  ```
+
+### 4. precheckPortFunc adjustment
+
+Remove host from error message to enable grouping:
+
+- Before: `"port %d is already in use on %s, required by %s"`
+- After: `"port %d is already in use, required by %s"`
+
+Role and IP annotation handled by precheckService.
+
+Also adjust the tool-missing error:
+- Before: `"port check tool (ss or netstat) not found on %s, skip port availability check..."`
+- After: `"port check tool (ss or netstat) not found, skip port availability check, deployment may fail if port is occupied"`
+
+### 5. sudo.MultiNIC refactor
+
+Replace `sshutils.CmdBatch` with custom concurrent collection (same pattern as precheckService):
+
+- Use goroutines + WaitGroup to check all nodes
+- Collect multi-NIC nodes into a slice
+- On failure, output merged format:
+  ```
+  ============>ipDetect PRECHECK FAILED!
+  node has multiple network interfaces, --ip-detect not specified (default: first-found may choose wrong interface):
+    - [agent@10.0.0.5]
+    - [agent@10.0.0.8]
+  ```
+- Role is fixed as `"agent"` since MultiNIC only checks agent nodes
+
+Fixes existing bug: CmdBatch stops on first error, missing other multi-NIC nodes.
+
+### 6. Unchanged parts
+
+- `sudo.PreCheck`: errors already contain `user@host`, no change needed
+- `precheckFunc` signature: unchanged
+- `generateCommonPreCheckFunc` / `precheckNtpFunc`: error messages unchanged (no host in message)
+
+## Data Flow
+
+```
+precheckFunc(host) → error("<message without host>")
+        ↓
+precheckService collects: nodeError{host, err}
+        ↓
+Group by err.Error(): map[message][]nodeRef
+        ↓
+Output per group:
+  <message>:
+    - [<role>@<ip>]
+    - [<role>@<ip>]
+```
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Merged display changes CLI output format | Low — output is human-readable, not machine-parsed | Keep `PRECHECK OK/FAILED` markers unchanged |
+| MultiNIC refactor introduces sync dependency in sudo package | Low — standard library only | No external risk |
+| nodeRole iterates lists, O(n) per call | Negligible — typically < 100 nodes | Acceptable |
+
+## Testing Strategy
+
+- `nodeRole` unit tests: table-driven, covering server-only, agent-only, server+agent, unknown IP
+- Build verification: `go build ./cmd/kcctl`
+- Manual verification: observe error output format in multi-node deploy scenarios

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -34,6 +34,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -147,20 +148,8 @@ func NewDeployOptions(streams options.IOStreams) *DeployOptions {
 }
 
 func (d *DeployOptions) nodeRole(ip string) string {
-	isServer := false
-	isAgent := false
-	for _, s := range d.deployConfig.ServerIPs {
-		if s == ip {
-			isServer = true
-			break
-		}
-	}
-	for _, a := range d.deployConfig.Agents.ListIP() {
-		if a == ip {
-			isAgent = true
-			break
-		}
-	}
+	isServer := slices.Contains(d.deployConfig.ServerIPs, ip)
+	_, isAgent := d.deployConfig.Agents[ip]
 	switch {
 	case isServer && isAgent:
 		return "server+agent"
@@ -386,43 +375,53 @@ func generateCommonPreCheckFunc(name string) precheckFunc {
 	}
 }
 
-type nodeError struct {
-	host string
-	err  error
-}
-
 func (d *DeployOptions) precheckService(name string, nodes []string, fn precheckFunc) bool {
 	logger.Infof("============>%s PRECHECK ...", name)
-	var errs []nodeError
-	var mu sync.Mutex
+	errs := make([]error, len(nodes))
 	wg := sync.WaitGroup{}
-	for _, node := range nodes {
+	for i, node := range nodes {
 		wg.Add(1)
-		go func(host string) {
+		go func(idx int, host string) {
 			defer wg.Done()
 			if err := fn(d.deployConfig.SSHConfig, host); err != nil {
-				mu.Lock()
-				errs = append(errs, nodeError{host: host, err: err})
-				mu.Unlock()
+				errs[idx] = err
 			}
-		}(node)
+		}(i, node)
 	}
 	wg.Wait()
-	if len(errs) == 0 {
+
+	hasError := false
+	for _, err := range errs {
+		if err != nil {
+			hasError = true
+			break
+		}
+	}
+	if !hasError {
 		logger.Infof("============>%s PRECHECK OK!", name)
 		return true
 	}
+
 	groups := make(map[string][]string)
-	for _, ne := range errs {
-		msg := ne.err.Error()
-		role := d.nodeRole(ne.host)
-		ref := fmt.Sprintf("[%s@%s]", role, ne.host)
+	var msgOrder []string
+	for i, err := range errs {
+		if err == nil {
+			continue
+		}
+		msg := err.Error()
+		host := nodes[i]
+		role := d.nodeRole(host)
+		ref := fmt.Sprintf("[%s@%s]", role, host)
 		if role == "" {
-			ref = fmt.Sprintf("[%s]", ne.host)
+			ref = fmt.Sprintf("[%s]", host)
+		}
+		if _, exists := groups[msg]; !exists {
+			msgOrder = append(msgOrder, msg)
 		}
 		groups[msg] = append(groups[msg], ref)
 	}
-	for msg, refs := range groups {
+	for _, msg := range msgOrder {
+		refs := groups[msg]
 		logger.Warnf("%s:", msg)
 		for _, ref := range refs {
 			logger.Warnf("  - %s", ref)
@@ -436,64 +435,68 @@ func (d *DeployOptions) precheckService(name string, nodes []string, fn precheck
 	return utils.AskForConfirmation()
 }
 
-type timeLagError struct {
-	host string
-	lag  float64
-}
-
 func (d *DeployOptions) precheckTimeLag() bool {
 	logger.Infof("============>TIME-LAG PRECHECK ...")
-	var lags []timeLagError
-	var mu sync.Mutex
+	type timeLagEntry struct {
+		lag float64
+		ok  bool
+	}
+	entries := make([]timeLagEntry, len(d.allNodes))
 	wg := sync.WaitGroup{}
 	now := time.Now()
 	logger.Infof("BaseLine Time: %s", now.Format(time.RFC3339))
-	for _, node := range d.allNodes {
+	for i, node := range d.allNodes {
 		wg.Add(1)
-		go func(host string) {
+		go func(idx int, host string) {
 			defer wg.Done()
 			ret, err := sshutils.SSHCmd(d.deployConfig.SSHConfig, host, "date +%s")
 			if err != nil {
 				logger.Errorf("get timestamp from %s failed: %s", host, err.Error())
-				mu.Lock()
-				lags = append(lags, timeLagError{host: host})
-				mu.Unlock()
+				entries[idx] = timeLagEntry{ok: true}
 				return
 			}
 			output := ret.StdoutToString("")
 			ts, err := strconv.ParseInt(output, 10, 64)
 			if err != nil {
 				logger.Errorf("parse timestamp from %s failed: %s", host, err.Error())
-				mu.Lock()
-				lags = append(lags, timeLagError{host: host})
-				mu.Unlock()
+				entries[idx] = timeLagEntry{ok: true}
 				return
 			}
 			t := time.Unix(ts, 0)
 			diff := t.Sub(now).Seconds()
 			logger.Infof("[%s] %v seconds", host, diff)
 			if math.Abs(diff) > float64(5) {
-				mu.Lock()
-				lags = append(lags, timeLagError{host: host, lag: diff})
-				mu.Unlock()
+				entries[idx] = timeLagEntry{lag: diff, ok: true}
 			}
-		}(node)
+		}(i, node)
 	}
 	wg.Wait()
-	if len(lags) == 0 {
+
+	hasLag := false
+	for _, e := range entries {
+		if e.ok {
+			hasLag = true
+			break
+		}
+	}
+	if !hasLag {
 		logger.Infof("all nodes time lag less then 5 seconds")
 		logger.Infof("============>TIME-LAG PRECHECK OK!")
 		return true
 	}
 	logger.Warnf("time lag exceeds 5s threshold:")
-	for _, lag := range lags {
-		role := d.nodeRole(lag.host)
-		ref := fmt.Sprintf("[%s@%s]", role, lag.host)
-		if role == "" {
-			ref = fmt.Sprintf("[%s]", lag.host)
+	for i, e := range entries {
+		if !e.ok {
+			continue
 		}
-		if lag.lag != 0 {
-			logger.Warnf("  - %s %.1fs", ref, lag.lag)
+		host := d.allNodes[i]
+		role := d.nodeRole(host)
+		ref := fmt.Sprintf("[%s@%s]", role, host)
+		if role == "" {
+			ref = fmt.Sprintf("[%s]", host)
+		}
+		if e.lag != 0 {
+			logger.Warnf("  - %s %.1fs", ref, e.lag)
 		} else {
 			logger.Warnf("  - %s (failed to get time)", ref)
 		}

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -146,6 +146,33 @@ func NewDeployOptions(streams options.IOStreams) *DeployOptions {
 	}
 }
 
+func (d *DeployOptions) nodeRole(ip string) string {
+	isServer := false
+	isAgent := false
+	for _, s := range d.deployConfig.ServerIPs {
+		if s == ip {
+			isServer = true
+			break
+		}
+	}
+	for _, a := range d.deployConfig.Agents.ListIP() {
+		if a == ip {
+			isAgent = true
+			break
+		}
+	}
+	switch {
+	case isServer && isAgent:
+		return "server+agent"
+	case isServer:
+		return "server"
+	case isAgent:
+		return "agent"
+	default:
+		return ""
+	}
+}
+
 func NewCmdDeploy(streams options.IOStreams) *cobra.Command {
 	o := NewDeployOptions(streams)
 	cmd := &cobra.Command{
@@ -333,13 +360,13 @@ func precheckPortFunc(port int, serviceName string) precheckFunc {
 		if err != nil {
 			ret, err = sshutils.SSHCmdWithSudo(sshConfig, host, "netstat -tlnp")
 			if err != nil {
-				return fmt.Errorf("check port %d on %s failed: %w", port, host, err)
+				return fmt.Errorf("check port %d failed: %w", port, err)
 			}
 		}
 		output := ret.StdoutToString("")
 		if strings.Contains(output, fmt.Sprintf(":%d ", port)) ||
 			strings.Contains(output, fmt.Sprintf(":%d\t", port)) {
-			return fmt.Errorf("port %d is already in use on %s, required by %s", port, host, serviceName)
+			return fmt.Errorf("port %d is already in use, required by %s", port, serviceName)
 		}
 		return nil
 	}
@@ -359,27 +386,47 @@ func generateCommonPreCheckFunc(name string) precheckFunc {
 	}
 }
 
+type nodeError struct {
+	host string
+	err  error
+}
+
 func (d *DeployOptions) precheckService(name string, nodes []string, fn precheckFunc) bool {
 	logger.Infof("============>%s PRECHECK ...", name)
-	nodeErrChan := make(chan error, len(nodes))
-	defer close(nodeErrChan)
+	var errs []nodeError
+	var mu sync.Mutex
 	wg := sync.WaitGroup{}
 	for _, node := range nodes {
 		wg.Add(1)
 		go func(host string) {
 			defer wg.Done()
 			if err := fn(d.deployConfig.SSHConfig, host); err != nil {
-				nodeErrChan <- err
+				mu.Lock()
+				errs = append(errs, nodeError{host: host, err: err})
+				mu.Unlock()
 			}
 		}(node)
 	}
 	wg.Wait()
-	if len(nodeErrChan) == 0 {
+	if len(errs) == 0 {
 		logger.Infof("============>%s PRECHECK OK!", name)
 		return true
 	}
-	for i := 0; i < len(nodeErrChan); i++ {
-		logger.Warn(<-nodeErrChan)
+	groups := make(map[string][]string)
+	for _, ne := range errs {
+		msg := ne.err.Error()
+		role := d.nodeRole(ne.host)
+		ref := fmt.Sprintf("[%s@%s]", role, ne.host)
+		if role == "" {
+			ref = fmt.Sprintf("[%s]", ne.host)
+		}
+		groups[msg] = append(groups[msg], ref)
+	}
+	for msg, refs := range groups {
+		logger.Warnf("%s:", msg)
+		for _, ref := range refs {
+			logger.Warnf("  - %s", ref)
+		}
 	}
 	logger.Errorf("===========>%s PRECHECK FAILED!", name)
 	if options.AssumeYes {
@@ -389,10 +436,15 @@ func (d *DeployOptions) precheckService(name string, nodes []string, fn precheck
 	return utils.AskForConfirmation()
 }
 
+type timeLagError struct {
+	host string
+	lag  float64
+}
+
 func (d *DeployOptions) precheckTimeLag() bool {
 	logger.Infof("============>TIME-LAG PRECHECK ...")
-	nodeErrChan := make(chan struct{}, len(d.allNodes))
-	defer close(nodeErrChan)
+	var lags []timeLagError
+	var mu sync.Mutex
 	wg := sync.WaitGroup{}
 	now := time.Now()
 	logger.Infof("BaseLine Time: %s", now.Format(time.RFC3339))
@@ -403,29 +455,48 @@ func (d *DeployOptions) precheckTimeLag() bool {
 			ret, err := sshutils.SSHCmd(d.deployConfig.SSHConfig, host, "date +%s")
 			if err != nil {
 				logger.Errorf("get timestamp from %s failed: %s", host, err.Error())
-				nodeErrChan <- struct{}{}
+				mu.Lock()
+				lags = append(lags, timeLagError{host: host})
+				mu.Unlock()
 				return
 			}
 			output := ret.StdoutToString("")
 			ts, err := strconv.ParseInt(output, 10, 64)
 			if err != nil {
 				logger.Errorf("parse timestamp from %s failed: %s", host, err.Error())
-				nodeErrChan <- struct{}{}
+				mu.Lock()
+				lags = append(lags, timeLagError{host: host})
+				mu.Unlock()
 				return
 			}
 			t := time.Unix(ts, 0)
 			diff := t.Sub(now).Seconds()
 			logger.Infof("[%s] %v seconds", host, diff)
 			if math.Abs(diff) > float64(5) {
-				nodeErrChan <- struct{}{}
+				mu.Lock()
+				lags = append(lags, timeLagError{host: host, lag: diff})
+				mu.Unlock()
 			}
 		}(node)
 	}
 	wg.Wait()
-	if len(nodeErrChan) == 0 {
+	if len(lags) == 0 {
 		logger.Infof("all nodes time lag less then 5 seconds")
 		logger.Infof("============>TIME-LAG PRECHECK OK!")
 		return true
+	}
+	logger.Warnf("time lag exceeds 5s threshold:")
+	for _, lag := range lags {
+		role := d.nodeRole(lag.host)
+		ref := fmt.Sprintf("[%s@%s]", role, lag.host)
+		if role == "" {
+			ref = fmt.Sprintf("[%s]", lag.host)
+		}
+		if lag.lag != 0 {
+			logger.Warnf("  - %s %.1fs", ref, lag.lag)
+		} else {
+			logger.Warnf("  - %s (failed to get time)", ref)
+		}
 	}
 	logger.Errorf("===========>TIME-LAG PRECHECK FAILED!")
 	if options.AssumeYes {
@@ -448,8 +519,8 @@ func (d *DeployOptions) precheckPorts() bool {
 				mu.Lock()
 				missingToolHosts[host] = true
 				mu.Unlock()
-				return fmt.Errorf("port check tool (ss or netstat) not found on %s, "+
-					"skip port availability check, deployment may fail if port is occupied", host)
+				return fmt.Errorf("port check tool (ss or netstat) not found, " +
+					"skip port availability check, deployment may fail if port is occupied")
 			}
 		}
 		return nil

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -86,11 +86,11 @@ func TestDeployOptions_getKcConsoleTemplateContent(t *testing.T) {
 
 func TestDeployOptions_nodeRole(t *testing.T) {
 	tests := []struct {
-		name       string
-		serverIPs  []string
-		agentIPs   []string
-		queryIP    string
-		wantRole   string
+		name      string
+		serverIPs []string
+		agentIPs  []string
+		queryIP   string
+		wantRole  string
 	}{
 		{
 			name:      "server only",

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -83,3 +83,56 @@ func TestDeployOptions_getKcConsoleTemplateContent(t *testing.T) {
 
 	t.Log(d.getKcConsoleTemplateContent())
 }
+
+func TestDeployOptions_nodeRole(t *testing.T) {
+	tests := []struct {
+		name       string
+		serverIPs  []string
+		agentIPs   []string
+		queryIP    string
+		wantRole   string
+	}{
+		{
+			name:      "server only",
+			serverIPs: []string{"10.0.0.1", "10.0.0.2"},
+			agentIPs:  []string{"10.0.0.3"},
+			queryIP:   "10.0.0.1",
+			wantRole:  "server",
+		},
+		{
+			name:      "agent only",
+			serverIPs: []string{"10.0.0.1"},
+			agentIPs:  []string{"10.0.0.2", "10.0.0.3"},
+			queryIP:   "10.0.0.2",
+			wantRole:  "agent",
+		},
+		{
+			name:      "AIO node is server+agent",
+			serverIPs: []string{"10.0.0.1"},
+			agentIPs:  []string{"10.0.0.1", "10.0.0.2"},
+			queryIP:   "10.0.0.1",
+			wantRole:  "server+agent",
+		},
+		{
+			name:      "unknown IP returns empty",
+			serverIPs: []string{"10.0.0.1"},
+			agentIPs:  []string{"10.0.0.2"},
+			queryIP:   "10.0.0.99",
+			wantRole:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDeployOptions(options.IOStreams{})
+			d.deployConfig.ServerIPs = tt.serverIPs
+			d.deployConfig.Agents = make(options.Agents)
+			for _, ip := range tt.agentIPs {
+				d.deployConfig.Agents[ip] = options.Metadata{}
+			}
+			got := d.nodeRole(tt.queryIP)
+			if got != tt.wantRole {
+				t.Errorf("nodeRole(%q) = %q, want %q", tt.queryIP, got, tt.wantRole)
+			}
+		})
+	}
+}

--- a/pkg/cli/sudo/sudo.go
+++ b/pkg/cli/sudo/sudo.go
@@ -105,39 +105,24 @@ func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 		logger.Infof("============>%s PRECHECK OK!", name)
 		return true
 	}
-	var multiNICNodes []string
-	var mu sync.Mutex
-	var firstErr error
+	hasMultiNIC := make([]bool, len(allNodes))
+	errs := make([]error, len(allNodes))
 	wg := sync.WaitGroup{}
-	for _, node := range allNodes {
+	for i, node := range allNodes {
 		wg.Add(1)
-		go func(host string) {
+		go func(idx int, host string) {
 			defer wg.Done()
 			result, err := sshutils.SSHCmd(sshConfig, host, `ip a|grep ": "|awk {'print $2'}|sed 's/://'`)
 			if err != nil {
 				if strings.Contains(err.Error(), "handshake failed: ssh: unable to authenticate, attempted methods [none password]") {
-					authErr := fmt.Errorf("passwd or user error while ssh '%s@%s',please try again", sshConfig.User, host)
-					mu.Lock()
-					if firstErr == nil {
-						firstErr = authErr
-					}
-					mu.Unlock()
-					return
+					errs[idx] = fmt.Errorf("passwd or user error while ssh '%s@%s',please try again", sshConfig.User, host)
+				} else {
+					errs[idx] = err
 				}
-				mu.Lock()
-				if firstErr == nil {
-					firstErr = err
-				}
-				mu.Unlock()
 				return
 			}
 			if result.ExitCode != 0 {
-				cmdErr := fmt.Errorf("%s stderr:%s", result.Short(), result.Stderr)
-				mu.Lock()
-				if firstErr == nil {
-					firstErr = cmdErr
-				}
-				mu.Unlock()
+				errs[idx] = fmt.Errorf("%s stderr:%s", result.Short(), result.Stderr)
 				return
 			}
 			ifaces := strings.Split(result.Stdout, "\n")
@@ -146,13 +131,19 @@ func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 			})
 			rifcae := filterLogicIface(ifaces)
 			if len(rifcae) > 1 {
-				mu.Lock()
-				multiNICNodes = append(multiNICNodes, host)
-				mu.Unlock()
+				hasMultiNIC[idx] = true
 			}
-		}(node)
+		}(i, node)
 	}
 	wg.Wait()
+
+	var firstErr error
+	for _, err := range errs {
+		if err != nil {
+			firstErr = err
+			break
+		}
+	}
 
 	if firstErr != nil {
 		logger.Error(firstErr)
@@ -165,6 +156,12 @@ func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 		return utils.AskForConfirmation()
 	}
 
+	var multiNICNodes []string
+	for i, host := range allNodes {
+		if hasMultiNIC[i] {
+			multiNICNodes = append(multiNICNodes, host)
+		}
+	}
 	if len(multiNICNodes) == 0 {
 		logger.Infof("============>%s PRECHECK OK!", name)
 		return true
@@ -179,9 +176,9 @@ func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 		return true
 	}
 	logger.Errorf("===========>%s PRECHECK FAILED!", name)
-	_, _ = streams.Out.Write([]byte("node has multi nic,and --ip-detect flag not specified,default ip " +
-		"detect method is 'first-found',which maybe chose a wrong one,you can add --ip-detect flag to specify it." + "\n"))
-	_, _ = streams.Out.Write([]byte("Ignore this error, still exec cmd? Please input (yes/no)"))
+	fmt.Fprintln(streams.Out, "node has multi nic,and --ip-detect flag not specified,default ip "+
+		"detect method is 'first-found',which maybe chose a wrong one,you can add --ip-detect flag to specify it.")
+	fmt.Fprint(streams.Out, "Ignore this error, still exec cmd? Please input (yes/no)")
 	return utils.AskForConfirmation()
 }
 

--- a/pkg/cli/sudo/sudo.go
+++ b/pkg/cli/sudo/sudo.go
@@ -19,10 +19,10 @@
 package sudo
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
 	"github.com/kubeclipper/kubeclipper/pkg/cli/logger"
@@ -98,10 +98,6 @@ func PreCheck(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 	return utils.AskForConfirmation()
 }
 
-var (
-	errorMultiNIC = errors.New("node has multi nic bug not specify --ip-detect flag")
-)
-
 // MultiNIC check node has multi NIC but node specify ip-detect flag.
 func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, allNodes []string, ipDetect string) bool {
 	logger.Infof("============>%s PRECHECK ...", name)
@@ -109,47 +105,84 @@ func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 		logger.Infof("============>%s PRECHECK OK!", name)
 		return true
 	}
-	// check iface list
-	// ifconfig|grep ": "|awk {'print $1'}|sed 's/://'
-	err := sshutils.CmdBatch(sshConfig, allNodes, `ip a|grep ": "|awk {'print $2'}|sed 's/://'`, func(result sshutils.Result, err error) error {
-		if err != nil {
-			if strings.Contains(err.Error(), "handshake failed: ssh: unable to authenticate, attempted methods [none password]") {
-				return fmt.Errorf("passwd or user error while ssh '%s@%s',please try again", result.User, result.Host)
+	var multiNICNodes []string
+	var mu sync.Mutex
+	var firstErr error
+	wg := sync.WaitGroup{}
+	for _, node := range allNodes {
+		wg.Add(1)
+		go func(host string) {
+			defer wg.Done()
+			result, err := sshutils.SSHCmd(sshConfig, host, `ip a|grep ": "|awk {'print $2'}|sed 's/://'`)
+			if err != nil {
+				if strings.Contains(err.Error(), "handshake failed: ssh: unable to authenticate, attempted methods [none password]") {
+					authErr := fmt.Errorf("passwd or user error while ssh '%s@%s',please try again", sshConfig.User, host)
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = authErr
+					}
+					mu.Unlock()
+					return
+				}
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				mu.Unlock()
+				return
 			}
-			return err
-		}
-		if result.ExitCode != 0 {
-			return fmt.Errorf("%s stderr:%s", result.Short(), result.Stderr)
-		}
-		ifaces := strings.Split(result.Stdout, "\n")
-		ifaces = sliceutil.RemoveString(ifaces, func(item string) bool {
-			return item == ""
-		})
-		rifcae := filterLogicIface(ifaces)
+			if result.ExitCode != 0 {
+				cmdErr := fmt.Errorf("%s stderr:%s", result.Short(), result.Stderr)
+				mu.Lock()
+				if firstErr == nil {
+					firstErr = cmdErr
+				}
+				mu.Unlock()
+				return
+			}
+			ifaces := strings.Split(result.Stdout, "\n")
+			ifaces = sliceutil.RemoveString(ifaces, func(item string) bool {
+				return item == ""
+			})
+			rifcae := filterLogicIface(ifaces)
+			if len(rifcae) > 1 {
+				mu.Lock()
+				multiNICNodes = append(multiNICNodes, host)
+				mu.Unlock()
+			}
+		}(node)
+	}
+	wg.Wait()
 
-		if len(rifcae) > 1 {
-			return errorMultiNIC
-		}
-		return nil
-	})
-
-	if err != nil {
-		logger.Error(err)
+	if firstErr != nil {
+		logger.Error(firstErr)
 		if options.AssumeYes {
 			logger.Infof("skip this error,continue exec cmd")
 			return true
 		}
 		logger.Errorf("===========>%s PRECHECK FAILED!", name)
-		if errors.Is(err, errorMultiNIC) {
-			_, _ = streams.Out.Write([]byte("node has multi nic,and --ip-detect flag not specified,default ip " +
-				"detect method is 'first-found',which maybe chose a wrong one,you can add --ip-detect flag to specify it." + "\n"))
-		}
 		_, _ = streams.Out.Write([]byte("Ignore this error, still exec cmd? Please input (yes/no)"))
 		return utils.AskForConfirmation()
 	}
 
-	logger.Infof("============>%s PRECHECK OK!", name)
-	return true
+	if len(multiNICNodes) == 0 {
+		logger.Infof("============>%s PRECHECK OK!", name)
+		return true
+	}
+
+	logger.Warnf("node has multiple network interfaces, --ip-detect not specified (default: first-found may choose wrong interface):")
+	for _, host := range multiNICNodes {
+		logger.Warnf("  - [agent@%s]", host)
+	}
+	if options.AssumeYes {
+		logger.Infof("skip this error,continue exec cmd")
+		return true
+	}
+	logger.Errorf("===========>%s PRECHECK FAILED!", name)
+	_, _ = streams.Out.Write([]byte("node has multi nic,and --ip-detect flag not specified,default ip " +
+		"detect method is 'first-found',which maybe chose a wrong one,you can add --ip-detect flag to specify it." + "\n"))
+	_, _ = streams.Out.Write([]byte("Ignore this error, still exec cmd? Please input (yes/no)"))
+	return utils.AskForConfirmation()
 }
 
 func filterLogicIface(ifcaes []string) []string {


### PR DESCRIPTION
Refactor precheckService, precheckTimeLag, and MultiNIC to include node IP and role (server/agent) in error output. Errors from multiple nodes with the same message are now grouped and displayed together with [role@ip] references, making it easy to identify which nodes failed. Also fixes a bug where CmdBatch in MultiNIC stopped on the first error, missing other multi-NIC nodes.

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
