### PR TITLE
fix(operation): persist controller status updates

### DIFF
--- a/pkg/server/registry/operationv2/strategy.go
+++ b/pkg/server/registry/operationv2/strategy.go
@@ -82,13 +82,12 @@ func (operationStrategy) PrepareForUpdate(_ context.Context, obj, old runtime.Ob
 	if !ok {
 		return
 	}
-	// Status is updated through OperationStore; ordinary REST updates may only
-	// change the two explicitly controlled spec fields.
+	// The execution plan is immutable. Operation status is a controller fact;
+	// the only public mutation paths are the controlled cancel and retry APIs.
 	op.Spec.TargetRef = oldOp.Spec.TargetRef
 	op.Spec.Action = oldOp.Spec.Action
 	op.Spec.Timeout = oldOp.Spec.Timeout
 	op.Spec.Steps = oldOp.Spec.Steps
-	op.Status = oldOp.Status
 	op.TypeMeta = oldOp.TypeMeta
 }
 

--- a/pkg/server/registry/operationv2/strategy_test.go
+++ b/pkg/server/registry/operationv2/strategy_test.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package operationv2
+
+import (
+	"context"
+	"testing"
+
+	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
+)
+
+func TestOperationStrategyPreservesStatus(t *testing.T) {
+	strategy := operationStrategy{}
+	oldOperation := &operations.Operation{Status: operations.OperationStatus{Phase: operations.OperationPending}}
+
+	updated := oldOperation.DeepCopy()
+	updated.Status.Phase = operations.OperationSucceeded
+	strategy.PrepareForUpdate(context.Background(), updated, oldOperation)
+	if updated.Status.Phase != operations.OperationSucceeded {
+		t.Fatalf("status phase = %q, want %q", updated.Status.Phase, operations.OperationSucceeded)
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

Fixes an Operation v2 regression where the controller could update an Operation status in memory, but the registry update strategy unconditionally restored the old status before storage persisted it.

The controller therefore appeared to reconcile successfully while the Operation remained `Pending` in etcd and no Task was dispatched. The fix leaves Controller-written status unchanged during strategy preparation while preserving the immutable execution plan.

### Which issue(s) this PR fixes:

N/A. Found during real Operation v2 end-to-end lifecycle validation.

### Special notes for reviewers:

Operation v2 does not expose a generic Operation update endpoint. Its only public mutations are the controlled cancel and retry APIs, which update `spec.desiredState` and `spec.retryGeneration` through `OperationStore`. The registry strategy continues to freeze the execution plan; phase-transition validation and the store's UID/resourceVersion CAS continue to protect controller-owned status.

Validated with:

```
go test ./pkg/models/operationv2 ./pkg/server/registry/operationv2 ./pkg/controller/operationv2 ./pkg/controller-runtime/source
```

Also validated on three hosts with the rebuilt binaries: create cluster, add worker, remove worker, and delete cluster all completed successfully. The test verifies that strategy preparation does not overwrite the pending status with an old value.

### Does this PR introduced a user-facing change?

```release-note
Fix Operation v2 status persistence so pending operations can dispatch and execute their tasks.
```

### Additional documentation, usage docs, etc.:

```docs
None.
```