### PR TITLE
feat: add kcctl doctor command

### DIFF
--- a/cmd/kcctl/app/root.go
+++ b/cmd/kcctl/app/root.go
@@ -22,6 +22,7 @@ import (
 	"io"
 
 	"github.com/kubeclipper/kubeclipper/pkg/cli/cluster"
+	doctorcmd "github.com/kubeclipper/kubeclipper/pkg/cli/doctor"
 
 	"github.com/kubeclipper/kubeclipper/pkg/cli/set"
 	statuscmd "github.com/kubeclipper/kubeclipper/pkg/cli/status"
@@ -102,6 +103,7 @@ func NewKubeClipperCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds.AddCommand(set.NewCmdSet(ioStreams))
 	cmds.AddCommand(operation.NewCmdOperation(ioStreams))
 	cmds.AddCommand(statuscmd.NewCmdStatus(ioStreams))
+	cmds.AddCommand(doctorcmd.NewCmdDoctor(ioStreams))
 
 	return cmds
 }

--- a/pkg/cli/doctor/checks.go
+++ b/pkg/cli/doctor/checks.go
@@ -1,0 +1,638 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doctor
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+)
+
+func checkKCServer(_ context.Context, state *diagnosticState) Component {
+	component := Component{Name: "kc-server"}
+	statusComponent := platformComponent(state.platform, "kc-server")
+	for _, name := range []string{"api", "controller-manager", "nats", "static-resource"} {
+		check := platformCheck(statusComponent, name)
+		if check == nil {
+			status := platformstatus.Unknown
+			message := fmt.Sprintf("%s status is unavailable", name)
+			if state.platform == nil {
+				status = platformstatus.Skipped
+				message = fmt.Sprintf("%s check skipped because platform status is unavailable", name)
+			}
+			component.Checks = append(component.Checks, Check{
+				Name: name, Target: platformTarget, Status: status, Message: message,
+			})
+			continue
+		}
+		component.Checks = append(component.Checks, Check{
+			Name: name, Target: platformTarget, Status: check.Status, Message: check.Message,
+		})
+	}
+
+	if state.deployConfig == nil || state.remote == nil {
+		component.Checks = append(component.Checks, Check{
+			Name: "remote-instances", Status: platformstatus.Skipped,
+			Message: "server SSH checks skipped because deployment configuration is unavailable",
+		})
+		component.Message = statusMessage(statusComponent, "server status unavailable")
+		return component
+	}
+
+	servers := sortedStrings(state.deployConfig.ServerIPs)
+	checks := runParallel(servers, func(host string) []Check {
+		return checkServerNode(state, host)
+	})
+	component.Checks = append(component.Checks, checks...)
+	attachServerFailureDetails(state, &component, servers)
+	component.Message = serverSummary(servers, checks, statusComponent)
+	return component
+}
+
+func checkServerNode(state *diagnosticState, host string) []Check {
+	service := state.remote.service(host, "kc-server")
+	checks := []Check{service}
+	if service.Status == platformstatus.Unhealthy || service.Status == platformstatus.Unknown {
+		return checks
+	}
+
+	scheme := "http"
+	if state.deployConfig.TLS {
+		scheme = "https"
+	}
+	checks = append(checks,
+		state.remote.httpHealth(host, "api-health", fmt.Sprintf("%s://%s/healthz", scheme, endpoint(host, state.deployConfig.ServerPort))),
+		state.remote.httpHealth(host, "static-resource-health",
+			fmt.Sprintf("http://%s/healthz", endpoint(host, state.deployConfig.StaticServerPort))),
+	)
+	if state.deployConfig.MQ != nil && !state.deployConfig.MQ.External {
+		checks = append(checks,
+			state.remote.port(host, "nats-client-port", endpoint(host, state.deployConfig.MQ.Port)),
+			state.remote.port(host, "nats-cluster-port", endpoint(host, state.deployConfig.MQ.ClusterPort)),
+		)
+	}
+	for i := range checks {
+		if checks[i].Status != platformstatus.Healthy && len(checks[i].Logs) == 0 {
+			checks[i].Logs = state.remote.journal(host, "kc-server")
+			checks[i].Commands = appendUnique(checks[i].Commands, state.remote.serviceCommands(host, "kc-server")...)
+		}
+	}
+	return checks
+}
+
+func checkKCEtcd(_ context.Context, state *diagnosticState) Component {
+	component := Component{Name: "kc-etcd"}
+	statusComponent := platformComponent(state.platform, "kc-etcd")
+	if statusComponent != nil {
+		component.Checks = append(component.Checks, Check{
+			Name: platformStatus, Target: platformTarget,
+			Status: statusComponent.Status, Message: statusComponent.Message,
+		})
+	} else {
+		component.Checks = append(component.Checks, Check{
+			Name: platformStatus, Target: platformTarget,
+			Status: platformstatus.Skipped, Message: "etcd platform status check skipped",
+		})
+	}
+	if state.deployConfig == nil || state.remote == nil {
+		component.Checks = append(component.Checks, Check{
+			Name: "remote-members", Status: platformstatus.Skipped,
+			Message: "etcd SSH checks skipped because deployment configuration is unavailable",
+		})
+		component.Message = statusMessage(statusComponent, "etcd status unavailable")
+		return component
+	}
+
+	servers := sortedStrings(state.deployConfig.ServerIPs)
+	serviceChecks := runParallel(servers, func(host string) []Check {
+		return []Check{state.remote.service(host, "kc-etcd")}
+	})
+	component.Checks = append(component.Checks, serviceChecks...)
+	healthyHost := ""
+	for i := range serviceChecks {
+		if serviceChecks[i].Status == platformstatus.Healthy {
+			healthyHost = serviceChecks[i].Target
+			break
+		}
+	}
+	if healthyHost == "" {
+		component.Checks = append(component.Checks, Check{
+			Name: "endpoint-health", Status: platformstatus.Skipped, Message: "etcd endpoint checks skipped because no member service is available",
+		})
+	} else {
+		component.Checks = append(component.Checks, state.remote.etcdCluster(healthyHost, state.deployConfig))
+	}
+	component.Message = etcdSummary(servers, component.Checks, statusComponent)
+	return component
+}
+
+func (r *remoteRunner) etcdCluster(host string, deployConfig *options.DeployConfig) Check {
+	check := Check{Name: "endpoint-health", Target: host}
+	if deployConfig.EtcdConfig == nil {
+		check.Status = platformstatus.Unknown
+		check.Message = "etcd configuration is unavailable"
+		return check
+	}
+	var endpoints []string
+	for _, server := range sortedStrings(deployConfig.ServerIPs) {
+		endpoints = append(endpoints, "https://"+endpoint(server, deployConfig.EtcdConfig.ClientPort))
+	}
+	base := fmt.Sprintf("timeout %d env ETCDCTL_API=3 etcdctl --endpoints=%s --cacert=%s --cert=%s --key=%s",
+		remoteCommandTimeout,
+		shellQuote(strings.Join(endpoints, ",")),
+		shellQuote(filepath.Join(options.DefaultKcServerConfigPath, options.DefaultCaPath, options.Ca+".crt")),
+		shellQuote(filepath.Join(options.DefaultKcServerConfigPath, options.DefaultEtcdPKIPath, options.EtcdKcClient+".crt")),
+		shellQuote(filepath.Join(options.DefaultKcServerConfigPath, options.DefaultEtcdPKIPath, options.EtcdKcClient+".key")),
+	)
+	healthCommand := base + " endpoint health --cluster"
+	healthResult, healthErr := r.runCommand(host, healthCommand)
+	if healthResult.ExitCode == commandNotFoundExitCode {
+		check.Status = platformstatus.Unknown
+		check.Message = fmt.Sprintf("etcdctl is unavailable on %s", host)
+		check.Evidence = compactOutput(healthResult.Stdout, healthResult.Stderr)
+		check.Commands = []string{r.sshCommand(host, "command -v etcdctl")}
+		return check
+	}
+	if healthErr != nil || healthResult.ExitCode != 0 {
+		check.Status = platformstatus.Unhealthy
+		check.Message = "etcd cluster health check failed"
+		check.Evidence = compactOutput(healthResult.Stdout, healthResult.Stderr, errorString(healthErr))
+		if deployConfig.EtcdConfig.DataDir != "" {
+			diskCommand := fmt.Sprintf("timeout %d df -P %s", remoteCommandTimeout,
+				shellQuote(deployConfig.EtcdConfig.DataDir))
+			check.Evidence = append(check.Evidence, r.capture(host, diskCommand)...)
+		}
+		check.Logs = r.journal(host, "kc-etcd")
+		check.Commands = append([]string{r.sshCommand(host, healthCommand)}, r.serviceCommands(host, "kc-etcd")...)
+		return check
+	}
+	check.Status = platformstatus.Healthy
+	check.Message = "etcd cluster endpoints are healthy"
+	check.Evidence = compactOutput(healthResult.Stdout)
+
+	statusCommand := base + " endpoint status --cluster --write-out=json"
+	statusResult, statusErr := r.runCommand(host, statusCommand)
+	if statusErr != nil || statusResult.ExitCode != 0 {
+		check.Status = platformstatus.Degraded
+		check.Message = "etcd endpoints are healthy but member status is unavailable"
+		check.Evidence = append(check.Evidence, compactOutput(statusResult.Stdout, statusResult.Stderr, errorString(statusErr))...)
+		check.Commands = []string{r.sshCommand(host, statusCommand)}
+		return check
+	}
+	if leader := etcdLeader(statusResult.Stdout); leader != "" {
+		check.Evidence = append(check.Evidence, "leader="+leader)
+	}
+	return check
+}
+
+func etcdLeader(output string) string {
+	var statuses []struct {
+		Endpoint string `json:"Endpoint"`
+		Status   struct {
+			Header struct {
+				MemberID uint64 `json:"member_id"`
+			} `json:"header"`
+			Leader uint64 `json:"leader"`
+		} `json:"Status"`
+	}
+	if err := json.Unmarshal([]byte(output), &statuses); err != nil {
+		return ""
+	}
+	for _, candidate := range statuses {
+		if candidate.Status.Header.MemberID == candidate.Status.Leader && candidate.Status.Leader != 0 {
+			return candidate.Endpoint
+		}
+	}
+	return ""
+}
+
+type agentTarget struct {
+	ID       string
+	IP       string
+	Node     *corev1.Node
+	Deployed bool
+	Disabled bool
+}
+
+func checkKCAgents(_ context.Context, state *diagnosticState) Component {
+	component := Component{Name: "kc-agent"}
+	statusComponent := platformComponent(state.platform, "kc-agent")
+	if statusComponent != nil {
+		component.Checks = append(component.Checks, Check{
+			Name: platformStatus, Target: platformTarget,
+			Status: statusComponent.Status, Message: statusComponent.Message,
+		})
+	} else {
+		component.Checks = append(component.Checks, Check{
+			Name: platformStatus, Target: platformTarget,
+			Status: platformstatus.Skipped, Message: "agent platform status check skipped",
+		})
+	}
+
+	targets := mergeAgentTargets(state.deployConfig, state.nodes)
+	if len(targets) == 0 {
+		component.Checks = append(component.Checks, Check{
+			Name: "agents", Status: platformstatus.Skipped, Message: "no agents discovered",
+		})
+		component.Message = "no agents discovered"
+		return component
+	}
+	checks := runParallel(targets, func(target agentTarget) []Check {
+		return checkAgent(state, target)
+	})
+	component.Checks = append(component.Checks, checks...)
+	component.Message = agentSummary(targets, checks, statusComponent)
+	return component
+}
+
+func checkAgent(state *diagnosticState, target agentTarget) []Check {
+	label := targetLabel(target)
+	if target.Disabled {
+		return []Check{{Name: "disabled", Target: label, Status: platformstatus.Skipped, Message: fmt.Sprintf("agent %s is disabled", label)}}
+	}
+	var checks []Check
+	checks = append(checks, agentHeartbeat(target, state.nodesLoaded))
+	if !target.Deployed {
+		status := platformstatus.Degraded
+		if state.deployConfig == nil {
+			status = platformstatus.Skipped
+		}
+		checks = append(checks, Check{
+			Name: "remote-service", Target: label, Status: status,
+			Message: fmt.Sprintf("SSH check skipped for %s because it is absent from deployment configuration", label),
+		})
+		return checks
+	}
+	if state.remote == nil {
+		checks = append(checks, Check{Name: "remote-service", Target: label, Status: platformstatus.Skipped, Message: "agent SSH check skipped"})
+		return checks
+	}
+	service := state.remote.service(target.IP, "kc-agent")
+	service.Target = label
+	checks = append(checks, service)
+	if service.Status == platformstatus.Unhealthy || service.Status == platformstatus.Unknown {
+		return checks
+	}
+	checks = append(checks, checkAgentNATS(state, target, label))
+	return checks
+}
+
+func checkAgentNATS(state *diagnosticState, target agentTarget, label string) Check {
+	if state.deployConfig.MQ == nil || state.deployConfig.MQ.External {
+		return Check{
+			Name: natsConnectivity, Target: label, Status: platformstatus.Skipped,
+			Message: "embedded NATS is not enabled",
+		}
+	}
+	mqIPs := state.deployConfig.MQ.IPs
+	if len(mqIPs) == 0 {
+		mqIPs = state.deployConfig.ServerIPs
+	}
+	connectivity := make([]Check, 0, len(mqIPs))
+	for _, server := range sortedStrings(mqIPs) {
+		check := state.remote.port(target.IP, natsConnectivity, endpoint(server, state.deployConfig.MQ.Port))
+		check.Target = label
+		connectivity = append(connectivity, check)
+	}
+	unhealthy := 0
+	unknown := 0
+	for i := range connectivity {
+		switch connectivity[i].Status {
+		case platformstatus.Unhealthy:
+			unhealthy++
+		case platformstatus.Unknown:
+			unknown++
+		}
+	}
+	if unhealthy+unknown > 0 {
+		status := platformstatus.Unknown
+		if unhealthy == len(connectivity) {
+			status = platformstatus.Unhealthy
+		} else if unhealthy > 0 {
+			status = platformstatus.Degraded
+		}
+		combined := Check{
+			Name: natsConnectivity, Target: label, Status: status,
+			Message: fmt.Sprintf("kc-agent on %s cannot verify %d/%d embedded NATS endpoints",
+				label, unhealthy+unknown, len(connectivity)),
+			Logs: state.remote.journal(target.IP, "kc-agent"),
+		}
+		for i := range connectivity {
+			combined.Evidence = append(combined.Evidence, connectivity[i].Message)
+			combined.Commands = appendUnique(combined.Commands, connectivity[i].Commands...)
+		}
+		combined.Commands = appendUnique(combined.Commands, state.remote.serviceCommands(target.IP, "kc-agent")...)
+		return combined
+	}
+	return Check{
+		Name: natsConnectivity, Target: label, Status: platformstatus.Healthy,
+		Message: fmt.Sprintf("all embedded NATS endpoints are reachable from %s", label),
+	}
+}
+
+func agentHeartbeat(target agentTarget, inventoryLoaded bool) Check {
+	label := targetLabel(target)
+	if target.Node == nil {
+		if !inventoryLoaded {
+			return Check{
+				Name: heartbeatCheck, Target: label, Status: platformstatus.Skipped,
+				Message: fmt.Sprintf("agent %s heartbeat check skipped because API inventory is unavailable", label),
+			}
+		}
+		return Check{
+			Name: heartbeatCheck, Target: label, Status: platformstatus.Unhealthy,
+			Message: fmt.Sprintf("agent %s is not registered", label),
+		}
+	}
+	condition := nodeReadyCondition(target.Node)
+	if condition == nil {
+		return Check{
+			Name: heartbeatCheck, Target: label, Status: platformstatus.Unknown,
+			Message: fmt.Sprintf("agent %s has never reported readiness", label),
+		}
+	}
+	check := Check{Name: heartbeatCheck, Target: label}
+	check.Evidence = []string{
+		"NodeReady=" + string(condition.Status),
+		"LastHeartbeat=" + condition.LastHeartbeatTime.Local().Format(time.RFC3339),
+	}
+	if condition.Reason != "" {
+		check.Evidence = append(check.Evidence, "Reason="+condition.Reason)
+	}
+	switch condition.Status {
+	case corev1.ConditionTrue:
+		check.Status = platformstatus.Healthy
+		check.Message = fmt.Sprintf("agent %s heartbeat is current", label)
+	case corev1.ConditionFalse:
+		check.Status = platformstatus.Unhealthy
+		check.Message = fmt.Sprintf("agent %s reports not ready", label)
+	default:
+		check.Status = platformstatus.Unhealthy
+		check.Message = fmt.Sprintf("agent %s heartbeat is stale", label)
+	}
+	return check
+}
+
+func nodeReadyCondition(node *corev1.Node) *corev1.NodeCondition {
+	for i := range node.Status.Conditions {
+		if node.Status.Conditions[i].Type == corev1.NodeReady {
+			return &node.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+func mergeAgentTargets(deployConfig *options.DeployConfig, nodes []corev1.Node) []agentTarget {
+	byID := make(map[string]*corev1.Node, len(nodes))
+	byIP := make(map[string]*corev1.Node, len(nodes))
+	for i := range nodes {
+		node := &nodes[i]
+		byID[node.Name] = node
+		if node.Status.Ipv4DefaultIP != "" {
+			byIP[node.Status.Ipv4DefaultIP] = node
+		}
+	}
+	var targets []agentTarget
+	used := make(map[string]struct{})
+	if deployConfig != nil {
+		for ip, metadata := range deployConfig.Agents {
+			node := byID[metadata.AgentID]
+			if node == nil {
+				node = byIP[ip]
+			}
+			target := agentTarget{ID: metadata.AgentID, IP: ip, Node: node, Deployed: true}
+			if target.ID == "" && node != nil {
+				target.ID = node.Name
+			}
+			if node != nil {
+				_, target.Disabled = node.Labels[common.LabelNodeDisable]
+				used[node.Name] = struct{}{}
+			}
+			targets = append(targets, target)
+		}
+	}
+	for i := range nodes {
+		node := &nodes[i]
+		if _, found := used[node.Name]; found {
+			continue
+		}
+		_, disabled := node.Labels[common.LabelNodeDisable]
+		targets = append(targets, agentTarget{
+			ID: node.Name, IP: node.Status.Ipv4DefaultIP, Node: node, Disabled: disabled,
+		})
+	}
+	return targets
+}
+
+func targetLabel(target agentTarget) string {
+	switch {
+	case target.ID != "" && target.IP != "":
+		return fmt.Sprintf("%s (%s)", target.ID, target.IP)
+	case target.ID != "":
+		return target.ID
+	default:
+		return target.IP
+	}
+}
+
+func statusMessage(component *platformstatus.Component, fallback string) string {
+	if component == nil || component.Message == "" {
+		return fallback
+	}
+	return component.Message
+}
+
+func attachServerFailureDetails(state *diagnosticState, component *Component, servers []string) {
+	for i := range component.Checks {
+		check := &component.Checks[i]
+		if check.Target != platformTarget || check.Status == platformstatus.Healthy || check.Status == platformstatus.Skipped {
+			continue
+		}
+		for _, host := range servers {
+			check.Logs = append(check.Logs, state.remote.journal(host, "kc-server")...)
+			check.Commands = appendUnique(check.Commands, state.remote.serviceCommands(host, "kc-server")...)
+		}
+		switch check.Name {
+		case "controller-manager":
+			attachServerTimes(state.remote, check, servers)
+		case "nats":
+			attachNATSConnectivity(state, check, servers)
+		case "static-resource":
+			attachStaticResourceEvidence(state, check, servers)
+		}
+		if len(check.Logs) > shownLogs {
+			check.Logs = check.Logs[len(check.Logs)-shownLogs:]
+		}
+	}
+}
+
+func attachServerTimes(remote *remoteRunner, check *Check, servers []string) {
+	for _, host := range servers {
+		lines := remote.capture(host, fmt.Sprintf("timeout %d date +%%s", remoteCommandTimeout))
+		if len(lines) == 1 {
+			timestamp, err := strconv.ParseInt(strings.TrimSpace(lines[0]), 10, 64)
+			if err == nil {
+				check.Evidence = append(check.Evidence,
+					fmt.Sprintf("%s clock offset=%ds", host, timestamp-time.Now().Unix()))
+				continue
+			}
+		}
+		check.Evidence = append(check.Evidence, fmt.Sprintf("%s clock check failed", host))
+	}
+}
+
+func attachNATSConnectivity(state *diagnosticState, check *Check, servers []string) {
+	if state.deployConfig.MQ == nil || state.deployConfig.MQ.External {
+		return
+	}
+	for _, source := range servers {
+		for _, target := range servers {
+			if source == target {
+				continue
+			}
+			result := state.remote.port(source, "nats-cluster-connectivity",
+				endpoint(target, state.deployConfig.MQ.ClusterPort))
+			check.Evidence = append(check.Evidence, result.Message)
+			check.Commands = appendUnique(check.Commands, result.Commands...)
+		}
+	}
+}
+
+func attachStaticResourceEvidence(state *diagnosticState, check *Check, servers []string) {
+	path := state.deployConfig.StaticServerPath
+	if path == "" {
+		return
+	}
+	quotedPath := shellQuote(path)
+	script := fmt.Sprintf("if test -d %s; then echo directory=present; else echo directory=missing; fi; "+
+		"if test -r %s; then echo readable=true; else echo readable=false; fi; df -P %s",
+		quotedPath, quotedPath, quotedPath)
+	command := fmt.Sprintf("timeout %d sh -c %s", remoteCommandTimeout, shellQuote(script))
+	for _, host := range servers {
+		for _, evidence := range state.remote.capture(host, command) {
+			check.Evidence = append(check.Evidence, host+" "+evidence)
+		}
+		check.Commands = appendUnique(check.Commands, state.remote.sshCommand(host, "df -P "+quotedPath))
+	}
+}
+
+func serverSummary(servers []string, checks []Check, status *platformstatus.Component) string {
+	healthy := healthyServices(checks, "kc-server-service")
+	if healthy == len(servers) && status != nil && status.Status == platformstatus.Healthy {
+		return fmt.Sprintf("%d/%d instances healthy; all subsystems ready", healthy, len(servers))
+	}
+	return fmt.Sprintf("%d/%d instances running; %s", healthy, len(servers), statusMessage(status, "subsystem status unavailable"))
+}
+
+func etcdSummary(servers []string, checks []Check, status *platformstatus.Component) string {
+	healthy := healthyServices(checks, "kc-etcd-service")
+	clusterHealthy := hasHealthyCheck(checks, "endpoint-health")
+	if healthy == len(servers) && clusterHealthy {
+		return fmt.Sprintf("%d/%d members healthy", healthy, len(servers))
+	}
+	return fmt.Sprintf("%d/%d member services running; %s", healthy, len(servers), statusMessage(status, "cluster status unavailable"))
+}
+
+func hasHealthyCheck(checks []Check, name string) bool {
+	for i := range checks {
+		if checks[i].Name == name && checks[i].Status == platformstatus.Healthy {
+			return true
+		}
+	}
+	return false
+}
+
+func agentSummary(targets []agentTarget, checks []Check, status *platformstatus.Component) string {
+	enabled := 0
+	for _, target := range targets {
+		if !target.Disabled {
+			enabled++
+		}
+	}
+	running, inspected := serviceCounts(checks, "kc-agent-service")
+	if inspected == 0 {
+		return statusMessage(status, "heartbeat status unavailable") + "; SSH checks skipped"
+	}
+	if status != nil && status.Status == platformstatus.Healthy && running == enabled && inspected == enabled {
+		return fmt.Sprintf("%d/%d agents healthy", enabled, enabled)
+	}
+	hostState := fmt.Sprintf("%d/%d agent services running", running, inspected)
+	if status == nil {
+		return hostState + "; API heartbeat status unavailable"
+	}
+	if status.Status == platformstatus.Healthy && running < inspected {
+		return hostState + "; API still reports " + status.Message
+	}
+	return hostState + "; API reports " + status.Message
+}
+
+func healthyServices(checks []Check, name string) int {
+	healthy, _ := serviceCounts(checks, name)
+	return healthy
+}
+
+func serviceCounts(checks []Check, name string) (healthy, total int) {
+	for i := range checks {
+		if checks[i].Name != name {
+			continue
+		}
+		total++
+		if checks[i].Status == platformstatus.Healthy {
+			healthy++
+		}
+	}
+	return
+}
+
+func endpoint(host string, port int) string {
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func appendUnique(values []string, additions ...string) []string {
+	seen := make(map[string]struct{}, len(values)+len(additions))
+	for _, value := range values {
+		seen[value] = struct{}{}
+	}
+	for _, value := range additions {
+		if value == "" {
+			continue
+		}
+		if _, found := seen[value]; found {
+			continue
+		}
+		seen[value] = struct{}{}
+		values = append(values, value)
+	}
+	return values
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/pkg/cli/doctor/doctor.go
+++ b/pkg/cli/doctor/doctor.go
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doctor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
+	"github.com/kubeclipper/kubeclipper/pkg/cli/config"
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/query"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
+)
+
+const (
+	apiTimeout      = 10 * time.Second
+	nodeConcurrency = 5
+)
+
+type ExitError struct {
+	code int
+	err  error
+}
+
+func (e *ExitError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e *ExitError) Unwrap() error { return e.err }
+func (e *ExitError) ExitCode() int { return e.code }
+
+type Options struct {
+	options.IOStreams
+	configPath       string
+	deployConfigPath string
+	now              func() time.Time
+}
+
+type diagnosticState struct {
+	client       *kc.Client
+	platform     *platformstatus.PlatformStatus
+	nodes        []corev1.Node
+	nodesLoaded  bool
+	deployConfig *options.DeployConfig
+	remote       *remoteRunner
+}
+
+type deployConfigFile struct {
+	SSH              sshConfigFile    `json:"ssh" yaml:"ssh"`
+	Etcd             etcdConfigFile   `json:"etcd" yaml:"etcd"`
+	ServerIPs        []string         `json:"serverIPs" yaml:"serverIPs"`
+	Agents           options.Agents   `json:"agents" yaml:"agents"`
+	ServerPort       int              `json:"serverPort" yaml:"serverPort"`
+	TLS              bool             `json:"tls" yaml:"tls"`
+	StaticServerPort int              `json:"staticServerPort" yaml:"staticServerPort"`
+	StaticServerPath string           `json:"staticServerPath" yaml:"staticServerPath"`
+	MQ               messageQueueFile `json:"mq" yaml:"mq"`
+}
+
+type sshConfigFile struct {
+	User       string `json:"user" yaml:"user"`
+	Password   string `json:"password" yaml:"password"`
+	Port       int    `json:"port" yaml:"port"`
+	PkFile     string `json:"pkFile" yaml:"pkFile"`
+	PrivateKey string `json:"privateKey" yaml:"privateKey"`
+	PkPassword string `json:"pkPassword" yaml:"pkPassword"`
+}
+
+type etcdConfigFile struct {
+	ClientPort  int    `json:"clientPort" yaml:"clientPort"`
+	PeerPort    int    `json:"peerPort" yaml:"peerPort"`
+	MetricsPort int    `json:"metricsPort" yaml:"metricsPort"`
+	DataDir     string `json:"dataDir" yaml:"dataDir"`
+}
+
+type messageQueueFile struct {
+	External    bool     `json:"external" yaml:"external"`
+	IPs         []string `json:"ips" yaml:"ips"`
+	Port        int      `json:"port" yaml:"port"`
+	ClusterPort int      `json:"clusterPort" yaml:"clusterPort"`
+}
+
+func NewCmdDoctor(streams options.IOStreams) *cobra.Command {
+	o := &Options{
+		IOStreams:        streams,
+		configPath:       options.DefaultConfigPath,
+		deployConfigPath: options.DefaultDeployConfigPath,
+		now:              time.Now,
+	}
+	cmd := &cobra.Command{
+		Use:          "doctor",
+		Short:        "Diagnose KubeClipper platform problems",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cmd.Root().SilenceErrors = true
+			report := o.run(cmd.Context())
+			if err := printReport(o.Out, report); err != nil {
+				return &ExitError{code: 2, err: err}
+			}
+			if report.Status != platformstatus.Healthy {
+				return &ExitError{code: 1}
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+func (o *Options) run(ctx context.Context) *Report {
+	startedAt := o.now()
+	state := &diagnosticState{}
+	local := o.checkLocalAccess(ctx, state)
+	components := []Component{
+		local,
+		checkKCServer(ctx, state),
+		checkKCEtcd(ctx, state),
+		checkKCAgents(ctx, state),
+	}
+	return newReport(startedAt, o.now().Sub(startedAt), components)
+}
+
+func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) Component {
+	component := Component{Name: "kcctl"}
+	deployConfig, err := loadDeployConfig(o.deployConfigPath)
+	if err != nil {
+		status := platformstatus.Degraded
+		message := fmt.Sprintf("cannot load %s", o.deployConfigPath)
+		if !errors.Is(err, os.ErrNotExist) {
+			message = fmt.Sprintf("invalid deployment configuration: %v", err)
+		}
+		component.Checks = append(component.Checks, Check{
+			Name: "deploy-config", Status: status, Message: message,
+			Evidence: []string{"remote service, network and journal checks will be skipped"},
+		})
+	} else {
+		state.deployConfig = deployConfig
+		state.remote = newRemoteRunner(ctx, deployConfig.SSHConfig)
+		component.Checks = append(component.Checks, Check{
+			Name: "deploy-config", Status: platformstatus.Healthy, Message: "deployment configuration loaded",
+		})
+	}
+
+	apiConfig, err := config.TryLoadFromFile(o.configPath)
+	if err != nil {
+		component.Checks = append(component.Checks, Check{
+			Name: apiConfigCheck, Status: platformstatus.Unhealthy,
+			Message: fmt.Sprintf("cannot load API configuration %s", o.configPath), Evidence: []string{sanitize(err.Error())},
+		})
+		component.Message = "API configuration is unavailable"
+		return component
+	}
+	client, err := kc.FromConfigWithoutValidation(*apiConfig)
+	if err != nil {
+		component.Checks = append(component.Checks, Check{
+			Name: apiConfigCheck, Status: platformstatus.Unhealthy,
+			Message: "API configuration is invalid", Evidence: []string{sanitize(err.Error())},
+		})
+		component.Message = "API configuration is invalid"
+		return component
+	}
+	state.client = client
+	component.Checks = append(component.Checks, Check{
+		Name: apiConfigCheck, Status: platformstatus.Healthy, Message: "API configuration loaded",
+	})
+
+	apiCtx, cancel := context.WithTimeout(ctx, apiTimeout)
+	defer cancel()
+	healthErr := client.Healthz(apiCtx)
+	if healthErr != nil {
+		component.Checks = append(component.Checks, Check{
+			Name: "api-health", Status: platformstatus.Unhealthy, Message: "KubeClipper API is unreachable",
+			Evidence: []string{sanitize(healthErr.Error())},
+		})
+		component.Message = "API is unreachable"
+		return component
+	}
+	component.Checks = append(component.Checks, Check{
+		Name: "api-health", Status: platformstatus.Healthy, Message: "API liveness check passed",
+	})
+
+	statusCtx, statusCancel := context.WithTimeout(ctx, apiTimeout)
+	defer statusCancel()
+	platform, err := client.PlatformStatus(statusCtx)
+	if err != nil {
+		component.Checks = append(component.Checks, Check{
+			Name: "api-authentication", Status: platformstatus.Unhealthy,
+			Message: "cannot read platform status", Evidence: []string{sanitize(err.Error())},
+		})
+		component.Message = "API is reachable but status access failed"
+		return component
+	}
+	state.platform = platform
+	component.Checks = append(component.Checks, Check{
+		Name: "api-authentication", Status: platformstatus.Healthy,
+		Message: "API is reachable and authenticated",
+	})
+
+	nodesCtx, nodesCancel := context.WithTimeout(ctx, apiTimeout)
+	defer nodesCancel()
+	nodes, err := client.ListNodes(nodesCtx, kc.Queries(*query.New()))
+	if err != nil {
+		component.Checks = append(component.Checks, Check{
+			Name: "node-inventory", Status: platformstatus.Degraded, Message: "cannot read agent inventory",
+			Evidence: []string{sanitize(err.Error())},
+		})
+	} else {
+		state.nodes = nodes.Items
+		state.nodesLoaded = true
+		component.Checks = append(component.Checks, Check{
+			Name: "node-inventory", Status: platformstatus.Healthy, Message: "agent inventory loaded",
+		})
+	}
+	component.Message = "connected to KubeClipper API"
+	return component
+}
+
+func loadDeployConfig(path string) (*options.DeployConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	defaults := options.NewDeployOptions()
+	fileConfig := deployConfigFile{
+		SSH: sshConfigFile{User: defaults.SSHConfig.User, Port: defaults.SSHConfig.Port},
+		Etcd: etcdConfigFile{
+			ClientPort: defaults.EtcdConfig.ClientPort, PeerPort: defaults.EtcdConfig.PeerPort,
+			MetricsPort: defaults.EtcdConfig.MetricsPort, DataDir: defaults.EtcdConfig.DataDir,
+		},
+		Agents: defaults.Agents, ServerPort: defaults.ServerPort, TLS: defaults.TLS,
+		StaticServerPort: defaults.StaticServerPort, StaticServerPath: defaults.StaticServerPath,
+		MQ: messageQueueFile{Port: defaults.MQ.Port, ClusterPort: defaults.MQ.ClusterPort},
+	}
+	if err := yaml.Unmarshal(data, &fileConfig); err != nil {
+		return nil, err
+	}
+	deployConfig := defaults
+	deployConfig.Config = path
+	deployConfig.SSHConfig = &sshutils.SSH{
+		User: fileConfig.SSH.User, Password: fileConfig.SSH.Password, Port: fileConfig.SSH.Port,
+		PkFile: fileConfig.SSH.PkFile, PrivateKey: fileConfig.SSH.PrivateKey, PkPassword: fileConfig.SSH.PkPassword,
+	}
+	deployConfig.EtcdConfig = &options.Etcd{
+		ClientPort: fileConfig.Etcd.ClientPort, PeerPort: fileConfig.Etcd.PeerPort,
+		MetricsPort: fileConfig.Etcd.MetricsPort, DataDir: fileConfig.Etcd.DataDir,
+	}
+	deployConfig.ServerIPs = fileConfig.ServerIPs
+	deployConfig.Agents = fileConfig.Agents
+	deployConfig.ServerPort = fileConfig.ServerPort
+	deployConfig.TLS = fileConfig.TLS
+	deployConfig.StaticServerPort = fileConfig.StaticServerPort
+	deployConfig.StaticServerPath = fileConfig.StaticServerPath
+	deployConfig.MQ = &options.MQ{
+		External: fileConfig.MQ.External, IPs: fileConfig.MQ.IPs,
+		Port: fileConfig.MQ.Port, ClusterPort: fileConfig.MQ.ClusterPort,
+	}
+	if len(deployConfig.ServerIPs) == 0 {
+		return nil, fmt.Errorf("serverIPs is empty")
+	}
+	return deployConfig, nil
+}
+
+func runParallel[T any](items []T, check func(T) []Check) []Check {
+	semaphore := make(chan struct{}, nodeConcurrency)
+	results := make(chan []Check, len(items))
+	var wg sync.WaitGroup
+	for i := range items {
+		item := items[i]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			semaphore <- struct{}{}
+			defer func() { <-semaphore }()
+			results <- check(item)
+		}()
+	}
+	wg.Wait()
+	close(results)
+	var checks []Check
+	for result := range results {
+		checks = append(checks, result...)
+	}
+	sortChecks(checks)
+	return checks
+}
+
+func platformComponent(status *platformstatus.PlatformStatus, name string) *platformstatus.Component {
+	if status == nil {
+		return nil
+	}
+	for i := range status.Components {
+		if status.Components[i].Name == name {
+			return &status.Components[i]
+		}
+	}
+	return nil
+}
+
+func platformCheck(component *platformstatus.Component, name string) *platformstatus.Check {
+	if component == nil {
+		return nil
+	}
+	for i := range component.Checks {
+		if component.Checks[i].Name == name {
+			return &component.Checks[i]
+		}
+	}
+	return nil
+}
+
+func sortedStrings(values []string) []string {
+	result := append([]string(nil), values...)
+	sort.Strings(result)
+	return result
+}

--- a/pkg/cli/doctor/doctor_test.go
+++ b/pkg/cli/doctor/doctor_test.go
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doctor
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
+)
+
+func TestServiceState(t *testing.T) {
+	tests := []struct {
+		name       string
+		output     string
+		exitCode   int
+		err        error
+		wantStatus platformstatus.Status
+	}{
+		{name: "running", output: serviceOutput("active", "running", "enabled"), wantStatus: platformstatus.Healthy},
+		{name: "stopped", output: serviceOutput("inactive", "dead", "enabled"), wantStatus: platformstatus.Unhealthy},
+		{name: "disabled", output: serviceOutput("active", "running", "disabled"), wantStatus: platformstatus.Degraded},
+		{name: "ssh failure", err: errors.New("connection refused"), wantStatus: platformstatus.Unknown},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			runner := &remoteRunner{run: func(_ context.Context, _ *sshutils.SSH, _, _ string) (sshutils.Result, error) {
+				return sshutils.Result{Stdout: test.output, ExitCode: test.exitCode}, test.err
+			}}
+			check := runner.service("192.0.2.10", "kc-agent")
+			if check.Status != test.wantStatus {
+				t.Fatalf("status = %s, want %s", check.Status, test.wantStatus)
+			}
+		})
+	}
+}
+
+func TestPortCommandFailureIsUnhealthy(t *testing.T) {
+	var command string
+	runner := &remoteRunner{run: func(_ context.Context, _ *sshutils.SSH, _ string, remoteCommand string) (sshutils.Result, error) {
+		command = remoteCommand
+		return sshutils.Result{ExitCode: 1, Stderr: "connection timed out"}, errors.New("exit status 1")
+	}}
+	check := runner.port("192.0.2.20", "nats-connectivity", "192.0.2.10:9889")
+	if check.Status != platformstatus.Unhealthy {
+		t.Fatalf("status = %s, want %s", check.Status, platformstatus.Unhealthy)
+	}
+	if !strings.Contains(command, `/dev/tcp/$1/$2`) || !strings.Contains(command, "-- '192.0.2.10' '9889'") {
+		t.Fatalf("command = %q", command)
+	}
+}
+
+func TestPortCommandQuotesEndpointAsArguments(t *testing.T) {
+	var command string
+	runner := &remoteRunner{run: func(_ context.Context, _ *sshutils.SSH, _ string, remoteCommand string) (sshutils.Result, error) {
+		command = remoteCommand
+		return sshutils.Result{ExitCode: 1}, nil
+	}}
+	runner.port("192.0.2.20", "nats-connectivity", "[$(touch /tmp/unsafe)]:9889")
+
+	if strings.Contains(command, "/dev/tcp/$(touch") {
+		t.Fatalf("endpoint was embedded in shell program: %q", command)
+	}
+	if !strings.Contains(command, "-- '$(touch /tmp/unsafe)' '9889'") {
+		t.Fatalf("endpoint was not passed as quoted arguments: %q", command)
+	}
+}
+
+func TestStoppedAgentDetectedBeforeHeartbeatExpires(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	node := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-1"},
+		Status: corev1.NodeStatus{Conditions: []corev1.NodeCondition{{
+			Type: corev1.NodeReady, Status: corev1.ConditionTrue, LastHeartbeatTime: now,
+		}}},
+	}
+	heartbeat := agentHeartbeat(agentTarget{ID: "worker-1", IP: "192.0.2.20", Node: node, Deployed: true}, true)
+	if heartbeat.Status != platformstatus.Healthy {
+		t.Fatalf("heartbeat status = %s", heartbeat.Status)
+	}
+	runner := &remoteRunner{run: func(_ context.Context, _ *sshutils.SSH, _, command string) (sshutils.Result, error) {
+		if strings.HasPrefix(command, "journalctl") {
+			return sshutils.Result{}, nil
+		}
+		return sshutils.Result{Stdout: serviceOutput("inactive", "dead", "enabled")}, nil
+	}}
+	service := runner.service("192.0.2.20", "kc-agent")
+	if service.Status != platformstatus.Unhealthy {
+		t.Fatalf("service status = %s, want Unhealthy", service.Status)
+	}
+}
+
+func TestAgentRegistrationUnknownWhenAPIInventoryUnavailable(t *testing.T) {
+	target := agentTarget{ID: "worker-1", IP: "192.0.2.20", Deployed: true}
+	check := agentHeartbeat(target, false)
+	if check.Status != platformstatus.Skipped {
+		t.Fatalf("status = %s, want Skipped", check.Status)
+	}
+	check = agentHeartbeat(target, true)
+	if check.Status != platformstatus.Unhealthy {
+		t.Fatalf("status with loaded inventory = %s, want Unhealthy", check.Status)
+	}
+}
+
+func TestMergeAgentTargets(t *testing.T) {
+	deployConfig := options.NewDeployOptions()
+	deployConfig.Agents["192.0.2.10"] = options.Metadata{AgentID: "worker-1"}
+	nodes := []corev1.Node{
+		{ObjectMeta: metav1.ObjectMeta{Name: "worker-1"}, Status: corev1.NodeStatus{Ipv4DefaultIP: "192.0.2.10"}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "worker-2", Labels: map[string]string{common.LabelNodeDisable: "true"}}, Status: corev1.NodeStatus{Ipv4DefaultIP: "192.0.2.11"}},
+	}
+	targets := mergeAgentTargets(deployConfig, nodes)
+	if len(targets) != 2 {
+		t.Fatalf("targets = %d, want 2", len(targets))
+	}
+	if !targets[0].Deployed || targets[0].Node == nil {
+		t.Fatalf("deployed target was not reconciled: %#v", targets[0])
+	}
+	if !targets[1].Disabled {
+		t.Fatalf("disabled node was not preserved: %#v", targets[1])
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	input := "\x1b[31m\x1b]52;c;Y2xpcGJvYXJk\a" +
+		`password=hunter2 {"token":"abc.def"} Authorization:Bearer abc.def nats://admin:secret@example:9889 ` +
+		"-----BEGIN PRIVATE KEY-----\nsensitive\n-----END PRIVATE KEY-----"
+	result := sanitize(input)
+	for _, secret := range []string{"hunter2", "abc.def", "admin:secret", "sensitive", "\x1b", "Y2xpcGJvYXJk"} {
+		if strings.Contains(result, secret) {
+			t.Errorf("sanitized output contains %q: %s", secret, result)
+		}
+	}
+}
+
+func TestEtcdSummaryUsesNativeEndpointHealth(t *testing.T) {
+	checks := []Check{
+		{Name: "kc-etcd-service", Status: platformstatus.Healthy},
+		{Name: "endpoint-health", Status: platformstatus.Healthy},
+	}
+	if got, want := etcdSummary([]string{"192.0.2.10"}, checks, nil), "1/1 members healthy"; got != want {
+		t.Fatalf("etcd summary = %q, want %q", got, want)
+	}
+}
+
+func TestPadRightUsesDisplayCharacters(t *testing.T) {
+	if got, want := padRight("✓ Healthy", statusColumnWidth), "✓ Healthy   "; got != want {
+		t.Fatalf("padded status = %q, want %q", got, want)
+	}
+}
+
+func TestPrintReportExpandsOnlyProblems(t *testing.T) {
+	report := newReport(time.Now(), time.Second, []Component{
+		{Name: "kcctl", Message: "API reachable", Checks: []Check{{Name: "api", Status: platformstatus.Healthy, Message: "healthy detail"}}},
+		{Name: "kc-agent", Message: "0/1 agents healthy", Checks: []Check{{
+			Name: "service", Target: "worker-1", Status: platformstatus.Unhealthy,
+			Message: "kc-agent on worker-1 is not running", Evidence: []string{"ActiveState=inactive"},
+		}}},
+	})
+	var output bytes.Buffer
+	if err := printReport(&output, report); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	for _, expected := range []string{
+		"Overall: Unhealthy",
+		"[OK]  kcctl",
+		"[FAIL] kc-agent",
+		"Problems",
+		"ActiveState=inactive",
+		"Summary: 1 passed, 1 failed",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Errorf("output does not contain %q:\n%s", expected, text)
+		}
+	}
+	if strings.Contains(text, "healthy detail") {
+		t.Errorf("healthy check details should be collapsed:\n%s", text)
+	}
+}
+
+func TestDoctorCommandHasNoBusinessFlags(t *testing.T) {
+	command := NewCmdDoctor(options.IOStreams{Out: &bytes.Buffer{}})
+	if command.Flags().HasFlags() {
+		t.Fatalf("doctor command unexpectedly defines flags: %s", command.Flags().FlagUsages())
+	}
+}
+
+func TestAgentSummaryExplainsStaleAPIStatus(t *testing.T) {
+	targets := []agentTarget{{ID: "worker-1", Deployed: true}}
+	checks := []Check{{Name: "kc-agent-service", Status: platformstatus.Unhealthy}}
+	status := &platformstatus.Component{
+		Name: "kc-agent", Status: platformstatus.Healthy, Message: "1/1 agents running",
+	}
+
+	got := agentSummary(targets, checks, status)
+	want := "0/1 agent services running; API still reports 1/1 agents running"
+	if got != want {
+		t.Fatalf("agent summary = %q, want %q", got, want)
+	}
+}
+
+func TestLoadDeployConfigIgnoresUnrelatedDurations(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "deploy-config.yaml")
+	data := []byte(`
+serverIPs: [192.0.2.10]
+agents:
+  192.0.2.20:
+    agentID: worker-1
+ssh:
+  user: root
+  port: 22
+audit:
+  retentionPeriod: 168h
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config, err := loadDeployConfig(path)
+	if err != nil {
+		t.Fatalf("load deploy config: %v", err)
+	}
+	if len(config.ServerIPs) != 1 || config.ServerIPs[0] != "192.0.2.10" {
+		t.Fatalf("serverIPs = %v", config.ServerIPs)
+	}
+	if !config.Agents.ExistsByID("worker-1") {
+		t.Fatalf("agent was not loaded: %v", config.Agents)
+	}
+}
+
+func serviceOutput(active, sub, unitFile string) string {
+	return "LoadState=loaded\n" +
+		"UnitFileState=" + unitFile + "\n" +
+		"ActiveState=" + active + "\n" +
+		"SubState=" + sub + "\n" +
+		"Result=success\nExecMainStatus=0\nNRestarts=0\n"
+}

--- a/pkg/cli/doctor/output.go
+++ b/pkg/cli/doctor/output.go
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doctor
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"golang.org/x/term"
+
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+)
+
+const (
+	componentColumnWidth = 14
+	statusColumnWidth    = 12
+	labelWidth           = 8
+)
+
+func printReport(out io.Writer, report *Report) error {
+	style := newOutputStyle(out)
+	if err := printHeader(out, report, style); err != nil {
+		return err
+	}
+	if err := printComponents(out, report, style); err != nil {
+		return err
+	}
+	if err := printProblems(out, report, style); err != nil {
+		return err
+	}
+	passed, failed, skipped := countChecks(report)
+	_, err := fmt.Fprintf(out, "\n%s%s%s, %s, %s\n",
+		style.label("Summary"),
+		style.separator(),
+		style.checkCount(platformstatus.Healthy, passed, "passed"),
+		style.checkCount(platformstatus.Unhealthy, failed, "failed"),
+		style.checkCount(platformstatus.Skipped, skipped, "skipped"),
+	)
+	return err
+}
+
+func printHeader(out io.Writer, report *Report, style outputStyle) error {
+	if _, err := fmt.Fprintln(out, style.title("KubeClipper Doctor")); err != nil {
+		return err
+	}
+	overall := string(report.Status)
+	if style.enabled {
+		overall = statusMarker(report.Status, true) + " " + overall
+	}
+	if _, err := fmt.Fprintf(out, "\n%s%s%s\n",
+		style.label("Overall"), style.separator(), style.status(report.Status, overall)); err != nil {
+		return err
+	}
+	checkedAt := report.CheckedAt.Local().Format(time.RFC3339)
+	duration := style.muted("(" + formatDuration(report.DurationMillis) + ")")
+	if _, err := fmt.Fprintf(out, "%s%s%s %s\n", style.label("Checked"), style.separator(), checkedAt, duration); err != nil {
+		return err
+	}
+	_, err := fmt.Fprintln(out)
+	return err
+}
+
+func printComponents(out io.Writer, report *Report, style outputStyle) error {
+	if style.enabled {
+		if _, err := fmt.Fprintf(out, "%s  %s  %s\n",
+			style.heading(padRight("COMPONENT", componentColumnWidth)),
+			style.heading(padRight("STATUS", statusColumnWidth)),
+			style.heading("DETAILS")); err != nil {
+			return err
+		}
+	}
+	for _, component := range report.Components {
+		marker := statusMarker(component.Status, style.enabled)
+		name := component.Name
+		if style.enabled {
+			status := marker + " " + string(component.Status)
+			if _, err := fmt.Fprintf(out, "%s  %s  %s\n",
+				padRight(name, componentColumnWidth),
+				style.status(component.Status, padRight(status, statusColumnWidth)),
+				component.Message); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := fmt.Fprintf(out, "%-5s %-13s %s\n", marker, name, component.Message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func printProblems(out io.Writer, report *Report, style outputStyle) error {
+	problem := 0
+	for componentIndex := range report.Components {
+		component := &report.Components[componentIndex]
+		for checkIndex := range component.Checks {
+			check := &component.Checks[checkIndex]
+			if check.Status == platformstatus.Healthy || check.Status == platformstatus.Skipped {
+				continue
+			}
+			problem++
+			if problem == 1 {
+				if _, err := fmt.Fprintln(out, "\n"+style.section("Problems")); err != nil {
+					return err
+				}
+			}
+			if err := printProblem(out, problem, check, style); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func printProblem(out io.Writer, number int, check *Check, style outputStyle) error {
+	title := fmt.Sprintf("[%d] %s", number, check.Message)
+	if _, err := fmt.Fprintf(out, "\n%s\n", style.status(check.Status, title)); err != nil {
+		return err
+	}
+	if err := printDetailLines(out, style, "Evidence:", check.Evidence, false); err != nil {
+		return err
+	}
+	if err := printDetailLines(out, style, "Recent logs:", check.Logs, false); err != nil {
+		return err
+	}
+	return printDetailLines(out, style, "Next steps:", check.Commands, true)
+}
+
+func printDetailLines(out io.Writer, style outputStyle, heading string, lines []string, command bool) error {
+	if len(lines) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintf(out, "\n%s\n", style.detailHeading(heading)); err != nil {
+		return err
+	}
+	for _, line := range lines {
+		if command {
+			line = style.command(line)
+		}
+		if _, err := fmt.Fprintf(out, "  %s\n", line); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func countChecks(report *Report) (passed, failed, skipped int) {
+	for componentIndex := range report.Components {
+		component := &report.Components[componentIndex]
+		for checkIndex := range component.Checks {
+			check := &component.Checks[checkIndex]
+			switch check.Status {
+			case platformstatus.Healthy:
+				passed++
+			case platformstatus.Skipped:
+				skipped++
+			default:
+				failed++
+			}
+		}
+	}
+	return passed, failed, skipped
+}
+
+func statusMarker(status platformstatus.Status, terminal bool) string {
+	if terminal {
+		switch status {
+		case platformstatus.Healthy:
+			return "✓"
+		case platformstatus.Degraded:
+			return "!"
+		case platformstatus.Unhealthy:
+			return "✗"
+		default:
+			return "?"
+		}
+	}
+	switch status {
+	case platformstatus.Healthy:
+		return "[OK]"
+	case platformstatus.Degraded:
+		return "[WARN]"
+	case platformstatus.Unhealthy:
+		return "[FAIL]"
+	case platformstatus.Skipped:
+		return "[SKIP]"
+	default:
+		return "[UNKNOWN]"
+	}
+}
+
+func padRight(value string, width int) string {
+	displayWidth := utf8.RuneCountInString(value)
+	if displayWidth >= width {
+		return value
+	}
+	return value + strings.Repeat(" ", width-displayWidth)
+}
+
+type outputStyle struct {
+	enabled bool
+}
+
+func newOutputStyle(out io.Writer) outputStyle {
+	_, noColor := os.LookupEnv("NO_COLOR")
+	return outputStyle{
+		enabled: writerIsTerminal(out) && !noColor && os.Getenv("TERM") != "dumb",
+	}
+}
+
+func (s outputStyle) title(value string) string {
+	return s.wrap("1;36", value)
+}
+
+func (s outputStyle) section(value string) string {
+	return s.wrap("1", value)
+}
+
+func (s outputStyle) heading(value string) string {
+	return s.wrap("2", value)
+}
+
+func (s outputStyle) label(value string) string {
+	if !s.enabled {
+		return value + ":"
+	}
+	return s.wrap("1", padRight(value, labelWidth))
+}
+
+func (s outputStyle) separator() string {
+	if s.enabled {
+		return "  "
+	}
+	return " "
+}
+
+func (s outputStyle) detailHeading(value string) string {
+	return s.wrap("1", value)
+}
+
+func (s outputStyle) muted(value string) string {
+	return s.wrap("2", value)
+}
+
+func (s outputStyle) command(value string) string {
+	return s.wrap("36", value)
+}
+
+func (s outputStyle) status(status platformstatus.Status, value string) string {
+	code := "35"
+	switch status {
+	case platformstatus.Healthy:
+		code = "1;32"
+	case platformstatus.Degraded:
+		code = "1;33"
+	case platformstatus.Unhealthy:
+		code = "1;31"
+	case platformstatus.Skipped:
+		code = "2"
+	}
+	return s.wrap(code, value)
+}
+
+func (s outputStyle) checkCount(status platformstatus.Status, count int, label string) string {
+	value := fmt.Sprintf("%d %s", count, label)
+	if count == 0 {
+		return s.muted(value)
+	}
+	return s.status(status, value)
+}
+
+func (s outputStyle) wrap(code, value string) string {
+	if !s.enabled {
+		return value
+	}
+	return "\x1b[" + code + "m" + value + "\x1b[0m"
+}
+
+func writerIsTerminal(out io.Writer) bool {
+	file, ok := out.(*os.File)
+	return ok && term.IsTerminal(int(file.Fd()))
+}
+
+func formatDuration(milliseconds int64) string {
+	duration := time.Duration(milliseconds) * time.Millisecond
+	if duration < time.Second {
+		return duration.String()
+	}
+	value := fmt.Sprintf("%.1f", duration.Seconds())
+	return strings.TrimSuffix(value, ".0") + "s"
+}

--- a/pkg/cli/doctor/remote.go
+++ b/pkg/cli/doctor/remote.go
@@ -1,0 +1,392 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
+)
+
+const (
+	journalSince         = "15 min ago"
+	journalLines         = 50
+	shownLogs            = 3
+	defaultSSHPort       = 22
+	sshConnectionTimeout = 5 * time.Second
+	remoteExecutionLimit = 15 * time.Second
+	remoteCommandTimeout = 10
+)
+
+var (
+	keyValueSecretPattern = regexp.MustCompile(
+		`(?i)((?:"?)(?:password|passwd|token|secret|authorization)(?:"?)[=:][[:space:]]*"?)([^",[:space:]}]+)`,
+	)
+	authorizationPattern  = regexp.MustCompile(`(?i)(authorization"?[=:][[:space:]]*)(?:bearer[[:space:]]+)?[^",;[:space:]}]+`)
+	bearerPattern         = regexp.MustCompile(`(?i)bearer\s+[A-Za-z0-9._~+/-]+=*`)
+	jwtPattern            = regexp.MustCompile(`\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b`)
+	natsCredentialPattern = regexp.MustCompile(`(?i)(nats://)[^@\s]+@`)
+	pemPrivateKeyPattern  = regexp.MustCompile(`(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----`)
+	interestingLogPattern = regexp.MustCompile(
+		`(?i)(error|failed|failure|fatal|panic|refused|timeout|unavailable|denied|stopp|disconnect|reconnect)`,
+	)
+)
+
+type commandRunner func(context.Context, *sshutils.SSH, string, string) (sshutils.Result, error)
+
+type remoteRunner struct {
+	ctx context.Context
+	ssh *sshutils.SSH
+	run commandRunner
+}
+
+type serviceState struct {
+	LoadState      string
+	UnitFileState  string
+	ActiveState    string
+	SubState       string
+	Result         string
+	ExecMainStatus string
+	NRestarts      string
+}
+
+func newRemoteRunner(ctx context.Context, sshConfig *sshutils.SSH) *remoteRunner {
+	config := *sshConfig
+	timeout := sshConnectionTimeout
+	config.ConnectionTimeout = &timeout
+	return &remoteRunner{ctx: ctx, ssh: &config, run: sshutils.SSHCmdWithSudoContext}
+}
+
+func (r *remoteRunner) runCommand(host, command string) (sshutils.Result, error) {
+	ctx := r.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, remoteExecutionLimit)
+	defer cancel()
+	if r.ssh == nil {
+		return r.run(ctx, nil, host, command)
+	}
+	config := *r.ssh
+	return r.run(ctx, &config, host, command)
+}
+
+func (r *remoteRunner) service(host, unit string) Check {
+	properties := "-p LoadState -p UnitFileState -p ActiveState -p SubState " +
+		"-p Result -p ExecMainStatus -p NRestarts"
+	command := fmt.Sprintf("timeout %d systemctl show %s %s", remoteCommandTimeout, unit, properties)
+	result, err := r.runCommand(host, command)
+	check := Check{Name: unit + "-service", Target: host}
+	if err != nil {
+		check.Status = platformstatus.Unknown
+		check.Message = fmt.Sprintf("cannot inspect %s on %s", unit, host)
+		check.Evidence = []string{sanitize(err.Error())}
+		return check
+	}
+	if result.ExitCode != 0 {
+		check.Status = platformstatus.Unknown
+		check.Message = fmt.Sprintf("cannot inspect %s on %s", unit, host)
+		check.Evidence = compactOutput(result.Stdout, result.Stderr)
+		return check
+	}
+
+	state := parseServiceState(result.Stdout)
+	check.Evidence = state.evidence()
+	switch {
+	case state.LoadState == "not-found":
+		check.Status = platformstatus.Unhealthy
+		check.Message = fmt.Sprintf("%s is not installed on %s", unit, host)
+	case state.ActiveState == "failed" || state.ActiveState == "inactive":
+		check.Status = platformstatus.Unhealthy
+		check.Message = fmt.Sprintf("%s on %s is not running", unit, host)
+	case state.ActiveState != "active":
+		check.Status = platformstatus.Degraded
+		check.Message = fmt.Sprintf("%s on %s is %s", unit, host, state.ActiveState)
+	case state.SubState == "auto-restart" || state.ActiveState == "activating":
+		check.Status = platformstatus.Degraded
+		check.Message = fmt.Sprintf("%s on %s is restarting", unit, host)
+	case state.UnitFileState == "disabled":
+		check.Status = platformstatus.Degraded
+		check.Message = fmt.Sprintf("%s on %s is running but disabled", unit, host)
+	default:
+		check.Status = platformstatus.Healthy
+		check.Message = fmt.Sprintf("%s on %s is running", unit, host)
+	}
+	if check.Status != platformstatus.Healthy {
+		check.Logs = r.journal(host, unit)
+		check.Commands = r.serviceCommands(host, unit)
+	}
+	return check
+}
+
+func (r *remoteRunner) port(host, name, endpoint string) Check {
+	endpointHost, endpointPort, splitErr := net.SplitHostPort(endpoint)
+	if splitErr != nil {
+		return Check{
+			Name: name, Target: host, Status: platformstatus.Unknown,
+			Message:  fmt.Sprintf("cannot parse endpoint %s", endpoint),
+			Evidence: []string{splitErr.Error()},
+		}
+	}
+	probe := `exec 3<>"/dev/tcp/$1/$2"`
+	command := fmt.Sprintf("timeout 3 bash -c %s -- %s %s",
+		shellQuote(probe), shellQuote(endpointHost), shellQuote(endpointPort))
+	result, err := r.runCommand(host, command)
+	check := Check{Name: name, Target: host}
+	if err != nil && result.ExitCode == 0 {
+		check.Status = platformstatus.Unknown
+		check.Message = fmt.Sprintf("cannot test %s from %s", endpoint, host)
+		check.Evidence = []string{sanitize(err.Error())}
+		return check
+	}
+	if result.ExitCode == commandNotFoundExitCode {
+		check.Status = platformstatus.Unknown
+		check.Message = fmt.Sprintf("TCP probe tools are unavailable on %s", host)
+		check.Evidence = compactOutput(result.Stdout, result.Stderr)
+		return check
+	}
+	if result.ExitCode != 0 {
+		check.Status = platformstatus.Unhealthy
+		check.Message = fmt.Sprintf("%s cannot reach %s", host, endpoint)
+		check.Evidence = append([]string{endpoint + ": connection failed"}, compactOutput(result.Stdout, result.Stderr)...)
+		check.Commands = []string{r.sshCommand(host, command)}
+		return check
+	}
+	check.Status = platformstatus.Healthy
+	check.Message = fmt.Sprintf("%s is reachable from %s", endpoint, host)
+	return check
+}
+
+func (r *remoteRunner) httpHealth(host, name, healthURL string) Check {
+	command := fmt.Sprintf("curl -kfsS --connect-timeout 3 --max-time 5 %s", shellQuote(healthURL))
+	result, err := r.runCommand(host, command)
+	check := Check{Name: name, Target: host}
+	if err != nil && result.ExitCode == 0 {
+		check.Status = platformstatus.Unknown
+		check.Message = fmt.Sprintf("cannot run %s health check on %s", name, host)
+		check.Evidence = []string{sanitize(err.Error())}
+		return check
+	}
+	if result.ExitCode == commandNotFoundExitCode {
+		check.Status = platformstatus.Unknown
+		check.Message = fmt.Sprintf("curl is unavailable on %s", host)
+		check.Evidence = compactOutput(result.Stdout, result.Stderr)
+		return check
+	}
+	if result.ExitCode != 0 {
+		check.Status = platformstatus.Unhealthy
+		check.Message = fmt.Sprintf("%s health check failed on %s", name, host)
+		check.Evidence = compactOutput(result.Stdout, result.Stderr)
+		check.Commands = []string{r.sshCommand(host, command)}
+		return check
+	}
+	check.Status = platformstatus.Healthy
+	check.Message = fmt.Sprintf("%s is healthy on %s", name, host)
+	return check
+}
+
+func (r *remoteRunner) journal(host, unit string) []string {
+	command := fmt.Sprintf("timeout %d journalctl -u %s --since %s --no-pager -n %d -o short-iso",
+		remoteCommandTimeout, unit, shellQuote(journalSince), journalLines)
+	result, err := r.runCommand(host, command)
+	if err != nil || result.ExitCode != 0 {
+		return nil
+	}
+	return selectLogLines(result.Stdout, shownLogs)
+}
+
+func (r *remoteRunner) capture(host, command string) []string {
+	result, err := r.runCommand(host, command)
+	return compactOutput(result.Stdout, result.Stderr, errorString(err))
+}
+
+func (r *remoteRunner) serviceCommands(host, unit string) []string {
+	return []string{
+		r.sshCommand(host, fmt.Sprintf("systemctl status %s --no-pager -l", unit)),
+		r.sshCommand(host, fmt.Sprintf("journalctl -u %s --since %s --no-pager", unit, shellQuote(journalSince))),
+	}
+}
+
+func (r *remoteRunner) sshCommand(host, command string) string {
+	user := "root"
+	port := defaultSSHPort
+	var options []string
+	if r.ssh != nil {
+		if r.ssh.User != "" {
+			user = r.ssh.User
+		}
+		if r.ssh.Port > 0 {
+			port = r.ssh.Port
+		}
+		if r.ssh.PkFile != "" {
+			options = append(options, "-i", shellQuote(r.ssh.PkFile))
+		}
+	}
+	if port != defaultSSHPort {
+		options = append(options, "-p", strconv.Itoa(port))
+	}
+	options = append(options, user+"@"+host, shellDoubleQuote(command))
+	return "ssh " + strings.Join(options, " ")
+}
+
+func parseServiceState(output string) serviceState {
+	values := make(map[string]string)
+	for line := range strings.SplitSeq(output, "\n") {
+		key, value, found := strings.Cut(strings.TrimSpace(line), "=")
+		if found {
+			values[key] = value
+		}
+	}
+	return serviceState{
+		LoadState: values["LoadState"], UnitFileState: values["UnitFileState"],
+		ActiveState: values["ActiveState"], SubState: values["SubState"],
+		Result: values["Result"], ExecMainStatus: values["ExecMainStatus"], NRestarts: values["NRestarts"],
+	}
+}
+
+func (s *serviceState) evidence() []string {
+	values := map[string]string{
+		"LoadState": s.LoadState, "UnitFileState": s.UnitFileState, "ActiveState": s.ActiveState,
+		"SubState": s.SubState, "Result": s.Result, "ExecMainStatus": s.ExecMainStatus, "NRestarts": s.NRestarts,
+	}
+	keys := []string{"LoadState", "UnitFileState", "ActiveState", "SubState", "Result", "ExecMainStatus", "NRestarts"}
+	result := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if values[key] != "" {
+			result = append(result, key+"="+values[key])
+		}
+	}
+	return result
+}
+
+func compactOutput(outputs ...string) []string {
+	var lines []string
+	for _, output := range outputs {
+		output = sanitize(output)
+		for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+			if line != "" {
+				lines = append(lines, sanitize(line))
+			}
+		}
+	}
+	if len(lines) > shownLogs {
+		lines = lines[len(lines)-shownLogs:]
+	}
+	return lines
+}
+
+func selectLogLines(output string, limit int) []string {
+	all := compactOutput(output)
+	var selected []string
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if interestingLogPattern.MatchString(line) {
+			selected = append(selected, sanitize(line))
+		}
+	}
+	if len(selected) == 0 {
+		selected = all
+	}
+	if len(selected) > limit {
+		selected = selected[len(selected)-limit:]
+	}
+	return selected
+}
+
+func sanitize(value string) string {
+	value = stripTerminalControls(value)
+	value = pemPrivateKeyPattern.ReplaceAllString(value, "[REDACTED-PRIVATE-KEY]")
+	value = authorizationPattern.ReplaceAllString(value, "$1[REDACTED]")
+	value = keyValueSecretPattern.ReplaceAllString(value, "$1[REDACTED]")
+	value = bearerPattern.ReplaceAllString(value, "Bearer [REDACTED]")
+	value = jwtPattern.ReplaceAllString(value, "[REDACTED-JWT]")
+	return natsCredentialPattern.ReplaceAllString(value, "$1[REDACTED]@")
+}
+
+func stripTerminalControls(value string) string {
+	var result strings.Builder
+	result.Grow(len(value))
+	for i := 0; i < len(value); i++ {
+		character := value[i]
+		if character == '\x1b' {
+			i = skipEscapeSequence(value, i)
+			continue
+		}
+		if character < 0x20 && character != '\n' && character != '\t' || character == 0x7f {
+			continue
+		}
+		result.WriteByte(character)
+	}
+	return result.String()
+}
+
+func skipEscapeSequence(value string, start int) int {
+	if start+1 >= len(value) {
+		return start
+	}
+	switch value[start+1] {
+	case '[':
+		for i := start + 2; i < len(value); i++ {
+			if value[i] >= 0x40 && value[i] <= 0x7e {
+				return i
+			}
+		}
+		return len(value) - 1
+	case ']':
+		for i := start + 2; i < len(value); i++ {
+			if value[i] == '\a' {
+				return i
+			}
+			if value[i] == '\x1b' && i+1 < len(value) && value[i+1] == '\\' {
+				return i + 1
+			}
+		}
+		return len(value) - 1
+	default:
+		return start + 1
+	}
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func shellDoubleQuote(value string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		`$`, `\$`,
+		"`", "\\`",
+	)
+	return `"` + replacer.Replace(value) + `"`
+}
+
+func sortChecks(checks []Check) {
+	sort.SliceStable(checks, func(i, j int) bool {
+		if checks[i].Target == checks[j].Target {
+			return checks[i].Name < checks[j].Name
+		}
+		return checks[i].Target < checks[j].Target
+	})
+}

--- a/pkg/cli/doctor/types.go
+++ b/pkg/cli/doctor/types.go
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package doctor
+
+import (
+	"time"
+
+	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
+)
+
+const (
+	platformTarget          = "platform"
+	platformStatus          = "platform-status"
+	natsConnectivity        = "nats-connectivity"
+	heartbeatCheck          = "heartbeat"
+	apiConfigCheck          = "api-config"
+	commandNotFoundExitCode = 127
+)
+
+type Report struct {
+	Status         platformstatus.Status
+	CheckedAt      time.Time
+	DurationMillis int64
+	Components     []Component
+}
+
+type Component struct {
+	Name    string
+	Status  platformstatus.Status
+	Message string
+	Checks  []Check
+}
+
+type Check struct {
+	Name     string
+	Target   string
+	Status   platformstatus.Status
+	Message  string
+	Evidence []string
+	Logs     []string
+	Commands []string
+}
+
+func newReport(checkedAt time.Time, duration time.Duration, components []Component) *Report {
+	status := platformstatus.Healthy
+	for i := range components {
+		components[i].Status = aggregateChecks(components[i].Checks)
+		status = worseStatus(status, components[i].Status)
+	}
+	return &Report{
+		Status:         status,
+		CheckedAt:      checkedAt,
+		DurationMillis: duration.Milliseconds(),
+		Components:     components,
+	}
+}
+
+func aggregateChecks(checks []Check) platformstatus.Status {
+	status := platformstatus.Healthy
+	meaningful := false
+	for i := range checks {
+		if checks[i].Status == platformstatus.Skipped {
+			continue
+		}
+		meaningful = true
+		status = worseStatus(status, checks[i].Status)
+	}
+	if !meaningful {
+		return platformstatus.Skipped
+	}
+	return status
+}
+
+func worseStatus(current, candidate platformstatus.Status) platformstatus.Status {
+	rank := map[platformstatus.Status]int{
+		platformstatus.Skipped:   0,
+		platformstatus.Healthy:   1,
+		platformstatus.Unknown:   2,
+		platformstatus.Degraded:  3,
+		platformstatus.Unhealthy: 4,
+	}
+	if rank[candidate] > rank[current] {
+		return candidate
+	}
+	return current
+}

--- a/pkg/cli/status/status.go
+++ b/pkg/cli/status/status.go
@@ -21,10 +21,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 	"sigs.k8s.io/yaml"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
@@ -32,7 +36,12 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
 )
 
-const defaultTimeout = 10 * time.Second
+const (
+	defaultTimeout       = 10 * time.Second
+	componentColumnWidth = 14
+	statusColumnWidth    = 12
+	labelWidth           = 8
+)
 
 type ExitError struct {
 	code int
@@ -148,6 +157,14 @@ func printStatus(out io.Writer, result *platformstatus.PlatformStatus, output st
 }
 
 func printTable(out io.Writer, result *platformstatus.PlatformStatus) error {
+	style := newStatusOutputStyle(out)
+	if style.enabled {
+		return printTerminalTable(out, result, style)
+	}
+	return printPlainTable(out, result)
+}
+
+func printPlainTable(out io.Writer, result *platformstatus.PlatformStatus) error {
 	if _, err := fmt.Fprintf(out, "KubeClipper Platform Status: %s\n", result.Status); err != nil {
 		return err
 	}
@@ -161,4 +178,101 @@ func printTable(out io.Writer, result *platformstatus.PlatformStatus) error {
 	}
 	table.Render()
 	return nil
+}
+
+func printTerminalTable(out io.Writer, result *platformstatus.PlatformStatus, style statusOutputStyle) error {
+	if _, err := fmt.Fprintln(out, style.title("KubeClipper Platform Status")); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "\n%s  %s\n",
+		style.label("Overall"), style.status(result.Status, statusMarker(result.Status)+" "+string(result.Status))); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "%s  %s\n\n",
+		style.label("Checked"), result.CheckedAt.Local().Format(time.RFC3339)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "%s  %s  %s\n",
+		style.heading(padRight("COMPONENT", componentColumnWidth)),
+		style.heading(padRight("STATUS", statusColumnWidth)),
+		style.heading("DETAILS")); err != nil {
+		return err
+	}
+	for _, component := range result.Components {
+		status := statusMarker(component.Status) + " " + string(component.Status)
+		if _, err := fmt.Fprintf(out, "%s  %s  %s\n",
+			padRight(component.Name, componentColumnWidth),
+			style.status(component.Status, padRight(status, statusColumnWidth)),
+			component.Message); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func statusMarker(status platformstatus.Status) string {
+	switch status {
+	case platformstatus.Healthy:
+		return "✓"
+	case platformstatus.Degraded:
+		return "!"
+	case platformstatus.Unhealthy:
+		return "✗"
+	default:
+		return "?"
+	}
+}
+
+func padRight(value string, width int) string {
+	displayWidth := utf8.RuneCountInString(value)
+	if displayWidth >= width {
+		return value
+	}
+	return value + strings.Repeat(" ", width-displayWidth)
+}
+
+type statusOutputStyle struct {
+	enabled bool
+}
+
+func newStatusOutputStyle(out io.Writer) statusOutputStyle {
+	file, terminal := out.(*os.File)
+	_, noColor := os.LookupEnv("NO_COLOR")
+	return statusOutputStyle{
+		enabled: terminal && term.IsTerminal(int(file.Fd())) && !noColor && os.Getenv("TERM") != "dumb",
+	}
+}
+
+func (s statusOutputStyle) title(value string) string {
+	return s.wrap("1;36", value)
+}
+
+func (s statusOutputStyle) heading(value string) string {
+	return s.wrap("2", value)
+}
+
+func (s statusOutputStyle) label(value string) string {
+	return s.wrap("1", padRight(value, labelWidth))
+}
+
+func (s statusOutputStyle) status(status platformstatus.Status, value string) string {
+	code := "35"
+	switch status {
+	case platformstatus.Healthy:
+		code = "1;32"
+	case platformstatus.Degraded:
+		code = "1;33"
+	case platformstatus.Unhealthy:
+		code = "1;31"
+	case platformstatus.Skipped:
+		code = "2"
+	}
+	return s.wrap(code, value)
+}
+
+func (s statusOutputStyle) wrap(code, value string) string {
+	if !s.enabled {
+		return value
+	}
+	return "\x1b[" + code + "m" + value + "\x1b[0m"
 }

--- a/pkg/cli/status/status_test.go
+++ b/pkg/cli/status/status_test.go
@@ -56,6 +56,29 @@ func TestPrintTable(t *testing.T) {
 	}
 }
 
+func TestPrintTerminalTableUsesStatusColors(t *testing.T) {
+	var output bytes.Buffer
+	if err := printTerminalTable(&output, testStatus(), statusOutputStyle{enabled: true}); err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		"KubeClipper Platform Status",
+		"\x1b[1;33m! Degraded",
+		"\x1b[1;32m✓ Healthy",
+		"7/8 agents running",
+	} {
+		if !strings.Contains(output.String(), expected) {
+			t.Errorf("terminal output does not contain %q:\n%s", expected, output.String())
+		}
+	}
+}
+
+func TestPadRightUsesDisplayCharacters(t *testing.T) {
+	if got, want := padRight("✓ Healthy", statusColumnWidth), "✓ Healthy   "; got != want {
+		t.Fatalf("padded status = %q, want %q", got, want)
+	}
+}
+
 func TestPrintJSONPreservesChecks(t *testing.T) {
 	var output bytes.Buffer
 	if err := printStatus(&output, testStatus(), "json"); err != nil {

--- a/pkg/simple/client/kc/api.go
+++ b/pkg/simple/client/kc/api.go
@@ -35,6 +35,7 @@ import (
 )
 
 const (
+	healthzPath          = "/healthz"
 	ListNodesPath        = "/api/core.kubeclipper.io/v1/nodes"
 	clustersPath         = "/api/core.kubeclipper.io/v1/clusters"
 	clustersCertPath     = "/api/core.kubeclipper.io/v1/clusters/%s/certification"
@@ -57,6 +58,13 @@ const (
 	operationPath = "/api/core.kubeclipper.io/v1/operations"
 	LogStreamPath = "/api/core.kubeclipper.io/v1/logs"
 )
+
+// Healthz checks whether the configured API server is live.
+func (cli *Client) Healthz(ctx context.Context) error {
+	serverResp, err := cli.get(ctx, healthzPath, nil, nil)
+	defer ensureReaderClosed(serverResp)
+	return err
+}
 
 func (cli *Client) PlatformStatus(ctx context.Context) (*platformstatus.PlatformStatus, error) {
 	serverResp, err := cli.get(ctx, platformStatusPath, nil, nil)

--- a/pkg/simple/client/kc/client_status_test.go
+++ b/pkg/simple/client/kc/client_status_test.go
@@ -44,3 +44,21 @@ func TestPlatformStatusRejectsInvalidResponse(t *testing.T) {
 		t.Fatalf("expected invalid response error, got %v", err)
 	}
 }
+
+func TestHealthz(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != healthzPath {
+			t.Fatalf("request path = %q, want %q", request.URL.Path, healthzPath)
+		}
+		writer.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithOpts(WithEndpoint(server.URL), WithHTTPClient(server.Client()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := client.Healthz(context.Background()); err != nil {
+		t.Fatalf("healthz: %v", err)
+	}
+}

--- a/pkg/utils/sshutils/cmd.go
+++ b/pkg/utils/sshutils/cmd.go
@@ -26,6 +26,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"syscall"
 
 	"github.com/kubeclipper/kubeclipper/pkg/cli/logger"
 )
@@ -76,6 +77,17 @@ func RunCmdAsSSHContext(ctx context.Context, cmdStr string) (Result, error) {
 	user := Whoami()
 	// #nosec G204 -- this helper intentionally executes the command supplied by its caller.
 	ec := exec.CommandContext(ctx, "sh", []string{"-c", cmdStr}...)
+	// A shell may leave child processes holding stdout and stderr open after it is
+	// killed. Put the command in its own process group so cancellation terminates
+	// the complete command tree and ec.Run can return promptly.
+	ec.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	ec.Cancel = func() error {
+		err := syscall.Kill(-ec.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
 	ec.Stdin = os.Stdin
 	var bout, berr bytes.Buffer
 	ec.Stdout, ec.Stderr = &bout, &berr

--- a/pkg/utils/sshutils/cmd.go
+++ b/pkg/utils/sshutils/cmd.go
@@ -20,6 +20,7 @@ package sshutils
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -65,10 +66,16 @@ func CmdToString(name string, arg ...string) (Result, error) {
 }
 
 func RunCmdAsSSH(cmdStr string) (Result, error) {
+	return RunCmdAsSSHContext(context.Background(), cmdStr)
+}
+
+// RunCmdAsSSHContext runs a local shell command and stops it when the context is canceled.
+func RunCmdAsSSHContext(ctx context.Context, cmdStr string) (Result, error) {
 	var ret Result
 
 	user := Whoami()
-	ec := exec.Command("sh", []string{"-c", cmdStr}...)
+	// #nosec G204 -- this helper intentionally executes the command supplied by its caller.
+	ec := exec.CommandContext(ctx, "sh", []string{"-c", cmdStr}...)
 	ec.Stdin = os.Stdin
 	var bout, berr bytes.Buffer
 	ec.Stdout, ec.Stderr = &bout, &berr
@@ -82,6 +89,9 @@ func RunCmdAsSSH(cmdStr string) (Result, error) {
 		Stderr:   berr.String(),
 	}
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ret, ctxErr
+		}
 		ok, exitCode := ExtraExitCode(err)
 		if !ok {
 			return ret, err

--- a/pkg/utils/sshutils/ssh_v2.go
+++ b/pkg/utils/sshutils/ssh_v2.go
@@ -20,6 +20,7 @@ package sshutils
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -93,6 +94,11 @@ type SSHRunCmd func(sshConfig *SSH, host, cmd string) (Result, error)
 
 // SSHCmdWithSudo  try to run cmd with sudo.
 func SSHCmdWithSudo(sshConfig *SSH, host, cmd string) (Result, error) {
+	return SSHCmdWithSudoContext(context.Background(), sshConfig, host, cmd)
+}
+
+// SSHCmdWithSudoContext runs a command with sudo and cancels the SSH session with the context.
+func SSHCmdWithSudoContext(ctx context.Context, sshConfig *SSH, host, cmd string) (Result, error) {
 	var (
 		sudoCmd = cmd
 		err     error
@@ -109,19 +115,24 @@ func SSHCmdWithSudo(sshConfig *SSH, host, cmd string) (Result, error) {
 			return result, err
 		}
 	}
-	return SSHCmd(sshConfig, host, sudoCmd)
+	return SSHCmdContext(ctx, sshConfig, host, sudoCmd)
 }
 
 // SSHCmd synchronously SSHs to a node running on provider and runs cmd. If there
 // is no error performing the SSH, the stdout, stderr, and exit code are
 // returned.
 func SSHCmd(sshConfig *SSH, host, cmd string) (Result, error) {
+	return SSHCmdContext(context.Background(), sshConfig, host, cmd)
+}
+
+// SSHCmdContext synchronously runs a remote command and closes the SSH connection on cancellation.
+func SSHCmdContext(ctx context.Context, sshConfig *SSH, host, cmd string) (Result, error) {
 	// if caller don't provide enough config for run ssh cmd，change to run cmd by os.exec on localhost.
 	// only for aio deploy now.
 	if SSHToCmd(sshConfig, host) {
-		return RunCmdAsSSH(cmd)
+		return RunCmdAsSSHContext(ctx, cmd)
 	}
-	stdout, stderr, code, err := runSSHCommand(sshConfig, host, cmd)
+	stdout, stderr, code, err := runSSHCommandContext(ctx, sshConfig, host, cmd)
 	result := Result{
 		User:     sshConfig.User,
 		Host:     host,
@@ -140,17 +151,34 @@ func SSHCmd(sshConfig *SSH, host, cmd string) (Result, error) {
 	return result, result.error()
 }
 
-// runSSHCommand returns the stdout, stderr, and exit code from running cmd on
+// runSSHCommandContext returns the stdout, stderr, and exit code from running cmd on
 // host as specific user, along with any SSH-level error.
-func runSSHCommand(sshConfig *SSH, host, cmd string) (stdout, stderr string, exitcode int, err error) {
+func runSSHCommandContext(
+	ctx context.Context,
+	sshConfig *SSH,
+	host, cmd string,
+) (stdout, stderr string, exitcode int, err error) {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return "", "", 0, ctxErr
+	}
 	pCmd := printCmd(sshConfig.Password, cmd)
 	client, err := sshConfig.NewClient(host)
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", "", 0, ctxErr
+		}
 		return "", "", 0, err
 	}
 	defer client.Close()
+	stopCancel := context.AfterFunc(ctx, func() {
+		_ = client.Close()
+	})
+	defer stopCancel()
 	session, err := client.NewSession()
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", "", 0, ctxErr
+		}
 		return "", "", 0, err
 	}
 	defer session.Close()
@@ -159,6 +187,9 @@ func runSSHCommand(sshConfig *SSH, host, cmd string) (stdout, stderr string, exi
 	var bout, berr bytes.Buffer
 	session.Stdout, session.Stderr = &bout, &berr
 	if err = session.Run(cmd); err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return bout.String(), berr.String(), exitcode, ctxErr
+		}
 		// Check whether the command failed to run or didn't complete.
 		if exiterr, ok := err.(*ssh.ExitError); ok {
 			// If we got an ExitError and the exit code is nonzero, we'll

--- a/pkg/utils/sshutils/ssh_v2_test.go
+++ b/pkg/utils/sshutils/ssh_v2_test.go
@@ -19,10 +19,26 @@
 package sshutils
 
 import (
+	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestSSHCmdWithSudoContextCancelsLocalCommand(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	startedAt := time.Now()
+	_, err := SSHCmdWithSudoContext(ctx, nil, "", "sleep 30")
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("command cancellation took %s", elapsed)
+	}
+}
 
 func TestSSHCmd(t *testing.T) {
 	defer func() {


### PR DESCRIPTION
### What type of PR is this?

/kind feature

### What this PR does / why we need it:

- Adds `kcctl doctor` for read-only KubeClipper platform diagnostics.
- Checks local kcctl access, kc-server subsystems, kc-etcd health, and kc-agent heartbeat, systemd, and NATS connectivity.
- Uses the existing `~/.kc/config` and `~/.kc/deploy-config.yaml` files without adding command flags.
- Continues SSH diagnostics when the platform API is unavailable.
- Expands failures with sanitized evidence, recent journal logs, and copyable manual troubleshooting commands.
- Adds bounded, context-aware SSH execution and passes TCP probe endpoints as shell arguments.
- Adds terminal-aware status colors and aligned compact output for `kcctl status` and `kcctl doctor`; redirected and machine-readable output remains free of ANSI sequences.

### Which issue(s) this PR fixes:

N/A

### Special notes for reviewers:

```
The command does not perform automatic repairs.

Embedded NATS is diagnosed through kc-server. External NATS is intentionally skipped.

Validation performed:
- golangci-lint on the changed packages: 0 issues
- race tests for doctor, status, kc client, sshutils, and server
- kcctl Linux amd64 build
- sh-dev-3 healthy validation: 21 passed, 0 failed, 0 skipped
- sh-dev-3 failure validation: stopped kc-agent, detected inactive systemd state, displayed sanitized logs and manual commands, returned exit code 1, then restored and revalidated the service
```

### Does this PR introduced a user-facing change?

```release-note
Add the kcctl doctor command for KubeClipper platform diagnostics and improve terminal status output with color-aware, aligned component summaries.
```

### Additional documentation, usage docs, etc.:

```docs
N/A
```
