### PR TITLE
ci: add backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,67 @@
+name: Backport
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  backport-by-label:
+    name: Backport pull request by label
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.merged &&
+      contains(toJSON(github.event.pull_request.labels.*.name), '"backport ')
+    steps:
+      - uses: actions/checkout@v7
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v4.6.0
+        with:
+          comment_style: summary
+          merge_commits: skip
+
+  determine-comment-targets:
+    name: Determine comment backport targets
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/backport ')
+    outputs:
+      target_branches: ${{ steps.parse-comment.outputs.target_branches }}
+    steps:
+      - name: Parse target branches
+        id: parse-comment
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          branches=$(printf '%s\n' "$COMMENT_BODY" | sed -n '1s#^/backport[[:space:]]\+##p')
+          branches=$(printf '%s\n' "$branches" | tr -s '[:space:]' ' ' | sed 's/^ //; s/ $//')
+
+          if ! printf '%s\n' "$branches" | grep -Eq '^[A-Za-z0-9._/-]+( [A-Za-z0-9._/-]+)*$'; then
+            branches=''
+          fi
+
+          echo "target_branches=${branches}" >> "$GITHUB_OUTPUT"
+
+  backport-by-comment:
+    name: Backport pull request by comment
+    runs-on: ubuntu-latest
+    needs: determine-comment-targets
+    if: needs.determine-comment-targets.outputs.target_branches != ''
+    steps:
+      - uses: actions/checkout@v7
+      - name: Create backport pull requests
+        uses: korthout/backport-action@v4.6.0
+        with:
+          comment_style: summary
+          merge_commits: skip
+          source_pr_number: ${{ github.event.issue.number }}
+          target_branches: ${{ needs.determine-comment-targets.outputs.target_branches }}


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by Kubeclipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind documentation
### What this PR does / why we need it:

### Which issue(s) this PR fixes:

<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Fixes #

### Special notes for reviewers:

```
```

### Does this PR introduced a user-facing change?

<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->

```release-note
None
```

### Additional documentation, usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

```docs
None
```
