### PR TITLE
docs: add adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,9 @@
+# KubeClipper Adopters
+
+The following organizations use KubeClipper:
+
+| Organization | Usage |
+| --- | --- |
+| 99Cloud | Uses KubeClipper to develop and validate Kubernetes cluster lifecycle management capabilities. |
+
+Organizations using KubeClipper are welcome to add themselves to this list by submitting a pull request.


### PR DESCRIPTION
## Summary

- add an `ADOPTERS.md` file
- list 99Cloud as an adopter of KubeClipper
- invite other organizations to add themselves through pull requests

## Context

This supports the CNCF `.project` onboarding metadata requested in kubeclipper/.project#1.

## Testing

Documentation-only change; no tests were run.