### PR TITLE
feat: add kcctl status command

### DIFF
--- a/cmd/kcctl/app/root.go
+++ b/cmd/kcctl/app/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/cli/cluster"
 
 	"github.com/kubeclipper/kubeclipper/pkg/cli/set"
+	statuscmd "github.com/kubeclipper/kubeclipper/pkg/cli/status"
 
 	"github.com/kubeclipper/kubeclipper/pkg/cli/upgrade"
 
@@ -100,6 +101,7 @@ func NewKubeClipperCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds.AddCommand(cluster.NewCmdCluster(ioStreams))
 	cmds.AddCommand(set.NewCmdSet(ioStreams))
 	cmds.AddCommand(operation.NewCmdOperation(ioStreams))
+	cmds.AddCommand(statuscmd.NewCmdStatus(ioStreams))
 
 	return cmds
 }

--- a/cmd/kcctl/main.go
+++ b/cmd/kcctl/main.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -28,7 +29,14 @@ import (
 func main() {
 	cmds := app.NewKubeClipperCommand(os.Stdin, os.Stdout, os.Stderr)
 	if err := cmds.Execute(); err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		code := 1
+		var exitError interface{ ExitCode() int }
+		if errors.As(err, &exitError) {
+			code = exitError.ExitCode()
+		}
+		if err.Error() != "" {
+			_, _ = fmt.Fprintln(os.Stderr, err)
+		}
+		os.Exit(code)
 	}
 }

--- a/pkg/apis/config/v1/handler.go
+++ b/pkg/apis/config/v1/handler.go
@@ -19,6 +19,7 @@
 package v1
 
 import (
+	"fmt"
 	"net/http"
 
 	"k8s.io/component-base/version"
@@ -40,18 +41,34 @@ import (
 	"github.com/emicklei/go-restful"
 
 	"github.com/kubeclipper/kubeclipper/pkg/models/platform"
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
 	"github.com/kubeclipper/kubeclipper/pkg/server/restplus"
 )
 
 type handler struct {
 	platformOperator platform.Operator
 	serverConfig     *serverconfig.Config
+	statusProvider   platformstatus.Provider
 }
 
-func newHandler(operator platform.Operator, config *serverconfig.Config) *handler {
+func newHandler(operator platform.Operator, config *serverconfig.Config, statusProvider platformstatus.Provider) *handler {
 	return &handler{
 		platformOperator: operator,
 		serverConfig:     config,
+		statusProvider:   statusProvider,
+	}
+}
+
+func (h *handler) GetPlatformStatus(request *restful.Request, response *restful.Response) {
+	if h.statusProvider == nil {
+		restplus.HandleInternalError(response, request, fmt.Errorf("platform status provider is not configured"))
+		return
+	}
+	if err := response.WriteHeaderAndEntity(
+		http.StatusOK,
+		h.statusProvider.PlatformStatus(request.Request.Context()),
+	); err != nil {
+		restplus.HandleInternalError(response, request, err)
 	}
 }
 

--- a/pkg/apis/config/v1/registry.go
+++ b/pkg/apis/config/v1/registry.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kubeclipper/kubeclipper/pkg/errors"
 	"github.com/kubeclipper/kubeclipper/pkg/models/platform"
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
 
 	"github.com/kubeclipper/kubeclipper/pkg/query"
 
@@ -52,8 +53,13 @@ const (
 
 var GroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 
-func AddToContainer(c *restful.Container, platformOperator platform.Operator, config *serverconfig.Config) error {
-	h := newHandler(platformOperator, config)
+func AddToContainer(
+	c *restful.Container,
+	platformOperator platform.Operator,
+	config *serverconfig.Config,
+	statusProvider platformstatus.Provider,
+) error {
+	h := newHandler(platformOperator, config, statusProvider)
 
 	webservice := runtime.NewWebService(GroupVersion)
 	webservice.Route(webservice.GET("/oauth").
@@ -68,6 +74,12 @@ func AddToContainer(c *restful.Container, platformOperator platform.Operator, co
 		To(func(request *restful.Request, response *restful.Response) {
 			_ = response.WriteAsJson(config.ToMap())
 		}).Returns(http.StatusOK, StatusOK, map[string]bool{}))
+
+	webservice.Route(webservice.GET("/status").
+		Doc("Current KubeClipper platform status").
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreConfigTag}).
+		To(h.GetPlatformStatus).
+		Returns(http.StatusOK, StatusOK, platformstatus.PlatformStatus{}))
 
 	webservice.Route(webservice.GET("/components").
 		Doc("Information about components").

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
+)
+
+const defaultTimeout = 10 * time.Second
+
+type ExitError struct {
+	code int
+	err  error
+}
+
+func (e *ExitError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *ExitError) Unwrap() error { return e.err }
+func (e *ExitError) ExitCode() int { return e.code }
+
+type Options struct {
+	options.IOStreams
+	cliOptions *options.CliOptions
+	client     *kc.Client
+	output     string
+	timeout    time.Duration
+}
+
+func NewCmdStatus(streams options.IOStreams) *cobra.Command {
+	o := &Options{
+		IOStreams:  streams,
+		cliOptions: options.NewCliOptions(),
+		output:     "table",
+		timeout:    defaultTimeout,
+	}
+	cmd := &cobra.Command{
+		Use:          "status",
+		Short:        "Show KubeClipper platform status",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.Root().SilenceErrors = true
+			if err := o.complete(); err != nil {
+				return &ExitError{code: 2, err: err}
+			}
+			if err := o.validate(); err != nil {
+				return &ExitError{code: 2, err: err}
+			}
+			return o.run(cmd.Context())
+		},
+	}
+	o.cliOptions.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", o.output, "Output format: table, json, or yaml")
+	cmd.Flags().DurationVar(&o.timeout, "timeout", o.timeout, "Maximum time to wait for platform status")
+	return cmd
+}
+
+func (o *Options) complete() error {
+	if err := o.cliOptions.Complete(); err != nil {
+		return err
+	}
+	client, err := kc.FromConfigWithoutValidation(o.cliOptions.ToRawConfig())
+	if err != nil {
+		return err
+	}
+	o.client = client
+	return nil
+}
+
+func (o *Options) validate() error {
+	switch o.output {
+	case "table", "json", "yaml":
+	default:
+		return fmt.Errorf("unsupported output format %q", o.output)
+	}
+	if o.timeout <= 0 {
+		return fmt.Errorf("timeout must be greater than zero")
+	}
+	return nil
+}
+
+func (o *Options) run(parent context.Context) error {
+	ctx, cancel := context.WithTimeout(parent, o.timeout)
+	defer cancel()
+	result, err := o.client.PlatformStatus(ctx)
+	if err != nil {
+		return &ExitError{code: 2, err: fmt.Errorf("unable to get platform status: %w", err)}
+	}
+	if err := printStatus(o.Out, result, o.output); err != nil {
+		return &ExitError{code: 2, err: err}
+	}
+	if result.Status != platformstatus.Healthy {
+		return &ExitError{code: 1}
+	}
+	return nil
+}
+
+func printStatus(out io.Writer, result *platformstatus.PlatformStatus, output string) error {
+	switch output {
+	case "json":
+		data, err := json.MarshalIndent(result, "", "  ")
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(out, string(data))
+		return err
+	case "yaml":
+		data, err := yaml.Marshal(result)
+		if err != nil {
+			return err
+		}
+		_, err = out.Write(data)
+		return err
+	default:
+		return printTable(out, result)
+	}
+}
+
+func printTable(out io.Writer, result *platformstatus.PlatformStatus) error {
+	if _, err := fmt.Fprintf(out, "KubeClipper Platform Status: %s\n", result.Status); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "Checked At: %s\n\n", result.CheckedAt.Local().Format(time.RFC3339)); err != nil {
+		return err
+	}
+	table := tablewriter.NewWriter(out)
+	table.SetHeader([]string{"COMPONENT", "STATUS", "MESSAGE"})
+	for _, component := range result.Components {
+		table.Append([]string{component.Name, string(component.Status), component.Message})
+	}
+	table.Render()
+	return nil
+}

--- a/pkg/cli/status/status_test.go
+++ b/pkg/cli/status/status_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package status
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
+)
+
+func testStatus() *platformstatus.PlatformStatus {
+	return &platformstatus.PlatformStatus{
+		APIVersion: platformstatus.APIVersion,
+		Kind:       platformstatus.Kind,
+		Status:     platformstatus.Degraded,
+		CheckedAt:  time.Date(2026, 7, 29, 8, 30, 12, 0, time.UTC),
+		Components: []platformstatus.Component{
+			{Name: "kc-server", Status: platformstatus.Healthy, Message: "all server subsystems ready", Checks: []platformstatus.Check{{Name: "api", Status: platformstatus.Healthy, Message: "API ready"}}},
+			{Name: "kc-etcd", Status: platformstatus.Healthy, Message: "3/3 endpoints healthy"},
+			{Name: "kc-agent", Status: platformstatus.Degraded, Message: "7/8 agents running"},
+		},
+	}
+}
+
+func TestPrintTable(t *testing.T) {
+	var output bytes.Buffer
+	if err := printStatus(&output, testStatus(), "table"); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"KubeClipper Platform Status: Degraded",
+		"kc-server",
+		"kc-etcd",
+		"7/8 agents running",
+	} {
+		if !strings.Contains(output.String(), expected) {
+			t.Errorf("table output does not contain %q:\n%s", expected, output.String())
+		}
+	}
+	if strings.Contains(output.String(), "kcctl doctor") {
+		t.Fatalf("table output references an unavailable command:\n%s", output.String())
+	}
+}
+
+func TestPrintJSONPreservesChecks(t *testing.T) {
+	var output bytes.Buffer
+	if err := printStatus(&output, testStatus(), "json"); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{`"kind": "PlatformStatus"`, `"name": "api"`, `"status": "Degraded"`} {
+		if !strings.Contains(output.String(), expected) {
+			t.Errorf("JSON output does not contain %q:\n%s", expected, output.String())
+		}
+	}
+}
+
+func TestRunExitCodes(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     platformstatus.Status
+		serverBody string
+		delay      time.Duration
+		timeout    time.Duration
+		wantCode   int
+	}{
+		{name: "healthy", status: platformstatus.Healthy, wantCode: 0},
+		{name: "degraded", status: platformstatus.Degraded, wantCode: 1},
+		{name: "unhealthy", status: platformstatus.Unhealthy, wantCode: 1},
+		{name: "unknown", status: platformstatus.Unknown, wantCode: 1},
+		{name: "invalid response", serverBody: `{}`, wantCode: 2},
+		{name: "request timeout", status: platformstatus.Healthy, delay: 100 * time.Millisecond, timeout: 10 * time.Millisecond, wantCode: 2},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				if test.delay > 0 {
+					time.Sleep(test.delay)
+				}
+				writer.Header().Set("Content-Type", "application/json")
+				if test.serverBody != "" {
+					if _, err := writer.Write([]byte(test.serverBody)); err != nil {
+						t.Errorf("write response: %v", err)
+					}
+					return
+				}
+				result := statusWithOverallStatus(test.status)
+				if err := json.NewEncoder(writer).Encode(result); err != nil {
+					t.Errorf("encode response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			client, err := kc.NewClientWithOpts(kc.WithEndpoint(server.URL), kc.WithHTTPClient(server.Client()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var output bytes.Buffer
+			opts := &Options{client: client, output: "json", timeout: time.Second}
+			opts.Out = &output
+			if test.timeout > 0 {
+				opts.timeout = test.timeout
+			}
+			err = opts.run(context.Background())
+			if got := commandExitCode(err); got != test.wantCode {
+				t.Fatalf("exit code = %d, want %d (error: %v)", got, test.wantCode, err)
+			}
+		})
+	}
+}
+
+func statusWithOverallStatus(status platformstatus.Status) *platformstatus.PlatformStatus {
+	result := testStatus()
+	result.Status = status
+	result.Components = append([]platformstatus.Component(nil), result.Components...)
+	switch status {
+	case platformstatus.Healthy:
+		result.Components[2].Status = platformstatus.Healthy
+	case platformstatus.Unhealthy:
+		result.Components[2].Status = platformstatus.Unhealthy
+	case platformstatus.Unknown:
+		result.Components[2].Status = platformstatus.Unknown
+	}
+	return result
+}
+
+func commandExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+	var exitError *ExitError
+	if errors.As(err, &exitError) {
+		return exitError.ExitCode()
+	}
+	return -1
+}

--- a/pkg/controller-runtime/manager/manager.go
+++ b/pkg/controller-runtime/manager/manager.go
@@ -20,9 +20,13 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/client"
@@ -81,8 +85,11 @@ func (r RunnableFunc) Start(ctx context.Context) error {
 }
 
 const (
-	resourceLockNS   = "default"
-	resourceLockName = "nodelifecycle-controller"
+	resourceLockNS        = "default"
+	resourceLockName      = "nodelifecycle-controller"
+	readinessLeaseName    = "kc-controller-manager-ready"
+	readinessLeasePeriod  = 5 * time.Second
+	readinessLeaseTimeout = 15 * time.Second
 )
 
 type LoopFunc func()
@@ -100,6 +107,8 @@ type ControllerManager struct {
 	lock           resourcelock.Interface
 	leaderElector  *leaderelection.LeaderElector
 	leaderStopChan chan struct{}
+	identity       string
+	leaseOperator  lease.Operator
 
 	defaultWorkerLoopPeriod time.Duration
 	workerLoops             []workerLoop
@@ -156,6 +165,8 @@ func (s *ControllerManager) GetCmdDelivery() service.CmdDelivery {
 }
 
 func NewControllerManager(rc *rest.Config, storageFactory registry.SharedStorageFactory, cmdDelivery service.CmdDelivery, terminationChan *chan struct{}, setupFunc SetupFunc) (*ControllerManager, error) {
+	identity := uuid.New().String()
+	leaseOperator := lease.NewLeaseOperator(storageFactory.Leases())
 	s := &ControllerManager{
 		leaderStopChan:          make(chan struct{}, 1),
 		defaultWorkerLoopPeriod: time.Second,
@@ -164,9 +175,11 @@ func NewControllerManager(rc *rest.Config, storageFactory registry.SharedStorage
 		storageFactory:          storageFactory,
 		setupFunc:               setupFunc,
 		terminationChan:         terminationChan,
+		identity:                identity,
+		leaseOperator:           leaseOperator,
 	}
-	s.lock = leaderelect.NewLock(resourceLockNS, resourceLockName, lease.NewLeaseOperator(storageFactory.Leases()), resourcelock.ResourceLockConfig{
-		Identity:      uuid.New().String(),
+	s.lock = leaderelect.NewLock(resourceLockNS, resourceLockName, leaseOperator, resourcelock.ResourceLockConfig{
+		Identity:      identity,
 		EventRecorder: nil,
 	})
 	cs, err := clientset.NewForConfig(rc)
@@ -279,15 +292,95 @@ func (s *ControllerManager) runManager(ctx context.Context) {
 	s.runnableLock.Lock()
 	s.runnables = nil
 	s.runnableLock.Unlock()
-	// TODO: error should be caught
 	if err := s.setupFunc(s, inFactory, s.storageFactory); err != nil {
 		s.log.Error("setup controller manager failed", zap.Error(err))
+		return
 	}
 	inFactory.Start(ctx.Done())
+	if !inFactory.WaitForCacheSync(ctx) {
+		s.log.Error("controller manager informer cache sync failed")
+		return
+	}
 	s.runWorkerLoops(ctx)
 	s.runRunnables(ctx)
+	go s.runReadinessLease(ctx)
 	<-ctx.Done()
 	s.log.Debug("stop run manager...")
+}
+
+func (s *ControllerManager) Health(ctx context.Context) error {
+	leader, err := s.leaseOperator.GetLeaseWithNamespaceEx(ctx, resourceLockName, resourceLockNS, "0")
+	if err != nil {
+		return fmt.Errorf("get leader lease: %w", err)
+	}
+	ready, err := s.leaseOperator.GetLeaseWithNamespaceEx(ctx, readinessLeaseName, resourceLockNS, "0")
+	if err != nil {
+		return fmt.Errorf("get readiness lease: %w", err)
+	}
+	now := time.Now()
+	if err := validateLease(leader, now); err != nil {
+		return fmt.Errorf("leader lease: %w", err)
+	}
+	if err := validateLease(ready, now); err != nil {
+		return fmt.Errorf("readiness lease: %w", err)
+	}
+	if leader.Spec.HolderIdentity == nil || ready.Spec.HolderIdentity == nil || *leader.Spec.HolderIdentity != *ready.Spec.HolderIdentity {
+		return fmt.Errorf("leader and readiness lease holders do not match")
+	}
+	return nil
+}
+
+func validateLease(item *coordinationv1.Lease, now time.Time) error {
+	if item.Spec.RenewTime == nil || item.Spec.LeaseDurationSeconds == nil {
+		return fmt.Errorf("lease timing is incomplete")
+	}
+	expiresAt := item.Spec.RenewTime.Add(time.Duration(*item.Spec.LeaseDurationSeconds) * time.Second)
+	if !now.Before(expiresAt) {
+		return fmt.Errorf("lease expired")
+	}
+	return nil
+}
+
+func (s *ControllerManager) runReadinessLease(ctx context.Context) {
+	ticker := time.NewTicker(readinessLeasePeriod)
+	defer ticker.Stop()
+	for {
+		if err := s.renewReadinessLease(ctx); err != nil && ctx.Err() == nil {
+			s.log.Error("renew controller manager readiness lease failed", zap.Error(err))
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *ControllerManager) renewReadinessLease(ctx context.Context) error {
+	now := metav1.NewMicroTime(time.Now())
+	durationSeconds := int32(readinessLeaseTimeout / time.Second)
+	item, err := s.leaseOperator.GetLeaseWithNamespaceEx(ctx, readinessLeaseName, resourceLockNS, "0")
+	if apierrors.IsNotFound(err) {
+		item = &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{Name: readinessLeaseName, Namespace: resourceLockNS},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       &s.identity,
+				LeaseDurationSeconds: &durationSeconds,
+				AcquireTime:          &now,
+				RenewTime:            &now,
+			},
+		}
+		_, err = s.leaseOperator.CreateLease(ctx, item)
+		return err
+	}
+	if err != nil {
+		return err
+	}
+	item.Spec.HolderIdentity = &s.identity
+	item.Spec.LeaseDurationSeconds = &durationSeconds
+	item.Spec.RenewTime = &now
+	_, err = s.leaseOperator.UpdateLease(ctx, item)
+	return err
 }
 
 func (s *ControllerManager) runWorkerLoops(ctx context.Context) {

--- a/pkg/controller-runtime/manager/manager_health_test.go
+++ b/pkg/controller-runtime/manager/manager_health_test.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package manager
+
+import (
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestValidateLease(t *testing.T) {
+	now := time.Now()
+	duration := int32(15)
+	validRenewTime := metav1.NewMicroTime(now.Add(-time.Second))
+	expiredRenewTime := metav1.NewMicroTime(now.Add(-20 * time.Second))
+
+	if err := validateLease(&coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{
+		RenewTime: &validRenewTime, LeaseDurationSeconds: &duration,
+	}}, now); err != nil {
+		t.Fatalf("valid lease rejected: %v", err)
+	}
+	if err := validateLease(&coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{
+		RenewTime: &expiredRenewTime, LeaseDurationSeconds: &duration,
+	}}, now); err == nil {
+		t.Fatal("expired lease was accepted")
+	}
+}

--- a/pkg/platformstatus/types.go
+++ b/pkg/platformstatus/types.go
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package platformstatus
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+const (
+	APIVersion = "config.kubeclipper.io/v1"
+	Kind       = "PlatformStatus"
+)
+
+type Status string
+
+const (
+	Healthy   Status = "Healthy"
+	Degraded  Status = "Degraded"
+	Unhealthy Status = "Unhealthy"
+	Unknown   Status = "Unknown"
+	Skipped   Status = "Skipped"
+)
+
+type Check struct {
+	Name           string `json:"name" yaml:"name"`
+	Status         Status `json:"status" yaml:"status"`
+	Message        string `json:"message" yaml:"message"`
+	DurationMillis int64  `json:"durationMillis,omitempty" yaml:"durationMillis,omitempty"`
+}
+
+type Component struct {
+	Name           string  `json:"name" yaml:"name"`
+	Status         Status  `json:"status" yaml:"status"`
+	Message        string  `json:"message" yaml:"message"`
+	DurationMillis int64   `json:"durationMillis,omitempty" yaml:"durationMillis,omitempty"`
+	Checks         []Check `json:"checks,omitempty" yaml:"checks,omitempty"`
+}
+
+type PlatformStatus struct {
+	APIVersion     string      `json:"apiVersion" yaml:"apiVersion"`
+	Kind           string      `json:"kind" yaml:"kind"`
+	Status         Status      `json:"status" yaml:"status"`
+	CheckedAt      time.Time   `json:"checkedAt" yaml:"checkedAt"`
+	DurationMillis int64       `json:"durationMillis" yaml:"durationMillis"`
+	Components     []Component `json:"components" yaml:"components"`
+}
+
+type Provider interface {
+	PlatformStatus(ctx context.Context) *PlatformStatus
+}
+
+func New(components []Component, checkedAt time.Time, duration time.Duration) *PlatformStatus {
+	return &PlatformStatus{
+		APIVersion:     APIVersion,
+		Kind:           Kind,
+		Status:         Aggregate(components),
+		CheckedAt:      checkedAt.UTC(),
+		DurationMillis: duration.Milliseconds(),
+		Components:     components,
+	}
+}
+
+func Aggregate(components []Component) Status {
+	result := Healthy
+	for _, component := range components {
+		switch component.Status {
+		case Unhealthy:
+			return Unhealthy
+		case Degraded:
+			result = Degraded
+		case Unknown:
+			if result == Healthy {
+				result = Unknown
+			}
+		}
+	}
+	return result
+}
+
+func (s *PlatformStatus) Validate() error {
+	if s.APIVersion != APIVersion {
+		return fmt.Errorf("unexpected apiVersion %q", s.APIVersion)
+	}
+	if s.Kind != Kind {
+		return fmt.Errorf("unexpected kind %q", s.Kind)
+	}
+	if s.CheckedAt.IsZero() {
+		return fmt.Errorf("checkedAt is required")
+	}
+	if !isAggregateStatus(s.Status) {
+		return fmt.Errorf("invalid platform status %q", s.Status)
+	}
+	expectedComponents := []string{"kc-server", "kc-etcd", "kc-agent"}
+	if len(s.Components) != len(expectedComponents) {
+		return fmt.Errorf("expected %d components, got %d", len(expectedComponents), len(s.Components))
+	}
+	for i := range s.Components {
+		component := &s.Components[i]
+		if component.Name != expectedComponents[i] {
+			return fmt.Errorf("component %d is %q, expected %q", i, component.Name, expectedComponents[i])
+		}
+		if !isCheckStatus(component.Status) {
+			return fmt.Errorf("component %q has invalid status %q", component.Name, component.Status)
+		}
+		for _, check := range component.Checks {
+			if !isCheckStatus(check.Status) {
+				return fmt.Errorf("check %q has invalid status %q", check.Name, check.Status)
+			}
+		}
+	}
+	if aggregated := Aggregate(s.Components); s.Status != aggregated {
+		return fmt.Errorf("platform status %q does not match aggregate %q", s.Status, aggregated)
+	}
+	return nil
+}
+
+func isAggregateStatus(status Status) bool {
+	return status == Healthy || status == Degraded || status == Unhealthy || status == Unknown
+}
+
+func isCheckStatus(status Status) bool {
+	return isAggregateStatus(status) || status == Skipped
+}

--- a/pkg/platformstatus/types_test.go
+++ b/pkg/platformstatus/types_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package platformstatus
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAggregate(t *testing.T) {
+	tests := []struct {
+		name       string
+		components []Component
+		want       Status
+	}{
+		{name: "healthy", components: []Component{{Status: Healthy}, {Status: Skipped}}, want: Healthy},
+		{name: "unknown", components: []Component{{Status: Healthy}, {Status: Unknown}}, want: Unknown},
+		{name: "degraded", components: []Component{{Status: Unknown}, {Status: Degraded}}, want: Degraded},
+		{name: "unhealthy", components: []Component{{Status: Degraded}, {Status: Unhealthy}}, want: Unhealthy},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := Aggregate(test.components); got != test.want {
+				t.Fatalf("Aggregate() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestPlatformStatusValidate(t *testing.T) {
+	valid := &PlatformStatus{
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Status:     Healthy,
+		CheckedAt:  time.Now(),
+		Components: []Component{
+			{Name: "kc-server", Status: Healthy},
+			{Name: "kc-etcd", Status: Healthy},
+			{Name: "kc-agent", Status: Skipped},
+		},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid status rejected: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*PlatformStatus)
+	}{
+		{name: "missing metadata", mutate: func(status *PlatformStatus) { status.APIVersion = "" }},
+		{name: "invalid status", mutate: func(status *PlatformStatus) { status.Status = Skipped }},
+		{name: "missing component", mutate: func(status *PlatformStatus) { status.Components = status.Components[:2] }},
+		{name: "wrong order", mutate: func(status *PlatformStatus) {
+			status.Components[0], status.Components[1] = status.Components[1], status.Components[0]
+		}},
+		{name: "aggregate mismatch", mutate: func(status *PlatformStatus) { status.Components[1].Status = Unhealthy }},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status := *valid
+			status.Components = append([]Component(nil), valid.Components...)
+			test.mutate(&status)
+			if err := status.Validate(); err == nil {
+				t.Fatal("invalid status was accepted")
+			}
+		})
+	}
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -878,7 +878,7 @@ var Roles = GlobalRoleList{
 			},
 			{
 				APIGroups: []string{"config.kubeclipper.io"},
-				Resources: []string{"configz", "components", "componentmeta"},
+				Resources: []string{"configz", "components", "componentmeta", "status"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	authx509 "github.com/kubeclipper/kubeclipper/pkg/authentication/request/x509"
@@ -30,6 +31,7 @@ import (
 	"github.com/emicklei/go-restful"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	unionauth "k8s.io/apiserver/pkg/authentication/request/union"
 	etcdRESTOptions "k8s.io/apiserver/pkg/server/options"
@@ -86,6 +88,14 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/utils/metrics"
 )
 
+const (
+	authenticatedRoleName = "authenticated"
+	statusResourceName    = "status"
+	getVerb               = "get"
+	listVerb              = "list"
+	watchVerb             = "watch"
+)
+
 type APIServer struct {
 	Server                *http.Server
 	container             *restful.Container
@@ -99,6 +109,11 @@ type APIServer struct {
 	internalInformerUser  string
 	InternalInformerToken string
 	terminationChan       chan struct{}
+	clusterOperator       cluster.Operator
+	leaseOperator         lease.Operator
+	deliveryService       *delivery.Service
+	controllerManager     *manager.ControllerManager
+	staticResourceService *staticresource.Service
 }
 
 func (s *APIServer) PrepareRun(stopCh <-chan struct{}) error {
@@ -263,18 +278,21 @@ func (s *APIServer) installAPIs(stopCh <-chan struct{}) error {
 		s.storageFactory.CloudProvider(),
 		s.storageFactory.Registry(),
 	)
+	s.clusterOperator = clusterOperator
 	coreOperator := core.NewOperator(s.storageFactory.ConfigMaps())
 	leaseOperator := lease.NewLeaseOperator(s.storageFactory.Leases())
+	s.leaseOperator = leaseOperator
 	opOperator := operation.NewOperationOperator(s.storageFactory.Operations())
 	iamOperator := iam.NewOperator(s.storageFactory.Users(), s.storageFactory.GlobalRoles(),
 		s.storageFactory.GlobalRoleBindings(), s.storageFactory.Tokens(), s.storageFactory.LoginRecords())
 	s.rbacAuthorizer = rbac.NewAuthorizer(iamOperator, clusterOperator)
 
 	deliverySvc := delivery.NewService(s.Config.MQOptions, clusterOperator, leaseOperator, opOperator, &s.terminationChan)
+	s.deliveryService = deliverySvc
 	s.Services = append(s.Services, deliverySvc)
 
 	platformOperator := platform.NewPlatformOperator(s.storageFactory.PlatformSettings(), s.storageFactory.Events())
-	if err := configv1.AddToContainer(s.container, platformOperator, s.Config); err != nil {
+	if err := configv1.AddToContainer(s.container, platformOperator, s.Config, s); err != nil {
 		return err
 	}
 
@@ -324,6 +342,7 @@ func (s *APIServer) installAPIs(stopCh <-chan struct{}) error {
 		return err
 	}
 	s.Services = append(s.Services, ctrl)
+	s.controllerManager = ctrl
 
 	if err = corev1.AddToContainer(s.container, clusterOperator, opOperator, platformOperator,
 		leaseOperator, coreOperator, deliverySvc, tokenOperator, s.Config.GenericServerRunOptions, &s.terminationChan); err != nil {
@@ -337,6 +356,7 @@ func (s *APIServer) installAPIs(stopCh <-chan struct{}) error {
 		return err
 	}
 	s.Services = append(s.Services, staticResourceSvc)
+	s.staticResourceService = staticResourceSvc
 	return nil
 }
 
@@ -364,7 +384,35 @@ func (s *APIServer) migrateRole(operator iam.Operator) error {
 			return err
 		}
 	}
+	for i := range result.Items {
+		role := &result.Items[i]
+		if role.Name == authenticatedRoleName && ensureStatusPermission(role) {
+			if _, err := operator.UpdateRole(context.TODO(), role); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
+}
+
+func ensureStatusPermission(role *v1.GlobalRole) bool {
+	for i := range role.Rules {
+		rule := &role.Rules[i]
+		if !slices.Contains(rule.APIGroups, configv1.GroupName) || !slices.Contains(rule.Verbs, getVerb) {
+			continue
+		}
+		if slices.Contains(rule.Resources, statusResourceName) || slices.Contains(rule.Resources, rbacv1.ResourceAll) {
+			return false
+		}
+		rule.Resources = append(rule.Resources, statusResourceName)
+		return true
+	}
+	role.Rules = append(role.Rules, rbacv1.PolicyRule{
+		APIGroups: []string{configv1.GroupName},
+		Resources: []string{statusResourceName},
+		Verbs:     []string{getVerb, listVerb, watchVerb},
+	})
+	return true
 }
 
 func (s *APIServer) migrateRoleBinding(operator iam.Operator) error {

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package server
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/component-base/version"
+
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/query"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+)
+
+const (
+	nodeLeaseNamespace       = "node-lease"
+	defaultNodeLeaseDuration = 240 * time.Second
+	statusTimeout            = 8 * time.Second
+	maxEtcdHealthBodyBytes   = 1024
+	httpScheme               = "http"
+	httpsScheme              = "https"
+)
+
+func (s *APIServer) PlatformStatus(ctx context.Context) *platformstatus.PlatformStatus {
+	startedAt := time.Now()
+	ctx, cancel := context.WithTimeout(ctx, statusTimeout)
+	defer cancel()
+
+	components := make([]platformstatus.Component, 3)
+	var wg sync.WaitGroup
+	wg.Add(len(components))
+	go func() {
+		defer wg.Done()
+		components[0] = s.kcServerStatus(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		components[1] = s.kcEtcdStatus(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		components[2] = s.kcAgentStatus(ctx)
+	}()
+	wg.Wait()
+
+	return platformstatus.New(components, startedAt, time.Since(startedAt))
+}
+
+func (s *APIServer) kcServerStatus(ctx context.Context) platformstatus.Component {
+	startedAt := time.Now()
+	checks := []platformstatus.Check{
+		{
+			Name:    "api",
+			Status:  platformstatus.Healthy,
+			Message: fmt.Sprintf("API ready, version %s", version.Get().GitVersion),
+		},
+		timedCheck("controller-manager", func() (platformstatus.Status, string) {
+			if s.controllerManager == nil {
+				return platformstatus.Unknown, "controller-manager status is unavailable"
+			}
+			if err := s.controllerManager.Health(ctx); err != nil {
+				return platformstatus.Unhealthy, "active leader is not ready"
+			}
+			return platformstatus.Healthy, "active leader is ready"
+		}),
+		timedCheck("nats", func() (platformstatus.Status, string) {
+			if s.Config.MQOptions.External {
+				return platformstatus.Skipped, "embedded NATS is not enabled"
+			}
+			if s.deliveryService == nil {
+				return platformstatus.Unknown, "embedded NATS status is unavailable"
+			}
+			if err := s.deliveryService.Health(ctx); err != nil {
+				return platformstatus.Unhealthy, "embedded server or messaging path is unavailable"
+			}
+			return platformstatus.Healthy, "embedded server and messaging path ready"
+		}),
+		timedCheck("static-resource", func() (platformstatus.Status, string) {
+			if s.staticResourceService == nil {
+				return platformstatus.Unknown, "resource service status is unavailable"
+			}
+			if err := s.staticResourceService.Health(ctx); err != nil {
+				return platformstatus.Unhealthy, "resource service is unavailable"
+			}
+			return platformstatus.Healthy, "resource service available"
+		}),
+	}
+
+	component := platformstatus.Component{
+		Name:           "kc-server",
+		DurationMillis: time.Since(startedAt).Milliseconds(),
+		Checks:         checks,
+	}
+	component.Status, component.Message = aggregateServerChecks(checks)
+	return component
+}
+
+func aggregateServerChecks(checks []platformstatus.Check) (status platformstatus.Status, message string) {
+	failed := make([]platformstatus.Check, 0, len(checks))
+	status = platformstatus.Healthy
+	for _, check := range checks {
+		if check.Status == platformstatus.Healthy || check.Status == platformstatus.Skipped {
+			continue
+		}
+		failed = append(failed, check)
+		if check.Name == "static-resource" {
+			if status == platformstatus.Healthy {
+				status = platformstatus.Degraded
+			}
+		} else {
+			status = platformstatus.Unhealthy
+		}
+	}
+	switch len(failed) {
+	case 0:
+		return platformstatus.Healthy, "all server subsystems ready"
+	case 1:
+		return status, failed[0].Message
+	default:
+		return status, fmt.Sprintf("%d/%d subsystems unhealthy", len(failed), len(checks))
+	}
+}
+
+func (s *APIServer) kcEtcdStatus(ctx context.Context) platformstatus.Component {
+	startedAt := time.Now()
+	component := platformstatus.Component{Name: "kc-etcd"}
+	endpoints := s.Config.EtcdOptions.ServerList
+	if len(endpoints) == 0 {
+		component.Status = platformstatus.Unknown
+		component.Message = "no endpoints configured"
+		return component
+	}
+
+	client, err := s.etcdHealthClient()
+	if err != nil {
+		component.Status = platformstatus.Unhealthy
+		component.Message = "health client configuration is invalid"
+		return component
+	}
+
+	var wg sync.WaitGroup
+	results := make(chan bool, len(endpoints))
+	for _, endpoint := range endpoints {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			healthURL, requestErr := etcdHealthURL(endpoint, s.etcdUsesTLS())
+			if requestErr != nil {
+				results <- false
+				return
+			}
+			request, requestErr := http.NewRequestWithContext(ctx, http.MethodGet, healthURL, http.NoBody)
+			if requestErr != nil {
+				results <- false
+				return
+			}
+			results <- etcdEndpointHealthy(client, request)
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	healthy := 0
+	for result := range results {
+		if result {
+			healthy++
+		}
+	}
+	component.DurationMillis = time.Since(startedAt).Milliseconds()
+	component.Status, component.Message = aggregateCount(healthy, len(endpoints), "endpoints healthy", false)
+	return component
+}
+
+func etcdEndpointHealthy(client *http.Client, request *http.Request) bool {
+	response, err := client.Do(request)
+	if err != nil {
+		return false
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return false
+	}
+	var result struct {
+		Health json.RawMessage `json:"health"`
+	}
+	if decodeErr := json.NewDecoder(io.LimitReader(response.Body, maxEtcdHealthBodyBytes)).Decode(&result); decodeErr != nil {
+		return false
+	}
+	healthy, err := strconv.ParseBool(strings.Trim(string(result.Health), `"`))
+	return err == nil && healthy
+}
+
+func (s *APIServer) etcdUsesTLS() bool {
+	options := s.Config.EtcdOptions
+	return options.TrustedCAFile != "" || options.CertFile != "" || options.KeyFile != ""
+}
+
+func etcdHealthURL(endpoint string, useTLS bool) (string, error) {
+	endpoint = strings.TrimSpace(endpoint)
+	if endpoint == "" {
+		return "", fmt.Errorf("etcd endpoint is empty")
+	}
+	if !strings.Contains(endpoint, "://") {
+		scheme := httpScheme
+		if useTLS {
+			scheme = httpsScheme
+		}
+		endpoint = scheme + "://" + endpoint
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("parse etcd endpoint: %w", err)
+	}
+	if (parsed.Scheme != httpScheme && parsed.Scheme != httpsScheme) || parsed.Host == "" {
+		return "", fmt.Errorf("invalid etcd endpoint %q", endpoint)
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/health"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func (s *APIServer) etcdHealthClient() (*http.Client, error) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+	if s.Config.EtcdOptions.TrustedCAFile != "" {
+		caData, err := os.ReadFile(s.Config.EtcdOptions.TrustedCAFile)
+		if err != nil {
+			return nil, err
+		}
+		pool := x509.NewCertPool()
+		if !pool.AppendCertsFromPEM(caData) {
+			return nil, fmt.Errorf("parse etcd CA certificate")
+		}
+		tlsConfig.RootCAs = pool
+	}
+	if s.Config.EtcdOptions.CertFile != "" || s.Config.EtcdOptions.KeyFile != "" {
+		certificate, err := tls.LoadX509KeyPair(s.Config.EtcdOptions.CertFile, s.Config.EtcdOptions.KeyFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig.Certificates = []tls.Certificate{certificate}
+	}
+	return &http.Client{Transport: &http.Transport{TLSClientConfig: tlsConfig}}, nil
+}
+
+func (s *APIServer) kcAgentStatus(ctx context.Context) platformstatus.Component {
+	startedAt := time.Now()
+	component := platformstatus.Component{Name: "kc-agent"}
+	if s.clusterOperator == nil || s.leaseOperator == nil {
+		component.Status = platformstatus.Unknown
+		component.Message = "agent status is unavailable"
+		return component
+	}
+
+	nodes, err := s.clusterOperator.ListNodes(ctx, query.New())
+	if err != nil {
+		component.Status = platformstatus.Unknown
+		component.Message = "unable to list registered agents"
+		return component
+	}
+	leases, err := s.leaseOperator.ListLeases(ctx, query.New())
+	if err != nil {
+		component.Status = platformstatus.Unknown
+		component.Message = "unable to read agent heartbeats"
+		return component
+	}
+
+	total, running := countRunningAgents(nodes, leases, time.Now())
+
+	component.DurationMillis = time.Since(startedAt).Milliseconds()
+	component.Status, component.Message = aggregateCount(running, total, "agents running", true)
+	return component
+}
+
+func countRunningAgents(nodes *corev1.NodeList, leases *coordinationv1.LeaseList, now time.Time) (total, running int) {
+	leaseByNode := make(map[string]time.Time, len(leases.Items))
+	for i := range leases.Items {
+		item := &leases.Items[i]
+		if item.Namespace != nodeLeaseNamespace || item.Spec.RenewTime == nil {
+			continue
+		}
+		duration := defaultNodeLeaseDuration
+		if item.Spec.LeaseDurationSeconds != nil {
+			duration = time.Duration(*item.Spec.LeaseDurationSeconds) * time.Second
+		}
+		leaseByNode[item.Name] = item.Spec.RenewTime.Add(duration)
+	}
+
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		if _, disabled := node.Labels[common.LabelNodeDisable]; disabled {
+			continue
+		}
+		total++
+		if expiresAt, found := leaseByNode[node.Name]; found && now.Before(expiresAt) {
+			running++
+		}
+	}
+	return total, running
+}
+
+func aggregateCount(
+	healthy, total int,
+	messageSuffix string,
+	skipWhenEmpty bool,
+) (status platformstatus.Status, message string) {
+	if total == 0 {
+		if skipWhenEmpty {
+			return platformstatus.Skipped, "no agents registered"
+		}
+		return platformstatus.Unknown, "no endpoints configured"
+	}
+	message = fmt.Sprintf("%d/%d %s", healthy, total, messageSuffix)
+	switch healthy {
+	case total:
+		return platformstatus.Healthy, message
+	case 0:
+		return platformstatus.Unhealthy, message
+	default:
+		return platformstatus.Degraded, message
+	}
+}
+
+func timedCheck(name string, check func() (platformstatus.Status, string)) platformstatus.Check {
+	startedAt := time.Now()
+	status, message := check()
+	return platformstatus.Check{
+		Name:           name,
+		Status:         status,
+		Message:        message,
+		DurationMillis: time.Since(startedAt).Milliseconds(),
+	}
+}

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	iamv1 "github.com/kubeclipper/kubeclipper/pkg/scheme/iam/v1"
+)
+
+func TestEtcdEndpointHealthy(t *testing.T) {
+	tests := []struct {
+		name string
+		code int
+		body string
+		want bool
+	}{
+		{name: "string true", code: http.StatusOK, body: `{"health":"true"}`, want: true},
+		{name: "boolean true", code: http.StatusOK, body: `{"health":true}`, want: true},
+		{name: "reported unhealthy", code: http.StatusOK, body: `{"health":"false"}`},
+		{name: "invalid response", code: http.StatusOK, body: `ok`},
+		{name: "http failure", code: http.StatusServiceUnavailable, body: `{"health":"true"}`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+				writer.WriteHeader(test.code)
+				if _, err := writer.Write([]byte(test.body)); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer server.Close()
+			request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL+"/health", http.NoBody)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := etcdEndpointHealthy(server.Client(), request); got != test.want {
+				t.Fatalf("etcdEndpointHealthy() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestEtcdHealthURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		useTLS   bool
+		want     string
+		wantErr  bool
+	}{
+		{name: "deployment endpoint with TLS", endpoint: "172.16.131.146:12379", useTLS: true, want: "https://172.16.131.146:12379/health"},
+		{name: "deployment endpoint without TLS", endpoint: "127.0.0.1:2379", want: "http://127.0.0.1:2379/health"},
+		{name: "explicit scheme", endpoint: "https://etcd.example:2379/", want: "https://etcd.example:2379/health"},
+		{name: "empty endpoint", wantErr: true},
+		{name: "unsupported scheme", endpoint: "grpc://127.0.0.1:2379", wantErr: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := etcdHealthURL(test.endpoint, test.useTLS)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("etcdHealthURL() error = %v, wantErr %v", err, test.wantErr)
+			}
+			if got != test.want {
+				t.Fatalf("etcdHealthURL() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCountRunningAgents(t *testing.T) {
+	now := time.Now()
+	duration := int32(240)
+	fresh := metav1.NewMicroTime(now.Add(-time.Minute))
+	expired := metav1.NewMicroTime(now.Add(-10 * time.Minute))
+	nodes := &corev1.NodeList{Items: []corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "fresh"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "expired"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "missing"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "disabled", Labels: map[string]string{common.LabelNodeDisable: "true"}}},
+	}}
+	leases := &coordinationv1.LeaseList{Items: []coordinationv1.Lease{
+		{ObjectMeta: metav1.ObjectMeta{Name: "fresh", Namespace: nodeLeaseNamespace}, Spec: coordinationv1.LeaseSpec{RenewTime: &fresh, LeaseDurationSeconds: &duration}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "expired", Namespace: nodeLeaseNamespace}, Spec: coordinationv1.LeaseSpec{RenewTime: &expired, LeaseDurationSeconds: &duration}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "disabled", Namespace: nodeLeaseNamespace}, Spec: coordinationv1.LeaseSpec{RenewTime: &fresh, LeaseDurationSeconds: &duration}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "wrong-namespace", Namespace: "default"}, Spec: coordinationv1.LeaseSpec{RenewTime: &fresh, LeaseDurationSeconds: &duration}},
+	}}
+	total, running := countRunningAgents(nodes, leases, now)
+	if total != 3 || running != 1 {
+		t.Fatalf("countRunningAgents() = (%d, %d), want (3, 1)", total, running)
+	}
+}
+
+func TestAggregateServerChecks(t *testing.T) {
+	tests := []struct {
+		name       string
+		checks     []platformstatus.Check
+		wantStatus platformstatus.Status
+		wantMsg    string
+	}{
+		{name: "healthy with skipped NATS", checks: []platformstatus.Check{
+			{Name: "api", Status: platformstatus.Healthy},
+			{Name: "controller-manager", Status: platformstatus.Healthy},
+			{Name: "nats", Status: platformstatus.Skipped},
+			{Name: "static-resource", Status: platformstatus.Healthy},
+		}, wantStatus: platformstatus.Healthy, wantMsg: "all server subsystems ready"},
+		{name: "static resource degraded", checks: []platformstatus.Check{
+			{Name: "api", Status: platformstatus.Healthy},
+			{Name: "static-resource", Status: platformstatus.Unhealthy, Message: "resource service is unavailable"},
+		}, wantStatus: platformstatus.Degraded, wantMsg: "resource service is unavailable"},
+		{name: "core subsystem unhealthy", checks: []platformstatus.Check{
+			{Name: "api", Status: platformstatus.Healthy},
+			{Name: "nats", Status: platformstatus.Unhealthy, Message: "embedded NATS is unavailable"},
+		}, wantStatus: platformstatus.Unhealthy, wantMsg: "embedded NATS is unavailable"},
+		{name: "multiple failures", checks: []platformstatus.Check{
+			{Name: "api", Status: platformstatus.Healthy},
+			{Name: "controller-manager", Status: platformstatus.Unhealthy},
+			{Name: "nats", Status: platformstatus.Unhealthy},
+			{Name: "static-resource", Status: platformstatus.Healthy},
+		}, wantStatus: platformstatus.Unhealthy, wantMsg: "2/4 subsystems unhealthy"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := aggregateServerChecks(test.checks)
+			if status != test.wantStatus || message != test.wantMsg {
+				t.Fatalf("aggregateServerChecks() = (%q, %q), want (%q, %q)", status, message, test.wantStatus, test.wantMsg)
+			}
+		})
+	}
+}
+
+func TestAggregateCount(t *testing.T) {
+	tests := []struct {
+		name       string
+		healthy    int
+		total      int
+		suffix     string
+		skipEmpty  bool
+		wantStatus platformstatus.Status
+		wantMsg    string
+	}{
+		{name: "all etcd endpoints", healthy: 3, total: 3, suffix: "endpoints healthy", wantStatus: platformstatus.Healthy, wantMsg: "3/3 endpoints healthy"},
+		{name: "some etcd endpoints", healthy: 2, total: 3, suffix: "endpoints healthy", wantStatus: platformstatus.Degraded, wantMsg: "2/3 endpoints healthy"},
+		{name: "no etcd endpoints healthy", total: 3, suffix: "endpoints healthy", wantStatus: platformstatus.Unhealthy, wantMsg: "0/3 endpoints healthy"},
+		{name: "all agents lost", total: 8, suffix: "agents running", skipEmpty: true, wantStatus: platformstatus.Unhealthy, wantMsg: "0/8 agents running"},
+		{name: "no agents", suffix: "agents running", skipEmpty: true, wantStatus: platformstatus.Skipped, wantMsg: "no agents registered"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := aggregateCount(test.healthy, test.total, test.suffix, test.skipEmpty)
+			if status != test.wantStatus || message != test.wantMsg {
+				t.Fatalf("aggregateCount() = (%q, %q), want (%q, %q)", status, message, test.wantStatus, test.wantMsg)
+			}
+		})
+	}
+}
+
+func TestEnsureStatusPermission(t *testing.T) {
+	role := &iamv1.GlobalRole{Rules: []rbacv1.PolicyRule{{
+		APIGroups: []string{"config.kubeclipper.io"},
+		Resources: []string{"configz", "components"},
+		Verbs:     []string{"get", "list", "watch"},
+	}}}
+	if changed := ensureStatusPermission(role); !changed {
+		t.Fatal("expected role to be updated")
+	}
+	if !slices.Contains(role.Rules[0].Resources, statusResourceName) {
+		t.Fatal("status permission was not added")
+	}
+	if changed := ensureStatusPermission(role); changed {
+		t.Fatal("permission update is not idempotent")
+	}
+}

--- a/pkg/service/delivery/delivery.go
+++ b/pkg/service/delivery/delivery.go
@@ -138,6 +138,13 @@ func (s *Service) Close() {
 	s.client.Close()
 }
 
+func (s *Service) Health(ctx context.Context) error {
+	if s.external {
+		return fmt.Errorf("embedded NATS is not enabled")
+	}
+	return s.client.Health(ctx)
+}
+
 func initPayload(operationIdentity string, operation service.Operation, step *v1.Step, lastStepReply []byte, cmds []string, dryRun, retry bool) ([]byte, error) {
 	payload := service.MsgPayload{
 		Op:                operation,

--- a/pkg/service/delivery/handler.go
+++ b/pkg/service/delivery/handler.go
@@ -21,12 +21,14 @@ package delivery
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubeclipper/kubeclipper/pkg/errors"
 	"github.com/kubeclipper/kubeclipper/pkg/logger"
@@ -259,8 +261,8 @@ func (s *Service) getNode(name string) (*v1.Node, error) {
 
 func (s *Service) UpdateNodeLeaseOperation(msg *nats.Msg, data []byte) *service.CommonReply {
 	resp := &service.CommonReply{}
-	lease := &coordinationv1.Lease{}
-	if err := json.Unmarshal(data, lease); err != nil {
+	requestedLease := &coordinationv1.Lease{}
+	if err := json.Unmarshal(data, requestedLease); err != nil {
 		logger.Error("failed to unmarshal payload", zap.Error(err))
 		resp.Error = &errors.StatusError{
 			Message: "unmarshal payload error with operation update node lease",
@@ -281,7 +283,7 @@ func (s *Service) UpdateNodeLeaseOperation(msg *nats.Msg, data []byte) *service.
 		}
 		return resp
 	}
-	lease, err := s.leaseOperator.GetLeaseWithNamespaceEx(context.TODO(), lease.Name, lease.Namespace, "0")
+	lease, err := s.leaseOperator.GetLeaseWithNamespaceEx(context.TODO(), requestedLease.Name, requestedLease.Namespace, "0")
 	if err != nil {
 		logger.Error("failed to get node lease", zap.Error(err))
 		resp.Error = &errors.StatusError{
@@ -306,6 +308,7 @@ func (s *Service) UpdateNodeLeaseOperation(msg *nats.Msg, data []byte) *service.
 		}
 		return resp
 	}
+	applyNodeLeaseRenewal(lease, requestedLease, time.Now())
 	leaseUpdated, err := s.leaseOperator.UpdateLease(context.TODO(), lease)
 	if err != nil {
 		logger.Error("failed to update node lease", zap.Error(err))
@@ -352,6 +355,13 @@ func (s *Service) UpdateNodeLeaseOperation(msg *nats.Msg, data []byte) *service.
 		}
 	}
 	return resp
+}
+
+func applyNodeLeaseRenewal(stored, requested *coordinationv1.Lease, now time.Time) {
+	renewTime := metav1.NewMicroTime(now)
+	stored.Spec.RenewTime = &renewTime
+	stored.Spec.HolderIdentity = requested.Spec.HolderIdentity
+	stored.Spec.LeaseDurationSeconds = requested.Spec.LeaseDurationSeconds
 }
 
 func (s *Service) getNodeLeaseOperation(msg *nats.Msg, name string, namespace string) *service.CommonReply {
@@ -426,6 +436,8 @@ func (s *Service) createNodeLeaseOperation(msg *nats.Msg, data []byte) *service.
 		}
 		return resp
 	}
+	now := metav1.NewMicroTime(time.Now())
+	lease.Spec.RenewTime = &now
 	leaseCreated, err := s.leaseOperator.CreateLease(context.TODO(), lease)
 	if err != nil {
 		resp.Error = &errors.StatusError{

--- a/pkg/service/delivery/handler_lease_test.go
+++ b/pkg/service/delivery/handler_lease_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package delivery
+
+import (
+	"testing"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestApplyNodeLeaseRenewal(t *testing.T) {
+	oldTime := metav1.NewMicroTime(time.Unix(1, 0))
+	stored := &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{RenewTime: &oldTime}}
+	holder := "node-1"
+	duration := int32(240)
+	requested := &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{
+		HolderIdentity: &holder, LeaseDurationSeconds: &duration,
+	}}
+	now := time.Unix(100, 0)
+
+	applyNodeLeaseRenewal(stored, requested, now)
+	if stored.Spec.RenewTime == nil || !stored.Spec.RenewTime.Time.Equal(now) {
+		t.Fatalf("renew time = %v, want %v", stored.Spec.RenewTime, now)
+	}
+	if stored.Spec.HolderIdentity == nil || *stored.Spec.HolderIdentity != holder {
+		t.Fatalf("holder identity was not copied")
+	}
+	if stored.Spec.LeaseDurationSeconds == nil || *stored.Spec.LeaseDurationSeconds != duration {
+		t.Fatalf("lease duration was not copied")
+	}
+}

--- a/pkg/service/staticresource/static_resource.go
+++ b/pkg/service/staticresource/static_resource.go
@@ -22,8 +22,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"sync/atomic"
 
 	"go.uber.org/zap"
 
@@ -34,12 +36,16 @@ import (
 
 var _ service.Interface = (*Service)(nil)
 
+const resourceDirectoryMode = os.FileMode(0755)
+
 type Service struct {
-	server *http.Server
-	path   string
+	server  *http.Server
+	path    string
+	secure  bool
+	running atomic.Bool
 }
 
-func NewService(opts *staticserver.Options) (service.Interface, error) {
+func NewService(opts *staticserver.Options) (*Service, error) {
 	httpSrv := &http.Server{
 		Addr: fmt.Sprintf("%s:%d", opts.BindAddress, opts.InsecurePort),
 	}
@@ -48,42 +54,120 @@ func NewService(opts *staticserver.Options) (service.Interface, error) {
 		if err != nil {
 			return nil, err
 		}
-		httpSrv.TLSConfig.Certificates = []tls.Certificate{certificate}
+		httpSrv.TLSConfig = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{certificate},
+		}
 		httpSrv.Addr = fmt.Sprintf("%s:%d", opts.BindAddress, opts.SecurePort)
 	}
 	return &Service{
 		server: httpSrv,
 		path:   opts.Path,
+		secure: opts.SecurePort != 0,
 	}, nil
 }
 
 func (s *Service) PrepareRun(stopCh <-chan struct{}) error {
-	if _, err := os.Stat(s.path); os.IsNotExist(err) {
-		return os.MkdirAll(s.path, os.ModeDir|0755)
+	if _, err := os.Stat(s.path); err != nil {
+		if os.IsNotExist(err) {
+			if mkdirErr := os.MkdirAll(s.path, os.ModeDir|resourceDirectoryMode); mkdirErr != nil {
+				return mkdirErr
+			}
+		} else {
+			return err
+		}
 	}
-	s.server.Handler = http.StripPrefix("/", http.FileServer(http.Dir(s.path)))
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealth)
+	mux.Handle("/", http.StripPrefix("/", http.FileServer(http.Dir(s.path))))
+	s.server.Handler = mux
 	return nil
 }
 
 func (s *Service) Run(stopCh <-chan struct{}) error {
 	logger.Info("Static resource server start", zap.String("addr", s.server.Addr), zap.String("path", s.path))
+	var listenConfig net.ListenConfig
+	listener, err := listenConfig.Listen(context.Background(), "tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+	s.server.Addr = listener.Addr().String()
+	s.running.Store(true)
 	go func() {
 		<-stopCh
 		_ = s.server.Shutdown(context.TODO())
 	}()
 	go func() {
-		var err error
-		if s.server.TLSConfig != nil {
-			err = s.server.ListenAndServeTLS("", "")
+		var serveErr error
+		if s.secure {
+			serveErr = s.server.ServeTLS(listener, "", "")
 		} else {
-			err = s.server.ListenAndServe()
+			serveErr = s.server.Serve(listener)
 		}
-		logger.Error("static resource server exit", zap.Error(err))
+		s.running.Store(false)
+		if serveErr != nil && serveErr != http.ErrServerClosed {
+			logger.Error("static resource server exit", zap.Error(serveErr))
+		}
 	}()
 
 	return nil
 }
 
 func (s *Service) Close() {
-	s.server.Close()
+	s.running.Store(false)
+	_ = s.server.Close()
+}
+
+func (s *Service) handleHealth(writer http.ResponseWriter, _ *http.Request) {
+	if !s.running.Load() {
+		http.Error(writer, "static resource server is not running", http.StatusServiceUnavailable)
+		return
+	}
+	info, err := os.Stat(s.path)
+	if err != nil || !info.IsDir() {
+		http.Error(writer, "static resource directory is unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	dir, err := os.Open(s.path)
+	if err != nil {
+		http.Error(writer, "static resource directory is unreadable", http.StatusServiceUnavailable)
+		return
+	}
+	_ = dir.Close()
+	writer.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	if _, err := writer.Write([]byte("ok")); err != nil {
+		logger.Error("write static resource health response", zap.Error(err))
+	}
+}
+
+func (s *Service) Health(ctx context.Context) error {
+	host, port, err := net.SplitHostPort(s.server.Addr)
+	if err != nil {
+		return err
+	}
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "127.0.0.1"
+	}
+	scheme := "http"
+	transport := http.DefaultTransport
+	if s.secure {
+		scheme = "https"
+		// The request only reaches this process through its listener address, which may not match the certificate host.
+		//nolint:gosec // TLS authenticity is established by the in-process listener, not a remote endpoint.
+		transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("%s://%s/healthz", scheme, net.JoinHostPort(host, port)), http.NoBody)
+	if err != nil {
+		return err
+	}
+	response, err := (&http.Client{Transport: transport}).Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("static resource health endpoint returned %s", response.Status)
+	}
+	return nil
 }

--- a/pkg/service/staticresource/static_resource_test.go
+++ b/pkg/service/staticresource/static_resource_test.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package staticresource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kubeclipper/kubeclipper/pkg/simple/staticserver"
+)
+
+func TestHealth(t *testing.T) {
+	service, err := NewService(&staticserver.Options{
+		BindAddress:  "127.0.0.1",
+		InsecurePort: 0,
+		Path:         t.TempDir(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopCh := make(chan struct{})
+	if err := service.PrepareRun(stopCh); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Run(stopCh); err != nil {
+		t.Fatal(err)
+	}
+	defer close(stopCh)
+	if err := service.Health(context.Background()); err != nil {
+		t.Fatalf("health check failed: %v", err)
+	}
+}

--- a/pkg/simple/client/kc/api.go
+++ b/pkg/simple/client/kc/api.go
@@ -28,6 +28,7 @@ import (
 
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/apis/core/v1"
 	"github.com/kubeclipper/kubeclipper/pkg/clusteroperation"
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
 
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	iamv1 "github.com/kubeclipper/kubeclipper/pkg/scheme/iam/v1"
@@ -46,6 +47,7 @@ const (
 	publicKeyPath        = "/api/config.kubeclipper.io/v1/terminal.key"
 	versionPath          = "/version"
 	componentMetaPath    = "/api/config.kubeclipper.io/v1/componentmeta"
+	platformStatusPath   = "/api/config.kubeclipper.io/v1/status"
 	configmapPath        = "/api/core.kubeclipper.io/v1/configmaps"
 	templatePath         = "/api/core.kubeclipper.io/v1/templates"
 	registryPath         = "/api/core.kubeclipper.io/v1/registries"
@@ -55,6 +57,22 @@ const (
 	operationPath = "/api/core.kubeclipper.io/v1/operations"
 	LogStreamPath = "/api/core.kubeclipper.io/v1/logs"
 )
+
+func (cli *Client) PlatformStatus(ctx context.Context) (*platformstatus.PlatformStatus, error) {
+	serverResp, err := cli.get(ctx, platformStatusPath, nil, nil)
+	defer ensureReaderClosed(serverResp)
+	if err != nil {
+		return nil, err
+	}
+	result := &platformstatus.PlatformStatus{}
+	if err := json.NewDecoder(serverResp.body).Decode(result); err != nil {
+		return nil, err
+	}
+	if err := result.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid platform status response: %w", err)
+	}
+	return result, nil
+}
 
 func (cli *Client) ListNodes(ctx context.Context, query Queries) (*NodesList, error) {
 	serverResp, err := cli.get(ctx, ListNodesPath, query.ToRawQuery(), nil)

--- a/pkg/simple/client/kc/client.go
+++ b/pkg/simple/client/kc/client.go
@@ -51,13 +51,60 @@ type Client struct {
 }
 
 func FromConfig(c config.Config) (*Client, error) {
-	ctx := c.Contexts[c.CurrentContext]
-	currentServer := c.Servers[ctx.Server]
-	currentAuthInfo := c.AuthInfos[ctx.AuthInfo]
-	var opts []Opt
-	opts = append(opts,
-		WithEndpoint(c.Servers[ctx.Server].Server),
-		WithBearerAuth(c.AuthInfos[ctx.AuthInfo].Token))
+	cli, err := FromConfigWithoutValidation(c)
+	if err != nil {
+		return nil, err
+	}
+
+	// call api to check whether the token is valid
+	q := query.New()
+	if _, err = cli.ListConfigMaps(context.TODO(), Queries(*q)); err != nil {
+		if strings.Contains(err.Error(), "Unauthorized") {
+			return nil, errors.New("unauthorized,please use kcctl login cmd to login first")
+		}
+		return nil, err
+	}
+	return cli, nil
+}
+
+// FromConfigWithoutValidation creates a client without making a preliminary API request.
+// Diagnostic commands use it so they can report a partially unavailable platform.
+func FromConfigWithoutValidation(c config.Config) (*Client, error) {
+	currentServer, currentAuthInfo, err := currentConnectionConfig(c)
+	if err != nil {
+		return nil, err
+	}
+	opts, err := serverClientOptions(currentServer)
+	if err != nil {
+		return nil, err
+	}
+	authOpts, err := authClientOptions(currentAuthInfo)
+	if err != nil {
+		return nil, err
+	}
+	return NewClientWithOpts(append(opts, authOpts...)...)
+}
+
+func currentConnectionConfig(c config.Config) (*config.Server, *config.AuthInfo, error) {
+	ctx, ok := c.Contexts[c.CurrentContext]
+	if !ok || ctx == nil {
+		return nil, nil, fmt.Errorf("current context %q is not configured", c.CurrentContext)
+	}
+	currentServer, ok := c.Servers[ctx.Server]
+	if !ok || currentServer == nil {
+		return nil, nil, fmt.Errorf("server %q is not configured", ctx.Server)
+	}
+	currentAuthInfo, ok := c.AuthInfos[ctx.AuthInfo]
+	if !ok || currentAuthInfo == nil {
+		return nil, nil, fmt.Errorf("user %q is not configured", ctx.AuthInfo)
+	}
+	return currentServer, currentAuthInfo, nil
+}
+
+func serverClientOptions(currentServer *config.Server) ([]Opt, error) {
+	opts := []Opt{
+		WithEndpoint(currentServer.Server),
+	}
 	if currentServer.TLSServerName != "" {
 		opts = append(opts, WithServerName(currentServer.TLSServerName))
 	}
@@ -74,7 +121,11 @@ func FromConfig(c config.Config) (*Client, error) {
 		}
 		opts = append(opts, WithCAData(caData))
 	}
+	return opts, nil
+}
 
+func authClientOptions(currentAuthInfo *config.AuthInfo) ([]Opt, error) {
+	opts := []Opt{WithBearerAuth(currentAuthInfo.Token)}
 	switch {
 	case len(currentAuthInfo.ClientCertificateData) != 0 && len(currentAuthInfo.ClientKeyData) != 0:
 		opts = append(opts, WithCertData(currentAuthInfo.ClientCertificateData, currentAuthInfo.ClientKeyData))
@@ -89,21 +140,7 @@ func FromConfig(c config.Config) (*Client, error) {
 		}
 		opts = append(opts, WithCertData(certData, keyData))
 	}
-
-	cli, err := NewClientWithOpts(opts...)
-	if err != nil {
-		return nil, err
-	}
-
-	// call api to  check is token valid
-	q := query.New()
-	if _, err = cli.ListConfigMaps(context.TODO(), Queries(*q)); err != nil {
-		if strings.Contains(err.Error(), "Unauthorized") {
-			return nil, errors.New("unauthorized,please use kcctl login cmd to login first")
-		}
-		return nil, err
-	}
-	return cli, nil
+	return opts, nil
 }
 
 func NewClientWithOpts(opts ...Opt) (*Client, error) {

--- a/pkg/simple/client/kc/client_status_test.go
+++ b/pkg/simple/client/kc/client_status_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package kc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/kubeclipper/kubeclipper/pkg/cli/config"
+)
+
+func TestFromConfigWithoutValidationRejectsIncompleteConfig(t *testing.T) {
+	_, err := FromConfigWithoutValidation(config.Config{CurrentContext: "missing"})
+	if err == nil || !strings.Contains(err.Error(), "current context") {
+		t.Fatalf("expected current context error, got %v", err)
+	}
+}
+
+func TestPlatformStatusRejectsInvalidResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != platformStatusPath {
+			t.Fatalf("request path = %q, want %q", request.URL.Path, platformStatusPath)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		if _, err := writer.Write([]byte(`{}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithOpts(WithEndpoint(server.URL), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.PlatformStatus(context.Background()); err == nil || !strings.Contains(err.Error(), "invalid platform status response") {
+		t.Fatalf("expected invalid response error, got %v", err)
+	}
+}

--- a/pkg/simple/client/natsio/interface.go
+++ b/pkg/simple/client/natsio/interface.go
@@ -40,6 +40,7 @@ type ReplyHandler func(msg *nats.Msg) error
 type TimeoutHandler func(msg *Msg) error
 
 type Interface interface {
+	Health(ctx context.Context) error
 	SetDisconnectErrHandler(handler nats.ConnErrHandler)
 	SetReconnectHandler(handler nats.ConnHandler)
 	SetErrorHandler(handler nats.ErrHandler)

--- a/pkg/simple/client/natsio/mock/mock_nats.go
+++ b/pkg/simple/client/natsio/mock/mock_nats.go
@@ -62,6 +62,23 @@ func (mr *MockInterfaceMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockInterface)(nil).Close))
 }
 
+// Health mocks base method.
+func (m *MockInterface) Health(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Health", ctx)
+	ret0, ok := ret[0].(error)
+	if !ok {
+		return nil
+	}
+	return ret0
+}
+
+// Health indicates an expected call of Health.
+func (mr *MockInterfaceMockRecorder) Health(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockInterface)(nil).Health), ctx)
+}
+
 // InitConn mocks base method.
 func (m *MockInterface) InitConn(stopCh <-chan struct{}) error {
 	m.ctrl.T.Helper()

--- a/pkg/simple/client/natsio/nats.go
+++ b/pkg/simple/client/natsio/nats.go
@@ -22,14 +22,20 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	natServer "github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	certutil "k8s.io/client-go/util/cert"
 )
+
+const maxMonitoringResponseBytes = 64 * 1024
 
 var _ Interface = (*Client)(nil)
 
@@ -55,6 +61,8 @@ func NewNats(opts *NatsOptions) Interface {
 }
 
 func (c *Client) Close() {
+	c.serverRunningMux.Lock()
+	defer c.serverRunningMux.Unlock()
 	if c.server != nil {
 		c.server.Shutdown()
 	}
@@ -123,6 +131,8 @@ func (c *Client) setupServerOptions(opts *NatsOptions) {
 		Port:     opts.Server.Port,
 		Username: opts.Auth.UserName,
 		Password: opts.Auth.Password,
+		HTTPHost: "127.0.0.1",
+		HTTPPort: -1,
 		Cluster: natServer.ClusterOpts{
 			Host: opts.Server.Cluster.Host,
 			Port: opts.Server.Cluster.Port,
@@ -142,6 +152,48 @@ func (c *Client) setupServerOptions(opts *NatsOptions) {
 		c.serverOptions.TLSConfig = c.setTLSConfig(opts)
 		c.serverOptions.TLSVerify = true
 	}
+}
+
+func (c *Client) Health(ctx context.Context) error {
+	c.serverRunningMux.Lock()
+	server := c.server
+	conn := c.conn
+	c.serverRunningMux.Unlock()
+	if server == nil || !server.ReadyForConnections(time.Second) {
+		return fmt.Errorf("embedded NATS server is not ready")
+	}
+	monitorAddr := server.MonitorAddr()
+	if monitorAddr == nil {
+		return fmt.Errorf("embedded NATS monitoring is unavailable")
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet,
+		fmt.Sprintf("http://127.0.0.1:%d/varz", monitorAddr.Port), http.NoBody)
+	if err != nil {
+		return err
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("NATS health endpoint returned %s", response.Status)
+	}
+	var status struct {
+		ServerID string `json:"server_id"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, maxMonitoringResponseBytes)).Decode(&status); err != nil {
+		return fmt.Errorf("decode NATS monitoring response: %w", err)
+	}
+	if status.ServerID == "" {
+		return fmt.Errorf("NATS monitoring response has no server ID")
+	}
+	if conn == nil || conn.Status() != nats.CONNECTED {
+		return fmt.Errorf("NATS client is not connected")
+	}
+	flushCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	return conn.FlushWithContext(flushCtx)
 }
 
 func (c *Client) RunServer(stopCh <-chan struct{}) error {
@@ -165,14 +217,16 @@ func (c *Client) RunServer(stopCh <-chan struct{}) error {
 }
 
 func (c *Client) InitConn(stopCh <-chan struct{}) error {
-	var err error
-	c.conn, err = nats.Connect(c.url, c.clientOptions...)
+	conn, err := nats.Connect(c.url, c.clientOptions...)
 	if err != nil {
 		return err
 	}
+	c.serverRunningMux.Lock()
+	c.conn = conn
+	c.serverRunningMux.Unlock()
 	go func() {
 		<-stopCh
-		c.conn.Close()
+		conn.Close()
 	}()
 	return nil
 }

--- a/pkg/simple/client/natsio/nats_health_test.go
+++ b/pkg/simple/client/natsio/nats_health_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ */
+
+package natsio
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestEmbeddedMonitoringUsesRandomLoopbackPort(t *testing.T) {
+	client, ok := NewNats(NewOptions()).(*Client)
+	if !ok {
+		t.Fatal("NewNats did not return *Client")
+	}
+	if client.serverOptions.HTTPHost != "127.0.0.1" {
+		t.Fatalf("monitor host = %q, want loopback", client.serverOptions.HTTPHost)
+	}
+	if client.serverOptions.HTTPPort != -1 {
+		t.Fatalf("monitor port = %d, want random port sentinel -1", client.serverOptions.HTTPPort)
+	}
+}
+
+func TestEmbeddedNATSHealth(t *testing.T) {
+	opts := NewOptions()
+	opts.Server.Host = "127.0.0.1"
+	opts.Server.Port = -1
+	opts.Server.Cluster.Host = "127.0.0.1"
+	opts.Server.Cluster.Port = 0
+	opts.Server.Cluster.LeaderHost = ""
+
+	client, ok := NewNats(opts).(*Client)
+	if !ok {
+		t.Fatal("NewNats did not return *Client")
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	if err := client.RunServer(stopCh); err != nil {
+		t.Fatal(err)
+	}
+	if !client.server.ReadyForConnections(time.Second) {
+		t.Fatal("embedded NATS server did not become ready")
+	}
+	client.url = client.server.Addr().String()
+	if err := client.InitConn(stopCh); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := client.Health(ctx); err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+}

--- a/tools/doc-gen/main.go
+++ b/tools/doc-gen/main.go
@@ -101,7 +101,7 @@ func generateSwaggerJSON() []byte {
 	container := restful.NewContainer()
 	urlruntime.Must(corev1.AddToContainer(container, nil, nil, nil, nil, nil, nil, nil, nil, nil))
 	urlruntime.Must(iamv1.AddToContainer(container, nil, nil, nil))
-	urlruntime.Must(configv1.AddToContainer(container, nil, nil))
+	urlruntime.Must(configv1.AddToContainer(container, nil, nil, nil))
 	urlruntime.Must(oauth.AddToContainer(container, nil, nil, nil, nil, nil, nil, nil))
 	urlruntime.Must(proxy.AddToContainer(container, nil))
 	urlruntime.Must(auditingv1.AddToContainer(container, nil))


### PR DESCRIPTION
### What type of PR is this?

/kind feature
/kind api-change

### What this PR does / why we need it:

Adds an authenticated `kcctl status` command for checking the health of the KubeClipper platform without mixing in cluster or operation lifecycle state.

The command:

- reports `kc-server`, `kc-etcd`, and `kc-agent` health;
- checks API readiness, Controller Manager leader/readiness leases, embedded NATS monitoring and messaging, static resources, etcd endpoints, and agent leases;
- supports table, JSON, and YAML output;
- returns exit code 0 for Healthy, 1 for non-healthy platform states, and 2 for configuration, connection, authentication, or response errors;
- keeps `/healthz` as API liveness and exposes detailed status through `/api/config.kubeclipper.io/v1/status`.

`kcctl doctor` is intentionally not included in this PR and will be implemented separately.

### Which issue(s) this PR fixes:

None.

### Special notes for reviewers:

```text
Validation performed:
- go test -race on all affected packages
- go vet ./pkg/... ./cmd/...
- repository package tests, excluding pkg/utils/systemctl (requires systemd/DBus) and the top-level test/e2e package (requires a real platform configuration)
- Linux amd64 builds for kcctl and kubeclipper-server
- AIO validation on sh-dev-3: all three components Healthy, table/JSON/YAML output valid, exit code 0, authenticated status API 200, unauthenticated request 403, and all platform services active
```

### Does this PR introduced a user-facing change?

```release-note
Add `kcctl status` with table, JSON, and YAML output for checking KubeClipper platform component health.
```

### Additional documentation, usage docs, etc.:

```docs
N/A
```
