### PR TITLE
fix: support offline local image loading

### DIFF
--- a/pkg/apis/core/v1/handler.go
+++ b/pkg/apis/core/v1/handler.go
@@ -432,10 +432,6 @@ func (h *handler) CreateClusters(request *restful.Request, response *restful.Res
 	if v := request.QueryParameter("timeout"); v != "" {
 		timeoutSecs = v
 	}
-	if c.Offline() && strings.TrimSpace(c.ImageRegistry) == "" {
-		restplus.HandleBadRequest(response, request, errors.New("imageRegistry must be specified in offline mode"))
-		return
-	}
 	c.Complete()
 	// validate node exist
 	extraMeta, err := h.getClusterMetadata(request.Request.Context(), &c, false)
@@ -542,10 +538,6 @@ func (h *handler) UpdateClusters(request *restful.Request, response *restful.Res
 		clu.Annotations = c.Annotations
 		clu.ImageRegistry = c.ImageRegistry
 		clu.ContainerRuntime.Registries = c.ContainerRuntime.Registries
-		if clu.Offline() && strings.TrimSpace(clu.ImageRegistry) == "" {
-			restplus.HandleBadRequest(response, request, errors.New("imageRegistry must be specified in offline mode"))
-			return
-		}
 		if _, err = utils.GetClusterCRIRegistriesWithContext(request.Request.Context(), clu, h.clusterOperator); err != nil {
 			restplus.HandleBadRequest(response, request, err)
 			return
@@ -948,7 +940,7 @@ func (h *handler) watchNodes(req *restful.Request, resp *restful.Response, q *qu
 
 // TODO: it will be deprecated in the future
 func (h *handler) getClusterMetadata(ctx context.Context, c *v1.Cluster, skipNodeNotFound bool) (*component.ExtraMetadata, error) {
-	registry, err := utils.ResolveImageRegistry(ctx, c.ImageRegistry, h.clusterOperator)
+	registry, err := utils.ResolveClusterImageRegistry(ctx, c, h.clusterOperator)
 	if err != nil {
 		return nil, err
 	}
@@ -1692,10 +1684,6 @@ func (h *handler) UpgradeCluster(request *restful.Request, response *restful.Res
 	if v := request.QueryParameter("timeout"); v != "" {
 		timeoutSecs = v
 	}
-	if body.Offline && strings.TrimSpace(body.ImageRegistry) == "" {
-		restplus.HandleBadRequest(response, request, errors.New("imageRegistry must be specified in offline mode"))
-		return
-	}
 	clu.ImageRegistry = body.ImageRegistry
 	extraMeta, err := h.getClusterMetadata(request.Request.Context(), clu, false)
 	if err != nil {
@@ -1706,7 +1694,15 @@ func (h *handler) UpgradeCluster(request *restful.Request, response *restful.Res
 		restplus.HandleInternalError(response, request, err)
 		return
 	}
+	registry, err := utils.ResolveImageRegistryForMode(request.Request.Context(), body.Offline, body.ImageRegistry, h.clusterOperator)
+	if err != nil {
+		restplus.HandleBadRequest(response, request, err)
+		return
+	}
+	clu.ResolvedImageRegistry = registry.Host
+	clu.Complete()
 	extraMeta.Offline = body.Offline
+	extraMeta.ImageRegistry = registry.Host
 	extraMeta.KubeVersion = body.Version
 	upgradeComp := &k8s.Upgrade{}
 	upgradeComp.InitStepper(extraMeta, clu)
@@ -1727,7 +1723,7 @@ func (h *handler) UpgradeCluster(request *restful.Request, response *restful.Res
 		common.LabelTopologyRegion: extraMeta.Masters[0].Region,
 	}
 	op.Steps = upgradeComp.GetInstallSteps()
-	statusRegistries, err := utils.GetClusterCRIRegistriesWithContext(request.Request.Context(), clu, h.clusterOperator)
+	statusRegistries, err := utils.GetClusterCRIRegistriesForMode(request.Request.Context(), clu, body.Offline, h.clusterOperator)
 	if err != nil {
 		restplus.HandleBadRequest(response, request, err)
 		return

--- a/pkg/cli/cluster/cluster_upgrade.go
+++ b/pkg/cli/cluster/cluster_upgrade.go
@@ -57,11 +57,10 @@ const (
 
 type ClusterUpgradeOpts struct {
 	BaseOptions
-	ClusterName           string
-	Version               string
-	Online                bool
-	ImageRegistry         string
-	imageRegistryExplicit bool
+	ClusterName   string
+	Version       string
+	Online        bool
+	ImageRegistry string
 }
 
 func NewClusterUpgradeOpts(streams options.IOStreams) *ClusterUpgradeOpts {
@@ -82,7 +81,6 @@ func NewCmdClusterUpgrade(streams options.IOStreams) *cobra.Command {
 		Long:    upgradeLongDescription,
 		Example: clusterUpgradeExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			c.imageRegistryExplicit = cmd.Flags().Changed("image-registry")
 			utils.CheckErr(c.Complete())
 			utils.CheckErr(c.Validates())
 			utils.CheckErr(c.Run())
@@ -137,9 +135,6 @@ func (c *ClusterUpgradeOpts) Complete() error {
 }
 
 func (c *ClusterUpgradeOpts) Validates() error {
-	if !c.Online && !c.imageRegistryExplicit {
-		return errors.New("--image-registry must be explicitly specified in offline mode")
-	}
 	if err := c.checkImageRegistry(); err != nil {
 		return err
 	}
@@ -164,10 +159,7 @@ func (c *ClusterUpgradeOpts) Validates() error {
 
 func (c *ClusterUpgradeOpts) checkImageRegistry() error {
 	if c.ImageRegistry == "" {
-		if c.Online {
-			return nil
-		}
-		return errors.New("--image-registry must not be empty in offline mode")
+		return nil
 	}
 	registries, err := c.Client.ListRegistries(context.Background(), kc.Queries{})
 	if err != nil {

--- a/pkg/component/utils/utils.go
+++ b/pkg/component/utils/utils.go
@@ -145,12 +145,20 @@ func GetClusterCRIRegistries(c *v1.Cluster, op cluster.Operator) ([]v1.RegistryS
 }
 
 func GetClusterCRIRegistriesWithContext(ctx context.Context, c *v1.Cluster, op cluster.Operator) ([]v1.RegistrySpec, error) {
-	imageRegistry, err := ResolveImageRegistry(ctx, c.ImageRegistry, op)
+	return GetClusterCRIRegistriesForMode(ctx, c, c.Offline(), op)
+}
+
+// GetClusterCRIRegistriesForMode returns the CRI registry configuration for an image source mode.
+func GetClusterCRIRegistriesForMode(ctx context.Context, c *v1.Cluster, offline bool, op cluster.Operator) ([]v1.RegistrySpec, error) {
+	imageRegistry, err := ResolveImageRegistryForMode(ctx, offline, c.ImageRegistry, op)
 	if err != nil {
 		return nil, err
 	}
 	c.ResolvedImageRegistry = imageRegistry.Host
-	registries := []v1.RegistrySpec{imageRegistry}
+	registries := make([]v1.RegistrySpec, 0, len(c.ContainerRuntime.Registries)+1)
+	if imageRegistry.Host != "" {
+		registries = append(registries, imageRegistry)
+	}
 	explicitHosts := make(map[string]v1.RegistrySpec)
 	for _, ref := range c.ContainerRuntime.Registries {
 		if ref.RegistryRef == nil || strings.TrimSpace(*ref.RegistryRef) == "" {
@@ -184,6 +192,20 @@ func GetClusterCRIRegistriesWithContext(ctx context.Context, c *v1.Cluster, op c
 		return registries[i].Host < registries[j].Host
 	})
 	return registries, nil
+}
+
+// ResolveClusterImageRegistry returns the registry used to pull cluster images.
+// Offline clusters without an image registry load packaged images on each node.
+func ResolveClusterImageRegistry(ctx context.Context, c *v1.Cluster, op cluster.Operator) (v1.RegistrySpec, error) {
+	return ResolveImageRegistryForMode(ctx, c.Offline(), c.ImageRegistry, op)
+}
+
+// ResolveImageRegistryForMode returns an empty registry only for offline local-image mode.
+func ResolveImageRegistryForMode(ctx context.Context, offline bool, name string, op cluster.Operator) (v1.RegistrySpec, error) {
+	if offline && strings.TrimSpace(name) == "" {
+		return v1.RegistrySpec{}, nil
+	}
+	return ResolveImageRegistry(ctx, name, op)
 }
 
 func ResolveImageRegistry(ctx context.Context, name string, op cluster.Operator) (v1.RegistrySpec, error) {

--- a/pkg/component/utils/utils_test.go
+++ b/pkg/component/utils/utils_test.go
@@ -27,8 +27,46 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	mockcluster "github.com/kubeclipper/kubeclipper/pkg/models/cluster/mock"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 )
+
+func TestResolveClusterImageRegistry(t *testing.T) {
+	t.Run("online cluster uses default registry", func(t *testing.T) {
+		registry, err := ResolveClusterImageRegistry(context.Background(), &v1.Cluster{}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if registry.Host != v1.DefaultImageRegistry {
+			t.Fatalf("registry host = %q, want %q", registry.Host, v1.DefaultImageRegistry)
+		}
+	})
+
+	t.Run("offline cluster without registry uses local images", func(t *testing.T) {
+		cluster := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{common.AnnotationOffline: "true"}}}
+		registry, err := ResolveClusterImageRegistry(context.Background(), cluster, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if registry.Host != "" {
+			t.Fatalf("registry host = %q, want empty", registry.Host)
+		}
+	})
+}
+
+func TestGetClusterCRIRegistriesUsesLocalImagesForOfflineClusterWithoutRegistry(t *testing.T) {
+	cluster := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{common.AnnotationOffline: "true"}}}
+	registries, err := GetClusterCRIRegistriesWithContext(context.Background(), cluster, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registries) != 0 {
+		t.Fatalf("registries = %#v, want none", registries)
+	}
+	if cluster.ResolvedImageRegistry != "" {
+		t.Fatalf("resolved image registry = %q, want empty", cluster.ResolvedImageRegistry)
+	}
+}
 
 func TestGetClusterCRIRegistries(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/pkg/controller/clustercontroller/metadata.go
+++ b/pkg/controller/clustercontroller/metadata.go
@@ -29,7 +29,7 @@ import (
 
 // assembleClusterExtraMetadata assemble cluster extra metadata, used to share data between the various steps
 func (r *ClusterReconciler) assembleClusterExtraMetadata(ctx context.Context, c *v1.Cluster) (*component.ExtraMetadata, error) {
-	registry, err := componentutils.ResolveImageRegistry(ctx, c.ImageRegistry, r.ClusterOperator)
+	registry, err := componentutils.ResolveClusterImageRegistry(ctx, c, r.ClusterOperator)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Restores the supported offline local-image mode when no image registry is configured.

Image source selection is now explicit:
- a configured image registry is used for image pulls in either mode;
- offline mode without a registry loads packaged images on each node;
- online mode without a registry continues to use the default Kubernetes image registry.

The upgrade path now resolves image sources from the request mode, and CRI registry configuration no longer injects a default registry for local-image mode.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

Validated with:
- unit tests for registry resolution and CRI registry generation;
- offline local-image CreateCluster E2E: 14/14 Operation steps succeeded;
- offline configured-registry AddNodes E2E on a cache-cleared node: 8/8 steps succeeded, with containerd logs confirming pulls from the configured registry.

### Does this PR introduced a user-facing change?

```release-note
Offline cluster creation and upgrade can omit --image-registry to load packaged images locally on nodes.
```

### Additional documentation, usage docs, etc.:

```docs
```