### PR TITLE
fix: restore agent status and doctor configuration

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"time"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
@@ -34,6 +35,7 @@ import (
 	operationv2 "github.com/kubeclipper/kubeclipper/pkg/agent/operationv2"
 	"github.com/kubeclipper/kubeclipper/pkg/client/clientset"
 	"github.com/kubeclipper/kubeclipper/pkg/logger"
+	"github.com/kubeclipper/kubeclipper/pkg/nodestatus"
 	"github.com/kubeclipper/kubeclipper/pkg/oplog"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
@@ -73,7 +75,13 @@ func (a taskClientAdapter) UpdateStatus(ctx context.Context, task *operations.Op
 	return a.client.UpdateStatus(ctx, task, metav1.UpdateOptions{})
 }
 
-const nodeStatusUpdateTimeout = 30 * time.Second
+const (
+	nodeStatusUpdateTimeout   = 30 * time.Second
+	nodeLeaseNamespace        = "node-lease"
+	nodeLeaseDurationSeconds  = int32(240)
+	nodeLeaseRenewInterval    = time.Duration(nodeLeaseDurationSeconds) * time.Second / 4
+	nodeLeaseMaxUpdateRetries = 5
+)
 
 func (s *Server) PrepareRun(stopCh <-chan struct{}) error {
 	opLog, err := oplog.NewOperationLog(s.Config.OpLogOptions)
@@ -166,6 +174,9 @@ func (s *Server) initialNode() *corev1.Node {
 	if gateway, err := netutil.GetDefaultGateway(true); err == nil {
 		node.Status.Ipv4DefaultGw = gateway.String()
 	}
+	if err := nodestatus.MachineInfo()(node); err != nil {
+		logger.Errorf("collect node machine information: %v", err)
+	}
 	return node
 }
 
@@ -177,11 +188,70 @@ func (s *Server) Run(stopCh <-chan struct{}) error {
 		return err
 	}
 	go s.reportNodeStatus(stopCh)
+	go s.reportNodeLease(stopCh)
 	<-stopCh
 	logger.Debugf("get stopCh signal, exit...")
 	s.logServer.Close()
 	s.worker.Close()
 	return nil
+}
+
+func (s *Server) reportNodeLease(stopCh <-chan struct{}) {
+	ticker := time.NewTicker(nodeLeaseRenewInterval)
+	defer ticker.Stop()
+	for {
+		if err := s.renewNodeLease(); err != nil {
+			logger.Errorf("renew Node Lease: %v", err)
+		}
+		select {
+		case <-stopCh:
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *Server) renewNodeLease() error {
+	ctx, cancel := context.WithTimeout(context.Background(), nodeStatusUpdateTimeout)
+	defer cancel()
+
+	leases := s.client.CoreV1().Leases()
+	for range nodeLeaseMaxUpdateRetries {
+		lease, err := leases.GetWithNamespace(ctx, s.Config.AgentID, nodeLeaseNamespace, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			_, err = leases.Create(ctx, s.newNodeLease(nil), &metav1.CreateOptions{})
+			if apierrors.IsAlreadyExists(err) {
+				continue
+			}
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		_, err = leases.Update(ctx, s.newNodeLease(lease), &metav1.UpdateOptions{})
+		if apierrors.IsConflict(err) {
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("renew Node Lease %q: too many resource version conflicts", s.Config.AgentID)
+}
+
+func (s *Server) newNodeLease(base *coordinationv1.Lease) *coordinationv1.Lease {
+	var lease *coordinationv1.Lease
+	if base == nil {
+		lease = &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{
+			Name: s.Config.AgentID, Namespace: nodeLeaseNamespace,
+		}}
+	} else {
+		lease = base.DeepCopy()
+	}
+	holderIdentity := s.Config.AgentID
+	leaseDuration := nodeLeaseDurationSeconds
+	lease.Spec.HolderIdentity = &holderIdentity
+	lease.Spec.LeaseDurationSeconds = &leaseDuration
+	lease.Spec.RenewTime = &metav1.MicroTime{Time: time.Now()}
+	return lease
 }
 
 func (s *Server) reportNodeStatus(stopCh <-chan struct{}) {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -17,10 +17,19 @@
 package agent
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+
 	"github.com/kubeclipper/kubeclipper/pkg/agent/config"
+	"github.com/kubeclipper/kubeclipper/pkg/client/clientset"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 )
 
 func TestInitialNodePublishesHostnameLabel(t *testing.T) {
@@ -35,4 +44,99 @@ func TestInitialNodePublishesHostnameLabel(t *testing.T) {
 	if got := node.Labels[common.LabelHostname]; got != node.Status.NodeInfo.Hostname {
 		t.Fatalf("hostname label = %q, want %q", got, node.Status.NodeInfo.Hostname)
 	}
+	if _, found := node.Status.Capacity[corev1.ResourceCPU]; !found {
+		t.Fatal("expected CPU capacity in node status")
+	}
+	if _, found := node.Status.Capacity[corev1.ResourceMemory]; !found {
+		t.Fatal("expected memory capacity in node status")
+	}
+}
+
+func TestNewNodeLease(t *testing.T) {
+	server := &Server{Config: &config.Config{AgentID: "agent-1"}}
+	lease := server.newNodeLease(nil)
+
+	if got, want := lease.Name, "agent-1"; got != want {
+		t.Fatalf("lease name = %q, want %q", got, want)
+	}
+	if got, want := lease.Namespace, nodeLeaseNamespace; got != want {
+		t.Fatalf("lease namespace = %q, want %q", got, want)
+	}
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != "agent-1" {
+		t.Fatalf("lease holder identity = %v, want agent-1", lease.Spec.HolderIdentity)
+	}
+	if lease.Spec.LeaseDurationSeconds == nil || *lease.Spec.LeaseDurationSeconds != nodeLeaseDurationSeconds {
+		t.Fatalf("lease duration = %v, want %d", lease.Spec.LeaseDurationSeconds, nodeLeaseDurationSeconds)
+	}
+	if lease.Spec.RenewTime == nil {
+		t.Fatal("expected lease renew time")
+	}
+}
+
+func TestRenewNodeLeaseCreatesMissingLease(t *testing.T) {
+	t.Parallel()
+
+	server, requests := newMissingLeaseServer(t)
+	defer server.Close()
+
+	client, err := clientset.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("NewForConfig() error = %v", err)
+	}
+	agent := &Server{Config: &config.Config{AgentID: "agent-1"}, client: client}
+	if err := agent.renewNodeLease(); err != nil {
+		t.Fatalf("renewNodeLease() error = %v", err)
+	}
+	if *requests != 2 {
+		t.Fatalf("request count = %d, want 2", *requests)
+	}
+}
+
+func newMissingLeaseServer(t *testing.T) (server *httptest.Server, requests *int) {
+	t.Helper()
+	requestCount := 0
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		switch requestCount {
+		case 1:
+			if got, want := r.Method, http.MethodGet; got != want {
+				t.Errorf("get method = %q, want %q", got, want)
+			}
+			if got, want := r.URL.Path, "/api/core.kubeclipper.io/v1/leases/agent-1"; got != want {
+				t.Errorf("get path = %q, want %q", got, want)
+			}
+			if got, want := r.URL.Query().Get("namespace"), nodeLeaseNamespace; got != want {
+				t.Errorf("get namespace = %q, want %q", got, want)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			if err := json.NewEncoder(w).Encode(&metav1.Status{Status: metav1.StatusFailure, Reason: metav1.StatusReasonNotFound, Code: http.StatusNotFound}); err != nil {
+				t.Errorf("encode status: %v", err)
+			}
+		case 2:
+			if got, want := r.Method, http.MethodPost; got != want {
+				t.Errorf("create method = %q, want %q", got, want)
+			}
+			if got, want := r.URL.Path, "/api/core.kubeclipper.io/v1/leases"; got != want {
+				t.Errorf("create path = %q, want %q", got, want)
+			}
+			var lease coordinationv1.Lease
+			if err := json.NewDecoder(r.Body).Decode(&lease); err != nil {
+				t.Errorf("decode lease: %v", err)
+			}
+			if got, want := lease.Namespace, nodeLeaseNamespace; got != want {
+				t.Errorf("lease namespace = %q, want %q", got, want)
+			}
+			if lease.Spec.RenewTime == nil {
+				t.Error("lease renew time is nil")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			if err := json.NewEncoder(w).Encode(&lease); err != nil {
+				t.Errorf("encode lease: %v", err)
+			}
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	return server, &requestCount
 }

--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	apimachineryErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -1817,6 +1818,51 @@ func (h *handler) ListLeases(request *restful.Request, response *restful.Respons
 	response.WriteHeader(http.StatusOK)
 }
 
+func (h *handler) CreateLease(request *restful.Request, response *restful.Response) {
+	leaseObj := &coordinationv1.Lease{}
+	if err := request.ReadEntity(leaseObj); err != nil {
+		restplus.HandleBadRequest(response, request, err)
+		return
+	}
+	created, err := h.leaseOperator.CreateLease(request.Request.Context(), leaseObj)
+	if err != nil {
+		if apimachineryErrors.IsAlreadyExists(err) {
+			restplus.HandleConflict(response, request, err)
+			return
+		}
+		restplus.HandleInternalError(response, request, err)
+		return
+	}
+	if err := response.WriteHeaderAndEntity(http.StatusCreated, created); err != nil {
+		return
+	}
+}
+
+func (h *handler) UpdateLease(request *restful.Request, response *restful.Response) {
+	leaseObj := &coordinationv1.Lease{}
+	if err := request.ReadEntity(leaseObj); err != nil {
+		restplus.HandleBadRequest(response, request, err)
+		return
+	}
+	leaseObj.Name = request.PathParameter(query.ParameterName)
+	updated, err := h.leaseOperator.UpdateLease(request.Request.Context(), leaseObj)
+	if err != nil {
+		if apimachineryErrors.IsConflict(err) {
+			restplus.HandleConflict(response, request, err)
+			return
+		}
+		if apimachineryErrors.IsNotFound(err) {
+			restplus.HandleNotFound(response, request, err)
+			return
+		}
+		restplus.HandleInternalError(response, request, err)
+		return
+	}
+	if err := response.WriteHeaderAndEntity(http.StatusOK, updated); err != nil {
+		return
+	}
+}
+
 func (h *handler) watchLeases(req *restful.Request, resp *restful.Response, q *query.Query) {
 	timeout := time.Duration(0)
 	if q.TimeoutSeconds != nil {
@@ -1837,7 +1883,16 @@ func (h *handler) watchLeases(req *restful.Request, resp *restful.Response, q *q
 func (h *handler) DescribeLease(request *restful.Request, response *restful.Response) {
 	name := request.PathParameter(query.ParameterName)
 	resourceVersion := request.QueryParameter(query.ParameterResourceVersion)
-	c, err := h.leaseOperator.GetLease(request.Request.Context(), name, resourceVersion)
+	namespace := request.QueryParameter("namespace")
+	var (
+		c   *coordinationv1.Lease
+		err error
+	)
+	if namespace == "" {
+		c, err = h.leaseOperator.GetLease(request.Request.Context(), name, resourceVersion)
+	} else {
+		c, err = h.leaseOperator.GetLeaseWithNamespaceEx(request.Request.Context(), name, namespace, resourceVersion)
+	}
 	if err != nil {
 		if apimachineryErrors.IsNotFound(err) {
 			restplus.HandleNotFound(response, request, err)

--- a/pkg/apis/core/v1/registry.go
+++ b/pkg/apis/core/v1/registry.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/emicklei/go-restful"
 	restfulspec "github.com/emicklei/go-restful-openapi"
+	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/kubeclipper/kubeclipper/pkg/models"
@@ -432,18 +433,36 @@ func SetupWebService(h *handler) *restful.WebService {
 			Required(false)).
 		Returns(http.StatusOK, http.StatusText(http.StatusOK), models.PageableResponse{}))
 
+	webservice.Route(webservice.POST("/leases").
+		To(h.CreateLease).
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreRegionTag}).
+		Doc("Create a lease.").
+		Reads(coordinationv1.Lease{}).
+		Returns(http.StatusCreated, http.StatusText(http.StatusCreated), coordinationv1.Lease{}))
+
 	webservice.Route(webservice.GET("/leases/{name}").
 		To(h.DescribeLease).
 		Metadata(restfulspec.KeyOpenAPITags, []string{CoreRegionTag}).
-		Doc("Describe region.").
-		Param(webservice.PathParameter(query.ParameterName, "region name").
+		Doc("Describe a lease.").
+		Param(webservice.PathParameter(query.ParameterName, "lease name").
 			Required(true).
+			DataType("string")).
+		Param(webservice.QueryParameter("namespace", "lease namespace").
+			Required(false).
 			DataType("string")).
 		Param(webservice.QueryParameter(query.ParameterResourceVersion, "resource version to query").
 			Required(false).
 			DataType("string")).
-		Returns(http.StatusOK, http.StatusText(http.StatusOK), corev1.Region{}).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), coordinationv1.Lease{}).
 		Returns(http.StatusNotFound, http.StatusText(http.StatusNotFound), nil))
+
+	webservice.Route(webservice.PUT("/leases/{name}").
+		To(h.UpdateLease).
+		Metadata(restfulspec.KeyOpenAPITags, []string{CoreRegionTag}).
+		Doc("Update a lease.").
+		Reads(coordinationv1.Lease{}).
+		Param(webservice.PathParameter(query.ParameterName, "lease name").Required(true).DataType("string")).
+		Returns(http.StatusOK, http.StatusText(http.StatusOK), coordinationv1.Lease{}))
 
 	webservice.Route(webservice.GET("/backups").
 		To(h.ListBackups).

--- a/pkg/cli/clean/clean.go
+++ b/pkg/cli/clean/clean.go
@@ -123,7 +123,7 @@ func (c *CleanOptions) Complete() error {
 		}
 
 		// deploy-config Complete
-		c.deployConfig, err = deploy.GetDeployConfig(context.Background(), c.client, false)
+		c.deployConfig, err = deploy.GetDeployConfig(context.Background(), c.client, true)
 		if err != nil {
 			return errors.WithMessage(err, "get online deploy-config failed")
 		}

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -185,14 +185,18 @@ func NewCmdDeploy(streams options.IOStreams) *cobra.Command {
 		Short:                 "Deploy Kubeclipper platform",
 		Long:                  longDescription,
 		Example:               deployExample,
-		Run: func(cmd *cobra.Command, args []string) {
-			utils.CheckErr(o.Complete())
-			utils.CheckErr(o.ValidateArgs())
+		RunE: func(_ *cobra.Command, _ []string) error {
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			if err := o.ValidateArgs(); err != nil {
+				return err
+			}
 			o.preRun()
 			if !o.preCheck() {
-				return
+				return fmt.Errorf("deploy precheck failed")
 			}
-			utils.CheckErr(o.RunDeploy())
+			return o.RunDeploy()
 		},
 		Args: cobra.NoArgs,
 	}
@@ -328,17 +332,20 @@ func (d *DeployOptions) preRun() {
 
 type precheckFunc func(sshConfig *sshutils.SSH, host string) error
 
+const (
+	timeSyncPrecheckCommand = `for service in chrony chronyd ntp ntpd systemd-timesyncd; ` +
+		`do systemctl is-active --quiet "$service" && exit 0; done; exit 10`
+	timeSyncServiceMissingExitCode = 10
+)
+
 var (
 	precheckKcEtcdFunc                = generateCommonPreCheckFunc("kc-etcd")
 	precheckKcServerFunc              = generateCommonPreCheckFunc("kc-server")
 	precheckKcAgentFunc               = generateCommonPreCheckFunc("kc-agent")
 	precheckNtpFunc      precheckFunc = func(sshConfig *sshutils.SSH, host string) error {
-		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, "systemctl --all --type service --state running | grep -e chrony -e ntp|wc -l")
-		if err != nil {
-			return err
-		}
-		if ret.StdoutToString("") == "0" {
-			err = fmt.Errorf("chronyd or ntpd service not running, may cause service internal error")
+		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, timeSyncPrecheckCommand)
+		if ret.ExitCode == timeSyncServiceMissingExitCode {
+			return fmt.Errorf("no supported time synchronization service is running (chrony, ntp, or systemd-timesyncd)")
 		}
 		return err
 	}
@@ -429,11 +436,7 @@ func (d *DeployOptions) precheckService(name string, nodes []string, fn precheck
 		}
 	}
 	logger.Errorf("===========>%s PRECHECK FAILED!", name)
-	if options.AssumeYes {
-		return true
-	}
-	_, _ = d.IOStreams.Out.Write([]byte("Ignore this error, still install? Please input (yes/no)"))
-	return utils.AskForConfirmation()
+	return false
 }
 
 func (d *DeployOptions) precheckTimeLag() bool {
@@ -503,11 +506,7 @@ func (d *DeployOptions) precheckTimeLag() bool {
 		}
 	}
 	logger.Errorf("===========>TIME-LAG PRECHECK FAILED!")
-	if options.AssumeYes {
-		return true
-	}
-	_, _ = d.IOStreams.Out.Write([]byte("Ignore this error, still install? Please input (yes/no)"))
-	return utils.AskForConfirmation()
+	return false
 }
 
 func (d *DeployOptions) precheckPorts() bool {
@@ -617,6 +616,9 @@ func (d *DeployOptions) RunDeploy() error {
 	d.dumpConfig()
 	logger.Infof("------ Upload configs ------")
 	d.uploadConfig()
+	if err := writeLocalDeployConfig(d.deployConfig); err != nil {
+		return fmt.Errorf("sync local deploy config: %w", err)
+	}
 	fmt.Printf("\033[1;40;36m%s\033[0m\n", options.Contact)
 	return nil
 }

--- a/pkg/cli/deploy/deploy_config.go
+++ b/pkg/cli/deploy/deploy_config.go
@@ -33,8 +33,9 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/simple/client/kc"
 )
 
-// GetDeployConfig get online deploy config and dump to local if we need.
-func GetDeployConfig(ctx context.Context, cli *kc.Client, dump bool) (*options.DeployConfig, error) {
+// GetDeployConfig returns the authoritative deployment configuration stored by kc-server.
+// When syncLocal is true, it also refreshes the default local cache.
+func GetDeployConfig(ctx context.Context, cli *kc.Client, syncLocal bool) (*options.DeployConfig, error) {
 	dc := new(options.DeployConfig)
 	configMap, err := cli.DescribeConfigMap(ctx, constatns.DeployConfigConfigMapName)
 	if err != nil {
@@ -52,21 +53,17 @@ func GetDeployConfig(ctx context.Context, cli *kc.Client, dump bool) (*options.D
 		dc.Agents = make(options.Agents)
 	}
 
-	if !dump {
-		if err = dc.Write(); err != nil {
+	if syncLocal {
+		if err = writeLocalDeployConfig(dc); err != nil {
 			return nil, errors.WithMessage(err, "dump local deploy-config")
 		}
 	}
 	return dc, nil
 }
 
-// UpdateDeployConfig update online deploy config and dump to local if we need.
-func UpdateDeployConfig(ctx context.Context, cli *kc.Client, deployConfig *options.DeployConfig, dump bool) error {
-	if dump {
-		if err := deployConfig.Write(); err != nil {
-			return errors.WithMessage(err, "dump local deploy config")
-		}
-	}
+// UpdateDeployConfig updates the authoritative deployment configuration first.
+// The local cache is refreshed only after the server accepts the update.
+func UpdateDeployConfig(ctx context.Context, cli *kc.Client, deployConfig *options.DeployConfig, syncLocal bool) error {
 	marshal, err := yaml.Marshal(deployConfig)
 	if err != nil {
 		return err
@@ -75,19 +72,37 @@ func UpdateDeployConfig(ctx context.Context, cli *kc.Client, deployConfig *optio
 	defer cancelFunc()
 
 	// kcctl join、drain will update online config after cmd success,so update with retry to avoid data inconsistency
-	return utils.RetryFunc(timeout, component.Options{DryRun: false}, time.Second, "updateDeployConfig", func(ctx context.Context, opts component.Options) error {
-		configMap, err := cli.DescribeConfigMap(ctx, constatns.DeployConfigConfigMapName)
-		if err != nil {
-			return errors.WithMessage(err, "get configmap")
-		}
-		if len(configMap.Items) == 0 {
-			return fmt.Errorf("configmap %s not found in server", constatns.DeployConfigConfigMapName)
-		}
-		cm := configMap.Items[0]
-		cm.Data[constatns.DeployConfigConfigMapKey] = string(marshal)
-		if _, err = cli.UpdateConfigMap(ctx, &cm); err != nil {
-			return errors.WithMessage(err, "update online deploy config")
-		}
+	if err := utils.RetryFunc(
+		timeout, component.Options{DryRun: false}, time.Second, "updateDeployConfig",
+		func(ctx context.Context, _ component.Options) error {
+			configMap, err := cli.DescribeConfigMap(ctx, constatns.DeployConfigConfigMapName)
+			if err != nil {
+				return errors.WithMessage(err, "get configmap")
+			}
+			if len(configMap.Items) == 0 {
+				return fmt.Errorf("configmap %s not found in server", constatns.DeployConfigConfigMapName)
+			}
+			cm := configMap.Items[0]
+			cm.Data[constatns.DeployConfigConfigMapKey] = string(marshal)
+			if _, err = cli.UpdateConfigMap(ctx, &cm); err != nil {
+				return errors.WithMessage(err, "update online deploy config")
+			}
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+	if !syncLocal {
 		return nil
-	})
+	}
+	if err := writeLocalDeployConfig(deployConfig); err != nil {
+		return errors.WithMessage(err, "dump local deploy config")
+	}
+	return nil
+}
+
+func writeLocalDeployConfig(deployConfig *options.DeployConfig) error {
+	localCopy := *deployConfig
+	localCopy.Config = ""
+	return localCopy.Write()
 }

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -20,12 +20,34 @@ package deploy
 
 import (
 	"crypto/x509"
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
 )
+
+func TestPrecheckServiceDoesNotIgnoreFailureWithAssumeYes(t *testing.T) {
+	originalAssumeYes := options.AssumeYes
+	options.AssumeYes = true
+	t.Cleanup(func() { options.AssumeYes = originalAssumeYes })
+
+	d := NewDeployOptions(options.IOStreams{})
+	if d.precheckService("test", []string{"192.0.2.1"}, func(*sshutils.SSH, string) error {
+		return errors.New("precheck failed")
+	}) {
+		t.Fatal("precheckService() succeeded with --assumeyes after a precheck failure")
+	}
+}
+
+func TestTimeSyncPrecheckSupportsSystemdTimesyncd(t *testing.T) {
+	if !strings.Contains(timeSyncPrecheckCommand, "systemd-timesyncd") {
+		t.Fatalf("time synchronization precheck must support systemd-timesyncd: %q", timeSyncPrecheckCommand)
+	}
+}
 
 func TestKcServerCertificateUsesAuthenticatedServerIdentity(t *testing.T) {
 	certs := kcServerCertList([]string{options.KCServerAltName}, map[string][]x509.ExtKeyUsage{

--- a/pkg/cli/doctor/doctor.go
+++ b/pkg/cli/doctor/doctor.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
 	"github.com/kubeclipper/kubeclipper/pkg/cli/config"
+	"github.com/kubeclipper/kubeclipper/pkg/cli/deploy"
 	"github.com/kubeclipper/kubeclipper/pkg/platformstatus"
 	"github.com/kubeclipper/kubeclipper/pkg/query"
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
@@ -142,25 +143,6 @@ func (o *Options) run(ctx context.Context) *Report {
 
 func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) Component {
 	component := Component{Name: "kcctl"}
-	deployConfig, err := loadDeployConfig(o.deployConfigPath)
-	if err != nil {
-		status := platformstatus.Degraded
-		message := fmt.Sprintf("cannot load %s", o.deployConfigPath)
-		if !errors.Is(err, os.ErrNotExist) {
-			message = fmt.Sprintf("invalid deployment configuration: %v", err)
-		}
-		component.Checks = append(component.Checks, Check{
-			Name: "deploy-config", Status: status, Message: message,
-			Evidence: []string{"remote service, network and journal checks will be skipped"},
-		})
-	} else {
-		state.deployConfig = deployConfig
-		state.remote = newRemoteRunner(ctx, deployConfig.SSHConfig)
-		component.Checks = append(component.Checks, Check{
-			Name: "deploy-config", Status: platformstatus.Healthy, Message: "deployment configuration loaded",
-		})
-	}
-
 	apiConfig, err := config.TryLoadFromFile(o.configPath)
 	if err != nil {
 		component.Checks = append(component.Checks, Check{
@@ -188,6 +170,7 @@ func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) 
 	defer cancel()
 	healthErr := client.Healthz(apiCtx)
 	if healthErr != nil {
+		o.useLocalDeployConfig(ctx, state, &component, "API is unreachable")
 		component.Checks = append(component.Checks, Check{
 			Name: "api-health", Status: platformstatus.Unhealthy, Message: "KubeClipper API is unreachable",
 			Evidence: []string{sanitize(healthErr.Error())},
@@ -198,6 +181,18 @@ func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) 
 	component.Checks = append(component.Checks, Check{
 		Name: "api-health", Status: platformstatus.Healthy, Message: "API liveness check passed",
 	})
+	deployCtx, deployCancel := context.WithTimeout(ctx, apiTimeout)
+	defer deployCancel()
+	deployConfig, deployErr := deploy.GetDeployConfig(deployCtx, client, false)
+	if deployErr != nil {
+		o.useLocalDeployConfig(ctx, state, &component, "cannot read deployment configuration from API")
+	} else {
+		state.deployConfig = deployConfig
+		state.remote = newRemoteRunner(ctx, deployConfig.SSHConfig)
+		component.Checks = append(component.Checks, Check{
+			Name: deployConfigCheck, Status: platformstatus.Healthy, Message: "deployment configuration loaded from API",
+		})
+	}
 
 	statusCtx, statusCancel := context.WithTimeout(ctx, apiTimeout)
 	defer statusCancel()
@@ -233,6 +228,27 @@ func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) 
 	}
 	component.Message = "connected to KubeClipper API"
 	return component
+}
+
+func (o *Options) useLocalDeployConfig(ctx context.Context, state *diagnosticState, component *Component, reason string) {
+	deployConfig, err := loadDeployConfig(o.deployConfigPath)
+	if err != nil {
+		message := fmt.Sprintf("%s; cannot load local deployment configuration", reason)
+		if !errors.Is(err, os.ErrNotExist) {
+			message = fmt.Sprintf("%s; invalid local deployment configuration: %v", reason, err)
+		}
+		component.Checks = append(component.Checks, Check{
+			Name: deployConfigCheck, Status: platformstatus.Degraded, Message: message,
+			Evidence: []string{"remote service, network and journal checks will be skipped"},
+		})
+		return
+	}
+	state.deployConfig = deployConfig
+	state.remote = newRemoteRunner(ctx, deployConfig.SSHConfig)
+	component.Checks = append(component.Checks, Check{
+		Name: deployConfigCheck, Status: platformstatus.Degraded,
+		Message: reason + "; using local deployment configuration cache",
+	})
 }
 
 func loadDeployConfig(path string) (*options.DeployConfig, error) {

--- a/pkg/cli/doctor/types.go
+++ b/pkg/cli/doctor/types.go
@@ -27,6 +27,7 @@ const (
 	platformStatus          = "platform-status"
 	heartbeatCheck          = "heartbeat"
 	apiConfigCheck          = "api-config"
+	deployConfigCheck       = "deploy-config"
 	commandNotFoundExitCode = 127
 )
 

--- a/pkg/client/clientset/versioned/typed/core/v1/lease.go
+++ b/pkg/client/clientset/versioned/typed/core/v1/lease.go
@@ -38,6 +38,9 @@ type LeasesGetter interface {
 }
 
 type LeasesInterface interface {
+	Create(ctx context.Context, lease *coordinationv1.Lease, opts *v1.CreateOptions) (*coordinationv1.Lease, error)
+	Update(ctx context.Context, lease *coordinationv1.Lease, opts *v1.UpdateOptions) (*coordinationv1.Lease, error)
+	GetWithNamespace(ctx context.Context, name, namespace string, opts v1.GetOptions) (*coordinationv1.Lease, error)
 	Get(ctx context.Context, name string, opts v1.GetOptions) (*coordinationv1.Lease, error)
 	List(ctx context.Context, opts v1.ListOptions) (*coordinationv1.LeaseList, error)
 	Watch(ctx context.Context, opts v1.ListOptions) (watch.Interface, error)
@@ -51,13 +54,49 @@ func newLeases(c *CoreV1Client) *leases {
 	return &leases{client: c.RESTClient()}
 }
 
-func (c *leases) Get(ctx context.Context, name string, opts v1.GetOptions) (result *coordinationv1.Lease, err error) {
+func (c *leases) Create(
+	ctx context.Context, lease *coordinationv1.Lease, opts *v1.CreateOptions,
+) (result *coordinationv1.Lease, err error) {
 	result = &coordinationv1.Lease{}
-	err = c.client.Get().
+	err = c.client.Post().
+		Resource("leases").
+		VersionedParams(opts, scheme.ParameterCodec).
+		Body(lease).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+func (c *leases) Update(
+	ctx context.Context, lease *coordinationv1.Lease, opts *v1.UpdateOptions,
+) (result *coordinationv1.Lease, err error) {
+	result = &coordinationv1.Lease{}
+	err = c.client.Put().
+		Resource("leases").
+		Name(lease.Name).
+		VersionedParams(opts, scheme.ParameterCodec).
+		Body(lease).
+		Do(ctx).
+		Into(result)
+	return
+}
+
+func (c *leases) Get(ctx context.Context, name string, opts v1.GetOptions) (result *coordinationv1.Lease, err error) {
+	return c.GetWithNamespace(ctx, name, "", opts)
+}
+
+func (c *leases) GetWithNamespace(
+	ctx context.Context, name, namespace string, opts v1.GetOptions,
+) (result *coordinationv1.Lease, err error) {
+	result = &coordinationv1.Lease{}
+	request := c.client.Get().
 		Resource("leases").
 		Name(name).
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do(ctx).
+		VersionedParams(&opts, scheme.ParameterCodec)
+	if namespace != "" {
+		request.Param("namespace", namespace)
+	}
+	err = request.Do(ctx).
 		Into(result)
 	return
 }

--- a/pkg/client/clientset/versioned/typed/core/v1/lease_test.go
+++ b/pkg/client/clientset/versioned/typed/core/v1/lease_test.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+)
+
+func TestLeaseCreateUpdateAndGetWithNamespace(t *testing.T) {
+	t.Parallel()
+
+	expected := []struct {
+		method    string
+		path      string
+		namespace string
+	}{
+		{method: http.MethodPost, path: "/api/core.kubeclipper.io/v1/leases"},
+		{method: http.MethodPut, path: "/api/core.kubeclipper.io/v1/leases/agent-a"},
+		{method: http.MethodGet, path: "/api/core.kubeclipper.io/v1/leases/agent-a", namespace: "node-lease"},
+	}
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests > len(expected) {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			return
+		}
+		want := expected[requests-1]
+		if got := r.Method; got != want.method {
+			t.Errorf("request %d method = %q, want %q", requests, got, want.method)
+		}
+		if got := r.URL.Path; got != want.path {
+			t.Errorf("request %d path = %q, want %q", requests, got, want.path)
+		}
+		if got := r.URL.Query().Get("namespace"); got != want.namespace {
+			t.Errorf("request %d namespace = %q, want %q", requests, got, want.namespace)
+		}
+
+		lease := coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: "agent-a", Namespace: "node-lease"}}
+		if r.Method != http.MethodGet {
+			if err := json.NewDecoder(r.Body).Decode(&lease); err != nil {
+				t.Errorf("decode lease: %v", err)
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(&lease); err != nil {
+			t.Errorf("encode lease: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	client, err := NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("NewForConfig() error = %v", err)
+	}
+	lease := &coordinationv1.Lease{ObjectMeta: metav1.ObjectMeta{Name: "agent-a", Namespace: "node-lease"}}
+	created, err := client.Leases().Create(context.Background(), lease, &metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := client.Leases().Update(context.Background(), created, &metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("Update() error = %v", err)
+	}
+	if _, err := client.Leases().GetWithNamespace(context.Background(), "agent-a", "node-lease", metav1.GetOptions{}); err != nil {
+		t.Fatalf("GetWithNamespace() error = %v", err)
+	}
+	if requests != 3 {
+		t.Fatalf("request count = %d, want 3", requests)
+	}
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -1019,7 +1019,7 @@ var Roles = GlobalRoleList{
 				Verbs:     []string{"get", "create", "update", "patch"},
 			},
 			{
-				APIGroups: []string{"coordination.k8s.io"},
+				APIGroups: []string{"core.kubeclipper.io"},
 				Resources: []string{"leases"},
 				Verbs:     []string{"get", "create", "update", "patch"},
 			},


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind api-change

### What this PR does / why we need it:

- Restore kc-agent machine resource reporting and Node Lease heartbeats after the Operation v2 API transition.
- Expose Lease create/update operations through the actual KubeClipper `core.kubeclipper.io` API and preserve the `node-lease` namespace.
- Keep deployment configuration authoritative in the Server ConfigMap, synchronize the local cache only after successful online updates, and make `kcctl doctor` prefer the online configuration.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
The API and Agent paths were verified on sh-dev-2, sh-dev-3, and sh-dev-4. Three Agents reported non-zero CPU/memory, created and renewed Leases, and `kcctl doctor` reported 22 passed checks. The test environment was preserved.
```

### Does this PR introduced a user-facing change?

```release-note
kc-agent now reports machine capacity and renews its Node Lease through the KubeClipper API. kcctl doctor uses the server deployment configuration as its authoritative source.
```

### Additional documentation, usage docs, etc.:

```docs
```
