### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ our [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) for details.
 
 ## Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=kubeclipper/kubeclipper&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=kubeclipper/kubeclipper&type=Date)
 
 ---
 


### PR DESCRIPTION
The star history chart shown in the README is currently broken due to GitHub restricting its stargazer API. This change points the chart to a working data source so the chart renders correctly again.

Signed-off-by: KubeClipper Developers