### PR TITLE
fix: preserve registry scheme in containerd hosts config

### DIFF
--- a/pkg/scheme/core/v1/cri/containerd.go
+++ b/pkg/scheme/core/v1/cri/containerd.go
@@ -566,6 +566,11 @@ func (h *ContainerdRegistry) renderConfigs(dir string) error {
 		Server:      h.Server,
 		HostConfigs: make(map[string]HostFileConfig),
 	}
+	if len(h.Hosts) > 0 {
+		// containerd uses server as the default endpoint. Preserve h.Server as
+		// the certs.d directory name and add the scheme only to this endpoint.
+		c.Server = fmt.Sprintf("%s://%s", h.Hosts[0].Scheme, h.Server)
+	}
 	for _, host := range h.Hosts {
 		var (
 			caFile     = ""

--- a/pkg/scheme/core/v1/cri/containerd_test.go
+++ b/pkg/scheme/core/v1/cri/containerd_test.go
@@ -160,7 +160,7 @@ func TestContainerdRegistryRender(t *testing.T) {
 	ca, err := os.ReadFile(cafile)
 	require.NoError(t, err)
 	assert.Equal(t, "ca data", string(ca))
-	exp := fmt.Sprintf(`server = "docker.io"
+	exp := fmt.Sprintf(`server = "https://docker.io"
 
 [host]
 
@@ -176,6 +176,26 @@ func TestContainerdRegistryRender(t *testing.T) {
 	hostConfig, err := os.ReadFile(filepath.Join(dir, "docker.io", "hosts.toml"))
 	require.NoError(t, err)
 	assert.Equal(t, exp, string(hostConfig))
+}
+
+func TestToContainerdRegistryConfigPreservesRegistryScheme(t *testing.T) {
+	configs := ToContainerdRegistryConfig([]v1.RegistrySpec{{
+		Scheme:     "http",
+		Host:       "registry.example.test:5000",
+		SkipVerify: true,
+	}})
+
+	config, ok := configs["registry.example.test:5000"]
+	if !ok {
+		t.Fatal("registry config was not created")
+	}
+	assert.Equal(t, "registry.example.test:5000", config.Server)
+
+	dir := t.TempDir()
+	require.NoError(t, config.renderConfigs(dir))
+	data, err := os.ReadFile(filepath.Join(dir, "registry.example.test:5000", "hosts.toml"))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `server = "http://registry.example.test:5000"`)
 }
 
 func TestMergeRegistryAuthIntoConfig(t *testing.T) {


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

Preserves the configured Registry scheme when rendering containerd `hosts.toml`. HTTP registries previously emitted a scheme-less default endpoint, which containerd interpreted as HTTPS and caused image pulls to fail with `http: server gave HTTP response to HTTPS client`.

The certs.d directory remains keyed by `host:port`; only the `server` endpoint in `hosts.toml` gains the configured scheme.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

- Adds a regression test that renders the actual `hosts.toml` file and verifies an HTTP endpoint remains `http://...`.
- Verified with `go test ./pkg/scheme/core/v1/cri ./pkg/component/utils`.

### Does this PR introduced a user-facing change?

```release-note
Fix HTTP private Registry image pulls by preserving the configured protocol in containerd hosts.toml.
```

### Additional documentation, usage docs, etc.:

```docs
```