### PR TITLE
fix(deploy): wait for etcd health

### DIFF
--- a/cmd/kcctl/app/options/options.go
+++ b/cmd/kcctl/app/options/options.go
@@ -265,7 +265,6 @@ type DeployConfig struct {
 	StaticServerPath           string                         `json:"staticServerPath" yaml:"staticServerPath,omitempty"`
 	Pkg                        string                         `json:"pkg" yaml:"pkg,omitempty"`
 	ConsolePort                int                            `json:"consolePort" yaml:"consolePort,omitempty"`
-	JWTSecret                  string                         `json:"jwtSecret" yaml:"jwtSecret,omitempty"`
 	AuditOpts                  *option.AuditOptions           `json:"audit" yaml:"audit,omitempty"`
 	OpLog                      *OpLog                         `json:"opLog" yaml:"opLog,omitempty"`
 	ImageProxy                 *ImageProxy                    `json:"imageProxy" yaml:"imageProxy,omitempty"`
@@ -469,8 +468,7 @@ func (c *DeployConfig) GetKcServerConfigTemplateContent(ip string) (string, erro
 		data["TLSPrivateKey"] = filepath.Join(DefaultKcServerConfigPath, DefaultKCPKIPath, fmt.Sprintf("%s.key", KCServer))
 		data["CACertFile"] = filepath.Join(DefaultKcServerConfigPath, DefaultCaPath, "ca.crt")
 	}
-	// JWTSecret is injected from the generated deploy config.
-	data["JwtSecret"] = c.JWTSecret
+	data["JwtSecret"] = c.AuthenticationOpts.JwtSecret
 	data["InitialPassword"] = c.AuthenticationOpts.InitialPassword
 	data["RetentionPeriod"] = c.AuditOpts.RetentionPeriod
 	data["MaximumEntries"] = c.AuditOpts.MaximumEntries

--- a/pkg/cli/deploy/config.go
+++ b/pkg/cli/deploy/config.go
@@ -106,8 +106,6 @@ agents:
 #staticServerPort: 8081
 # static package directory.
 #staticServerPath: /opt/kubeclipper-server/resource
-#automatic generate jwt token.
-#jwtSecret: ""
 
 # deploy resource package,support url or file absolute path.
 #pkg: ` + constatns.KubeClipperReleaseBaseURL + `/v1.1.0/kc-amd64.tar.gz

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -41,6 +41,7 @@ import (
 	"text/template"
 	"time"
 
+	clientv3 "go.etcd.io/etcd/client/v3"
 	"k8s.io/component-base/version"
 
 	"github.com/kubeclipper/kubeclipper/pkg/utils/strutil"
@@ -78,9 +79,10 @@ import (
 )
 
 const (
-	deployExamplePkg       = constatns.KubeClipperReleaseBaseURL + "/v1.4.0/kc-amd64.tar.gz"
-	kcServerClientIdentity = "system:kc-server"
-	longDescription        = `
+	deployExamplePkg          = constatns.KubeClipperReleaseBaseURL + "/v1.4.0/kc-amd64.tar.gz"
+	kcServerClientIdentity    = "system:kc-server"
+	serviceHealthCheckTimeout = 5 * time.Second
+	longDescription           = `
   Deploy Kubeclipper Platform from deploy-config.yaml or cmd flags.
 
   Kubeclipper Platform must have one kc-server node at lease, kc-server use etcd as db backend.
@@ -227,6 +229,9 @@ func (d *DeployOptions) Complete() error {
 	if err = d.deployConfig.Complete(); err != nil {
 		return err
 	}
+	if err = d.generateAuthenticationJWTSecret(); err != nil {
+		return err
+	}
 	if d.deployConfig.Pkg == "" {
 		v := os.Getenv("KC_VERSION")
 		var ok bool
@@ -273,6 +278,15 @@ func (d *DeployOptions) Complete() error {
 		logger.Infof("run in aio mode.")
 	}
 
+	return nil
+}
+
+func (d *DeployOptions) generateAuthenticationJWTSecret() error {
+	secret, err := password.Generate(24, 5, 0, false, true)
+	if err != nil {
+		return fmt.Errorf("generate authentication JWT secret: %w", err)
+	}
+	d.deployConfig.AuthenticationOpts.JwtSecret = secret
 	return nil
 }
 
@@ -325,8 +339,6 @@ func (d *DeployOptions) preRun() {
 		}
 		d.servers[sip] = hostname
 	}
-	res, _ := password.Generate(24, 5, 0, false, true)
-	d.deployConfig.JWTSecret = res
 	d.dumpConfig()
 }
 
@@ -601,11 +613,11 @@ func (d *DeployOptions) RunDeploy() error {
 	d.sendPackage()
 	logger.Infof("------ Install kc-etcd ------")
 	d.deployEtcd()
-	// TODO: add check etcd status instead of time.sleep
-	time.Sleep(5 * time.Second)
+	if err := d.waitEtcdReady(); err != nil {
+		return err
+	}
 	logger.Infof("------ Install kc-server ------")
 	d.deployKcServer()
-	time.Sleep(5 * time.Second)
 	logger.Infof("------ Install kc-agent ------")
 	d.deployKcAgent()
 	logger.Infof("------ Install kc-console ------")
@@ -775,6 +787,106 @@ func (d *DeployOptions) deployEtcd() {
 	}
 }
 
+type etcdHealthClient interface {
+	Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	Close() error
+}
+
+func (d *DeployOptions) waitEtcdReady() error {
+	tlsConfig, err := d.etcdHealthTLSConfig()
+	if err != nil {
+		return fmt.Errorf("load etcd health check credentials: %w", err)
+	}
+
+	endpoints := d.etcdEndpoints()
+	clients, err := newEtcdHealthClients(endpoints, tlsConfig)
+	if err != nil {
+		return fmt.Errorf("create etcd health check clients: %w", err)
+	}
+	defer closeEtcdHealthClients(clients)
+
+	ctx, cancel := context.WithTimeout(context.Background(), d.deployConfig.KCServerHealthCheckTimeout)
+	defer cancel()
+	if err := retryFunc(ctx, 3*time.Second, "waitEtcdReady", "cluster", func(string) error {
+		return checkEtcdEndpoints(ctx, clients, endpoints)
+	}); err != nil {
+		return fmt.Errorf("etcd cluster is not ready: %w", err)
+	}
+	return nil
+}
+
+func (d *DeployOptions) etcdEndpoints() []string {
+	endpoints := make([]string, 0, len(d.deployConfig.ServerIPs))
+	for _, host := range d.deployConfig.ServerIPs {
+		endpoints = append(endpoints, net.JoinHostPort(host, strconv.Itoa(d.deployConfig.EtcdConfig.ClientPort)))
+	}
+	return endpoints
+}
+
+func (d *DeployOptions) etcdHealthTLSConfig() (*tls.Config, error) {
+	basePath := filepath.Join(options.HomeDIR, options.DefaultPath)
+	clientCert, err := tls.LoadX509KeyPair(
+		filepath.Join(basePath, options.DefaultEtcdPKIPath, options.EtcdHealthCheck+".crt"),
+		filepath.Join(basePath, options.DefaultEtcdPKIPath, options.EtcdHealthCheck+".key"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	caCert, err := os.ReadFile(filepath.Join(basePath, options.DefaultCaPath, options.Ca+".crt"))
+	if err != nil {
+		return nil, err
+	}
+	rootCAs := x509.NewCertPool()
+	if !rootCAs.AppendCertsFromPEM(caCert) {
+		return nil, fmt.Errorf("parse etcd CA certificate")
+	}
+
+	return &tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      rootCAs,
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+func newEtcdHealthClients(endpoints []string, tlsConfig *tls.Config) ([]etcdHealthClient, error) {
+	clients := make([]etcdHealthClient, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		client, err := clientv3.New(clientv3.Config{
+			Endpoints:   []string{endpoint},
+			DialTimeout: serviceHealthCheckTimeout,
+			TLS:         tlsConfig,
+		})
+		if err != nil {
+			closeEtcdHealthClients(clients)
+			return nil, err
+		}
+		clients = append(clients, client)
+	}
+	return clients, nil
+}
+
+func closeEtcdHealthClients(clients []etcdHealthClient) {
+	for _, client := range clients {
+		_ = client.Close()
+	}
+}
+
+func checkEtcdEndpoints(ctx context.Context, clients []etcdHealthClient, endpoints []string) error {
+	if len(clients) != len(endpoints) {
+		return fmt.Errorf("etcd health client count %d does not match endpoint count %d", len(clients), len(endpoints))
+	}
+	for i, endpoint := range endpoints {
+		requestCtx, cancel := context.WithTimeout(ctx, serviceHealthCheckTimeout)
+		_, err := clients[i].Get(requestCtx, "health")
+		cancel()
+		if err != nil {
+			return fmt.Errorf("endpoint %s is unhealthy: %w", endpoint, err)
+		}
+	}
+	return nil
+}
+
 func (d *DeployOptions) getEtcdTemplateContent(ip string) string {
 	tmpl, err := template.New("text").Parse(config.EtcdServiceTmpl)
 	if err != nil {
@@ -900,7 +1012,7 @@ func (d *DeployOptions) waitServerRunning(host string) error {
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
-	client := &http.Client{Transport: tr}
+	client := &http.Client{Transport: tr, Timeout: serviceHealthCheckTimeout}
 
 	addr := fmt.Sprintf("http://%s:%v/healthz", host, d.deployConfig.ServerPort)
 	if d.deployConfig.TLS {
@@ -923,17 +1035,21 @@ func (d *DeployOptions) waitServerRunning(host string) error {
 }
 
 func retryFunc(ctx context.Context, intervalTime time.Duration, funcName, host string, fn func(host string) error) error {
+	ticker := time.NewTicker(intervalTime)
+	defer ticker.Stop()
+
 	for {
+		err := fn(host)
+		if err == nil {
+			return nil
+		}
+		logger.Infof("function '%s' running error: %s. about to enter retry", funcName, err.Error())
+
 		select {
 		case <-ctx.Done():
 			logger.Warnf("retry function '%s' timeout...", funcName)
 			return ctx.Err()
-		case <-time.After(intervalTime):
-			err := fn(host)
-			if err == nil {
-				return nil
-			}
-			logger.Infof("function '%s' running error: %s. about to enter retry", funcName, err.Error())
+		case <-ticker.C:
 		}
 	}
 }

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -79,10 +79,12 @@ import (
 )
 
 const (
-	deployExamplePkg          = constatns.KubeClipperReleaseBaseURL + "/v1.4.0/kc-amd64.tar.gz"
-	kcServerClientIdentity    = "system:kc-server"
-	serviceHealthCheckTimeout = 5 * time.Second
-	longDescription           = `
+	deployExamplePkg              = constatns.KubeClipperReleaseBaseURL + "/v1.4.0/kc-amd64.tar.gz"
+	kcServerClientIdentity        = "system:kc-server"
+	serviceHealthCheckTimeout     = 5 * time.Second
+	authenticationJWTSecretLength = 24
+	authenticationJWTSecretDigits = 5
+	longDescription               = `
   Deploy Kubeclipper Platform from deploy-config.yaml or cmd flags.
 
   Kubeclipper Platform must have one kc-server node at lease, kc-server use etcd as db backend.
@@ -225,11 +227,10 @@ func NewCmdDeploy(streams options.IOStreams) *cobra.Command {
 }
 
 func (d *DeployOptions) Complete() error {
-	var err error
-	if err = d.deployConfig.Complete(); err != nil {
+	if err := d.deployConfig.Complete(); err != nil {
 		return err
 	}
-	if err = d.generateAuthenticationJWTSecret(); err != nil {
+	if err := d.generateAuthenticationJWTSecret(); err != nil {
 		return err
 	}
 	if d.deployConfig.Pkg == "" {
@@ -259,9 +260,11 @@ func (d *DeployOptions) Complete() error {
 
 	// if specify config，ignore flags.
 	if d.deployConfig.Config == "" {
-		if d.deployConfig.Agents, err = BuildAgent(d.agents, d.fips, d.deployConfig.DefaultRegion); err != nil {
+		agents, err := BuildAgent(d.agents, d.fips, d.deployConfig.DefaultRegion)
+		if err != nil {
 			return err
 		}
+		d.deployConfig.Agents = agents
 	}
 
 	d.allNodes = sets.NewString().
@@ -282,7 +285,7 @@ func (d *DeployOptions) Complete() error {
 }
 
 func (d *DeployOptions) generateAuthenticationJWTSecret() error {
-	secret, err := password.Generate(24, 5, 0, false, true)
+	secret, err := password.Generate(authenticationJWTSecretLength, authenticationJWTSecretDigits, 0, false, true)
 	if err != nil {
 		return fmt.Errorf("generate authentication JWT secret: %w", err)
 	}
@@ -823,7 +826,7 @@ func (d *DeployOptions) etcdEndpoints() []string {
 	return endpoints
 }
 
-func (d *DeployOptions) etcdHealthTLSConfig() (*tls.Config, error) {
+func (*DeployOptions) etcdHealthTLSConfig() (*tls.Config, error) {
 	basePath := filepath.Join(options.HomeDIR, options.DefaultPath)
 	clientCert, err := tls.LoadX509KeyPair(
 		filepath.Join(basePath, options.DefaultEtcdPKIPath, options.EtcdHealthCheck+".crt"),

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -19,16 +19,33 @@
 package deploy
 
 import (
+	"context"
 	"crypto/x509"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/google/uuid"
+	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/sshutils"
 )
+
+type fakeEtcdHealthClient struct {
+	getErr error
+	keys   []string
+}
+
+func (c *fakeEtcdHealthClient) Get(_ context.Context, key string, _ ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	c.keys = append(c.keys, key)
+	return &clientv3.GetResponse{}, c.getErr
+}
+
+func (c *fakeEtcdHealthClient) Close() error {
+	return nil
+}
 
 func TestPrecheckServiceDoesNotIgnoreFailureWithAssumeYes(t *testing.T) {
 	originalAssumeYes := options.AssumeYes
@@ -46,6 +63,66 @@ func TestPrecheckServiceDoesNotIgnoreFailureWithAssumeYes(t *testing.T) {
 func TestTimeSyncPrecheckSupportsSystemdTimesyncd(t *testing.T) {
 	if !strings.Contains(timeSyncPrecheckCommand, "systemd-timesyncd") {
 		t.Fatalf("time synchronization precheck must support systemd-timesyncd: %q", timeSyncPrecheckCommand)
+	}
+}
+
+func TestCheckEtcdEndpoints(t *testing.T) {
+	endpoints := []string{"192.0.2.10:12379", "192.0.2.11:12379"}
+	t.Run("all endpoints healthy", func(t *testing.T) {
+		clients := []*fakeEtcdHealthClient{{}, {}}
+		if err := checkEtcdEndpoints(context.Background(), []etcdHealthClient{clients[0], clients[1]}, endpoints); err != nil {
+			t.Fatalf("checkEtcdEndpoints() error = %v", err)
+		}
+		for _, client := range clients {
+			if !reflect.DeepEqual(client.keys, []string{"health"}) {
+				t.Fatalf("health check keys = %v, want [health]", client.keys)
+			}
+		}
+	})
+
+	t.Run("endpoint unhealthy", func(t *testing.T) {
+		clients := []etcdHealthClient{&fakeEtcdHealthClient{}, &fakeEtcdHealthClient{getErr: errors.New("connection refused")}}
+		err := checkEtcdEndpoints(context.Background(), clients, endpoints)
+		if err == nil || !strings.Contains(err.Error(), endpoints[1]) {
+			t.Fatalf("checkEtcdEndpoints() error = %v, want endpoint %q", err, endpoints[1])
+		}
+	})
+}
+
+func TestDeployOptionsEtcdEndpoints(t *testing.T) {
+	d := NewDeployOptions(options.IOStreams{})
+	d.deployConfig.ServerIPs = []string{"192.0.2.10", "192.0.2.11"}
+	d.deployConfig.EtcdConfig.ClientPort = 22379
+
+	if got, want := d.etcdEndpoints(), []string{"192.0.2.10:22379", "192.0.2.11:22379"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("etcdEndpoints() = %v, want %v", got, want)
+	}
+}
+
+func TestDeployOptionsCompleteGeneratesAuthenticationJWTSecret(t *testing.T) {
+	d := NewDeployOptions(options.IOStreams{})
+	d.deployConfig.ServerIPs = []string{"192.0.2.10"}
+	d.deployConfig.AuthenticationOpts.JwtSecret = ""
+
+	if err := d.Complete(); err != nil {
+		t.Fatalf("Complete() error = %v", err)
+	}
+	if d.deployConfig.AuthenticationOpts.JwtSecret == "" {
+		t.Fatal("Complete() did not generate authentication JWT secret")
+	}
+}
+
+func TestKcServerConfigUsesAuthenticationJWTSecret(t *testing.T) {
+	d := NewDeployOptions(options.IOStreams{})
+	d.deployConfig.ServerIPs = []string{"192.0.2.10"}
+	d.deployConfig.AuthenticationOpts.JwtSecret = "authentication-secret"
+
+	content, err := d.deployConfig.GetKcServerConfigTemplateContent("192.0.2.10")
+	if err != nil {
+		t.Fatalf("GetKcServerConfigTemplateContent() error = %v", err)
+	}
+	if !strings.Contains(content, "jwtSecret: authentication-secret") {
+		t.Fatalf("server config does not use authentication JWT secret:\n%s", content)
 	}
 }
 

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -43,7 +43,7 @@ func (c *fakeEtcdHealthClient) Get(_ context.Context, key string, _ ...clientv3.
 	return &clientv3.GetResponse{}, c.getErr
 }
 
-func (c *fakeEtcdHealthClient) Close() error {
+func (*fakeEtcdHealthClient) Close() error {
 	return nil
 }
 

--- a/pkg/cli/doctor/checks.go
+++ b/pkg/cli/doctor/checks.go
@@ -35,7 +35,7 @@ import (
 func checkKCServer(_ context.Context, state *diagnosticState) Component {
 	component := Component{Name: "kc-server"}
 	statusComponent := platformComponent(state.platform, "kc-server")
-	for _, name := range []string{"api", "controller-manager", "operation-api", "static-resource"} {
+	for _, name := range []string{"api", "controller-manager", "static-resource"} {
 		check := platformCheck(statusComponent, name)
 		if check == nil {
 			status := platformstatus.Unknown

--- a/pkg/cli/doctor/doctor.go
+++ b/pkg/cli/doctor/doctor.go
@@ -115,7 +115,8 @@ func NewCmdDoctor(streams options.IOStreams) *cobra.Command {
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			cmd.Root().SilenceErrors = true
-			report := o.run(cmd.Context())
+			progress := newProgressReporter(o.Out)
+			report := o.run(cmd.Context(), progress)
 			if err := printReport(o.Out, report); err != nil {
 				return &ExitError{code: 2, err: err}
 			}
@@ -128,16 +129,27 @@ func NewCmdDoctor(streams options.IOStreams) *cobra.Command {
 	return cmd
 }
 
-func (o *Options) run(ctx context.Context) *Report {
+func (o *Options) run(ctx context.Context, progress *progressReporter) *Report {
 	startedAt := o.now()
 	state := &diagnosticState{}
-	local := o.checkLocalAccess(ctx, state)
-	components := []Component{
-		local,
-		checkKCServer(ctx, state),
-		checkKCEtcd(ctx, state),
-		checkKCAgents(ctx, state),
+	checks := []struct {
+		name string
+		run  func() Component
+	}{
+		{name: "kcctl", run: func() Component { return o.checkLocalAccess(ctx, state) }},
+		{name: "kc-server", run: func() Component { return checkKCServer(ctx, state) }},
+		{name: "kc-etcd", run: func() Component { return checkKCEtcd(ctx, state) }},
+		{name: "kc-agent", run: func() Component { return checkKCAgents(ctx, state) }},
 	}
+	components := make([]Component, 0, len(checks))
+	for _, check := range checks {
+		progress.start(check.name)
+		component := check.run()
+		component.Status = aggregateChecks(component.Checks)
+		progress.complete(component)
+		components = append(components, component)
+	}
+	progress.finish()
 	return newReport(startedAt, o.now().Sub(startedAt), components)
 }
 
@@ -145,6 +157,7 @@ func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) 
 	component := Component{Name: "kcctl"}
 	apiConfig, err := config.TryLoadFromFile(o.configPath)
 	if err != nil {
+		o.useLocalDeployConfig(ctx, state, &component, "cannot load API configuration")
 		component.Checks = append(component.Checks, Check{
 			Name: apiConfigCheck, Status: platformstatus.Unhealthy,
 			Message: fmt.Sprintf("cannot load API configuration %s", o.configPath), Evidence: []string{sanitize(err.Error())},
@@ -154,6 +167,7 @@ func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) 
 	}
 	client, err := kc.FromConfigWithoutValidation(*apiConfig)
 	if err != nil {
+		o.useLocalDeployConfig(ctx, state, &component, "API configuration is invalid")
 		component.Checks = append(component.Checks, Check{
 			Name: apiConfigCheck, Status: platformstatus.Unhealthy,
 			Message: "API configuration is invalid", Evidence: []string{sanitize(err.Error())},
@@ -189,9 +203,16 @@ func (o *Options) checkLocalAccess(ctx context.Context, state *diagnosticState) 
 	} else {
 		state.deployConfig = deployConfig
 		state.remote = newRemoteRunner(ctx, deployConfig.SSHConfig)
-		component.Checks = append(component.Checks, Check{
-			Name: deployConfigCheck, Status: platformstatus.Healthy, Message: "deployment configuration loaded from API",
-		})
+		if state.remote == nil {
+			component.Checks = append(component.Checks, Check{
+				Name: deployConfigCheck, Status: platformstatus.Degraded,
+				Message: "deployment configuration has no SSH settings; remote checks will be skipped",
+			})
+		} else {
+			component.Checks = append(component.Checks, Check{
+				Name: deployConfigCheck, Status: platformstatus.Healthy, Message: "deployment configuration loaded from API",
+			})
+		}
 	}
 
 	statusCtx, statusCancel := context.WithTimeout(ctx, apiTimeout)
@@ -245,6 +266,13 @@ func (o *Options) useLocalDeployConfig(ctx context.Context, state *diagnosticSta
 	}
 	state.deployConfig = deployConfig
 	state.remote = newRemoteRunner(ctx, deployConfig.SSHConfig)
+	if state.remote == nil {
+		component.Checks = append(component.Checks, Check{
+			Name: deployConfigCheck, Status: platformstatus.Degraded,
+			Message: reason + "; local deployment configuration has no SSH settings; remote checks will be skipped",
+		})
+		return
+	}
 	component.Checks = append(component.Checks, Check{
 		Name: deployConfigCheck, Status: platformstatus.Degraded,
 		Message: reason + "; using local deployment configuration cache",

--- a/pkg/cli/doctor/doctor_test.go
+++ b/pkg/cli/doctor/doctor_test.go
@@ -46,6 +46,7 @@ func TestServiceState(t *testing.T) {
 		{name: "running", output: serviceOutput("active", "running", "enabled"), wantStatus: platformstatus.Healthy},
 		{name: "stopped", output: serviceOutput("inactive", "dead", "enabled"), wantStatus: platformstatus.Unhealthy},
 		{name: "disabled", output: serviceOutput("active", "running", "disabled"), wantStatus: platformstatus.Degraded},
+		{name: "restarting", output: serviceOutput("activating", "auto-restart", "enabled"), wantStatus: platformstatus.Degraded},
 		{name: "ssh failure", err: errors.New("connection refused"), wantStatus: platformstatus.Unknown},
 	}
 	for _, test := range tests {
@@ -57,7 +58,16 @@ func TestServiceState(t *testing.T) {
 			if check.Status != test.wantStatus {
 				t.Fatalf("status = %s, want %s", check.Status, test.wantStatus)
 			}
+			if test.name == "restarting" && !strings.Contains(check.Message, "restarting") {
+				t.Fatalf("message = %q, want restarting state", check.Message)
+			}
 		})
+	}
+}
+
+func TestNewRemoteRunnerRequiresSSHSettings(t *testing.T) {
+	if runner := newRemoteRunner(context.Background(), nil); runner != nil {
+		t.Fatalf("newRemoteRunner(nil) = %#v, want nil", runner)
 	}
 }
 
@@ -175,6 +185,28 @@ func TestPadRightUsesDisplayCharacters(t *testing.T) {
 	}
 }
 
+func TestProgressReporterShowsEachCompletedComponent(t *testing.T) {
+	var output bytes.Buffer
+	progress := &progressReporter{out: &output, enabled: true}
+	progress.start("kc-server")
+	progress.complete(Component{
+		Name: "kc-server", Status: platformstatus.Healthy, Message: "all server subsystems ready",
+	})
+
+	text := output.String()
+	for _, expected := range []string{
+		"Running KubeClipper diagnostics...",
+		"checking...",
+		"kc-server",
+		"Healthy",
+		"all server subsystems ready",
+	} {
+		if !strings.Contains(text, expected) {
+			t.Errorf("progress output does not contain %q:\n%s", expected, text)
+		}
+	}
+}
+
 func TestPrintReportExpandsOnlyProblems(t *testing.T) {
 	report := newReport(time.Now(), time.Second, []Component{
 		{Name: "kcctl", Message: "API reachable", Checks: []Check{{Name: "api", Status: platformstatus.Healthy, Message: "healthy detail"}}},
@@ -194,7 +226,7 @@ func TestPrintReportExpandsOnlyProblems(t *testing.T) {
 		"[FAIL] kc-agent",
 		"Problems",
 		"ActiveState=inactive",
-		"Summary: 1 passed, 1 failed",
+		"Summary: 1 passed, 0 warnings, 1 failed, 0 skipped",
 	} {
 		if !strings.Contains(text, expected) {
 			t.Errorf("output does not contain %q:\n%s", expected, text)
@@ -202,6 +234,20 @@ func TestPrintReportExpandsOnlyProblems(t *testing.T) {
 	}
 	if strings.Contains(text, "healthy detail") {
 		t.Errorf("healthy check details should be collapsed:\n%s", text)
+	}
+}
+
+func TestCountChecksSeparatesWarnings(t *testing.T) {
+	report := newReport(time.Now(), 0, []Component{{Checks: []Check{
+		{Status: platformstatus.Healthy},
+		{Status: platformstatus.Degraded},
+		{Status: platformstatus.Unhealthy},
+		{Status: platformstatus.Unknown},
+		{Status: platformstatus.Skipped},
+	}}})
+	passed, warnings, failed, skipped := countChecks(report)
+	if passed != 1 || warnings != 1 || failed != 2 || skipped != 1 {
+		t.Fatalf("countChecks() = (%d, %d, %d, %d), want (1, 1, 2, 1)", passed, warnings, failed, skipped)
 	}
 }
 
@@ -252,6 +298,42 @@ audit:
 	if !config.Agents.ExistsByID("worker-1") {
 		t.Fatalf("agent was not loaded: %v", config.Agents)
 	}
+}
+
+func TestDoctorUsesLocalDeployConfigWhenAPIConfigIsUnavailable(t *testing.T) {
+	deployConfigPath := filepath.Join(t.TempDir(), "deploy-config.yaml")
+	data := []byte(`
+serverIPs: [192.0.2.10]
+ssh:
+  user: root
+  port: 22
+`)
+	if err := os.WriteFile(deployConfigPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Options{
+		configPath:       filepath.Join(t.TempDir(), "missing-config"),
+		deployConfigPath: deployConfigPath,
+	}
+	state := &diagnosticState{}
+	component := o.checkLocalAccess(context.Background(), state)
+
+	if state.deployConfig == nil || state.remote == nil {
+		t.Fatalf("local deploy config was not loaded: state=%#v", state)
+	}
+	if check := componentCheck(component, deployConfigCheck); check == nil || check.Status != platformstatus.Degraded {
+		t.Fatalf("deploy config fallback check = %#v", check)
+	}
+}
+
+func componentCheck(component Component, name string) *Check {
+	for i := range component.Checks {
+		if component.Checks[i].Name == name {
+			return &component.Checks[i]
+		}
+	}
+	return nil
 }
 
 func serviceOutput(active, sub, unitFile string) string {

--- a/pkg/cli/doctor/output.go
+++ b/pkg/cli/doctor/output.go
@@ -46,11 +46,12 @@ func printReport(out io.Writer, report *Report) error {
 	if err := printProblems(out, report, style); err != nil {
 		return err
 	}
-	passed, failed, skipped := countChecks(report)
-	_, err := fmt.Fprintf(out, "\n%s%s%s, %s, %s\n",
+	passed, warnings, failed, skipped := countChecks(report)
+	_, err := fmt.Fprintf(out, "\n%s%s%s, %s, %s, %s\n",
 		style.label("Summary"),
 		style.separator(),
 		style.checkCount(platformstatus.Healthy, passed, "passed"),
+		style.checkCount(platformstatus.Degraded, warnings, "warnings"),
 		style.checkCount(platformstatus.Unhealthy, failed, "failed"),
 		style.checkCount(platformstatus.Skipped, skipped, "skipped"),
 	)
@@ -162,7 +163,7 @@ func printDetailLines(out io.Writer, style outputStyle, heading string, lines []
 	return nil
 }
 
-func countChecks(report *Report) (passed, failed, skipped int) {
+func countChecks(report *Report) (passed, warnings, failed, skipped int) {
 	for componentIndex := range report.Components {
 		component := &report.Components[componentIndex]
 		for checkIndex := range component.Checks {
@@ -170,6 +171,8 @@ func countChecks(report *Report) (passed, failed, skipped int) {
 			switch check.Status {
 			case platformstatus.Healthy:
 				passed++
+			case platformstatus.Degraded:
+				warnings++
 			case platformstatus.Skipped:
 				skipped++
 			default:
@@ -177,7 +180,7 @@ func countChecks(report *Report) (passed, failed, skipped int) {
 			}
 		}
 	}
-	return passed, failed, skipped
+	return passed, warnings, failed, skipped
 }
 
 func statusMarker(status platformstatus.Status, terminal bool) string {
@@ -217,6 +220,48 @@ func padRight(value string, width int) string {
 
 type outputStyle struct {
 	enabled bool
+}
+
+type progressReporter struct {
+	out     io.Writer
+	style   outputStyle
+	enabled bool
+	started time.Time
+}
+
+func newProgressReporter(out io.Writer) *progressReporter {
+	return &progressReporter{
+		out:     out,
+		style:   newOutputStyle(out),
+		enabled: writerIsTerminal(out) && os.Getenv("TERM") != "dumb",
+	}
+}
+
+func (p *progressReporter) start(name string) {
+	if !p.enabled {
+		return
+	}
+	if p.started.IsZero() {
+		_, _ = fmt.Fprintln(p.out, "Running KubeClipper diagnostics...")
+	}
+	p.started = time.Now()
+	_, _ = fmt.Fprintf(p.out, "\r\x1b[2K  %s %-14s checking...", p.style.muted("..."), name)
+}
+
+func (p *progressReporter) complete(component Component) {
+	if !p.enabled {
+		return
+	}
+	duration := formatDuration(time.Since(p.started).Milliseconds())
+	status := statusMarker(component.Status, true) + " " + string(component.Status)
+	_, _ = fmt.Fprintf(p.out, "\r\x1b[2K  %s  %-14s %s %s\n",
+		p.style.status(component.Status, status), component.Name, component.Message, p.style.muted("("+duration+")"))
+}
+
+func (p *progressReporter) finish() {
+	if p.enabled && !p.started.IsZero() {
+		_, _ = fmt.Fprintln(p.out)
+	}
 }
 
 func newOutputStyle(out io.Writer) outputStyle {

--- a/pkg/cli/doctor/remote.go
+++ b/pkg/cli/doctor/remote.go
@@ -73,6 +73,9 @@ type serviceState struct {
 }
 
 func newRemoteRunner(ctx context.Context, sshConfig *sshutils.SSH) *remoteRunner {
+	if sshConfig == nil {
+		return nil
+	}
 	config := *sshConfig
 	timeout := sshConnectionTimeout
 	config.ConnectionTimeout = &timeout
@@ -121,12 +124,12 @@ func (r *remoteRunner) service(host, unit string) Check {
 	case state.ActiveState == "failed" || state.ActiveState == "inactive":
 		check.Status = platformstatus.Unhealthy
 		check.Message = fmt.Sprintf("%s on %s is not running", unit, host)
-	case state.ActiveState != "active":
-		check.Status = platformstatus.Degraded
-		check.Message = fmt.Sprintf("%s on %s is %s", unit, host, state.ActiveState)
 	case state.SubState == "auto-restart" || state.ActiveState == "activating":
 		check.Status = platformstatus.Degraded
 		check.Message = fmt.Sprintf("%s on %s is restarting", unit, host)
+	case state.ActiveState != "active":
+		check.Status = platformstatus.Degraded
+		check.Message = fmt.Sprintf("%s on %s is %s", unit, host, state.ActiveState)
 	case state.UnitFileState == "disabled":
 		check.Status = platformstatus.Degraded
 		check.Message = fmt.Sprintf("%s on %s is running but disabled", unit, host)

--- a/pkg/cli/status/status_test.go
+++ b/pkg/cli/status/status_test.go
@@ -30,7 +30,7 @@ func testStatus() *platformstatus.PlatformStatus {
 		CheckedAt:  time.Date(2026, 7, 29, 8, 30, 12, 0, time.UTC),
 		Components: []platformstatus.Component{
 			{Name: "kc-server", Status: platformstatus.Healthy, Message: "all server subsystems ready", Checks: []platformstatus.Check{{Name: "api", Status: platformstatus.Healthy, Message: "API ready"}}},
-			{Name: "kc-etcd", Status: platformstatus.Healthy, Message: "3/3 endpoints healthy"},
+			{Name: "kc-etcd", Status: platformstatus.Healthy, Message: "etcd is healthy"},
 			{Name: "kc-agent", Status: platformstatus.Degraded, Message: "7/8 agents running"},
 		},
 	}

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -91,12 +91,6 @@ func (s *APIServer) kcServerStatus(ctx context.Context) platformstatus.Component
 			}
 			return platformstatus.Healthy, "active leader is ready"
 		}),
-		timedCheck("operation-api", func() (platformstatus.Status, string) {
-			if s.operationV2Store == nil {
-				return platformstatus.Unknown, "Operation API storage is unavailable"
-			}
-			return platformstatus.Healthy, "Operation API storage ready"
-		}),
 		timedCheck("static-resource", func() (platformstatus.Status, string) {
 			if s.staticResourceService == nil {
 				return platformstatus.Unknown, "resource service status is unavailable"
@@ -189,7 +183,7 @@ func (s *APIServer) kcEtcdStatus(ctx context.Context) platformstatus.Component {
 		}
 	}
 	component.DurationMillis = time.Since(startedAt).Milliseconds()
-	component.Status, component.Message = aggregateCount(healthy, len(endpoints), "endpoints healthy", false)
+	component.Status, component.Message = aggregateEtcdEndpoints(healthy, len(endpoints))
 	return component
 }
 
@@ -340,6 +334,20 @@ func aggregateCount(
 		return platformstatus.Unhealthy, message
 	default:
 		return platformstatus.Degraded, message
+	}
+}
+
+func aggregateEtcdEndpoints(healthy, total int) (status platformstatus.Status, message string) {
+	if total == 0 {
+		return platformstatus.Unknown, "no endpoints configured"
+	}
+	switch healthy {
+	case total:
+		return platformstatus.Healthy, "etcd is healthy"
+	case 0:
+		return platformstatus.Unhealthy, "etcd is unavailable"
+	default:
+		return platformstatus.Degraded, "some etcd endpoints are unavailable"
 	}
 }
 

--- a/pkg/server/status_test.go
+++ b/pkg/server/status_test.go
@@ -115,10 +115,9 @@ func TestAggregateServerChecks(t *testing.T) {
 		wantStatus platformstatus.Status
 		wantMsg    string
 	}{
-		{name: "healthy operation API", checks: []platformstatus.Check{
+		{name: "healthy", checks: []platformstatus.Check{
 			{Name: "api", Status: platformstatus.Healthy},
 			{Name: "controller-manager", Status: platformstatus.Healthy},
-			{Name: "operation-api", Status: platformstatus.Healthy},
 			{Name: "static-resource", Status: platformstatus.Healthy},
 		}, wantStatus: platformstatus.Healthy, wantMsg: "all server subsystems ready"},
 		{name: "static resource degraded", checks: []platformstatus.Check{
@@ -127,14 +126,13 @@ func TestAggregateServerChecks(t *testing.T) {
 		}, wantStatus: platformstatus.Degraded, wantMsg: "resource service is unavailable"},
 		{name: "core subsystem unhealthy", checks: []platformstatus.Check{
 			{Name: "api", Status: platformstatus.Healthy},
-			{Name: "operation-api", Status: platformstatus.Unhealthy, Message: "Operation API storage is unavailable"},
-		}, wantStatus: platformstatus.Unhealthy, wantMsg: "Operation API storage is unavailable"},
+			{Name: "controller-manager", Status: platformstatus.Unhealthy, Message: "active leader is not ready"},
+		}, wantStatus: platformstatus.Unhealthy, wantMsg: "active leader is not ready"},
 		{name: "multiple failures", checks: []platformstatus.Check{
-			{Name: "api", Status: platformstatus.Healthy},
+			{Name: "api", Status: platformstatus.Unhealthy},
 			{Name: "controller-manager", Status: platformstatus.Unhealthy},
-			{Name: "operation-api", Status: platformstatus.Unhealthy},
 			{Name: "static-resource", Status: platformstatus.Healthy},
-		}, wantStatus: platformstatus.Unhealthy, wantMsg: "2/4 subsystems unhealthy"},
+		}, wantStatus: platformstatus.Unhealthy, wantMsg: "2/3 subsystems unhealthy"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -156,9 +154,6 @@ func TestAggregateCount(t *testing.T) {
 		wantStatus platformstatus.Status
 		wantMsg    string
 	}{
-		{name: "all etcd endpoints", healthy: 3, total: 3, suffix: "endpoints healthy", wantStatus: platformstatus.Healthy, wantMsg: "3/3 endpoints healthy"},
-		{name: "some etcd endpoints", healthy: 2, total: 3, suffix: "endpoints healthy", wantStatus: platformstatus.Degraded, wantMsg: "2/3 endpoints healthy"},
-		{name: "no etcd endpoints healthy", total: 3, suffix: "endpoints healthy", wantStatus: platformstatus.Unhealthy, wantMsg: "0/3 endpoints healthy"},
 		{name: "all agents lost", total: 8, suffix: "agents running", skipEmpty: true, wantStatus: platformstatus.Unhealthy, wantMsg: "0/8 agents running"},
 		{name: "no agents", suffix: "agents running", skipEmpty: true, wantStatus: platformstatus.Skipped, wantMsg: "no agents registered"},
 	}
@@ -167,6 +162,29 @@ func TestAggregateCount(t *testing.T) {
 			status, message := aggregateCount(test.healthy, test.total, test.suffix, test.skipEmpty)
 			if status != test.wantStatus || message != test.wantMsg {
 				t.Fatalf("aggregateCount() = (%q, %q), want (%q, %q)", status, message, test.wantStatus, test.wantMsg)
+			}
+		})
+	}
+}
+
+func TestAggregateEtcdEndpoints(t *testing.T) {
+	tests := []struct {
+		name       string
+		healthy    int
+		total      int
+		wantStatus platformstatus.Status
+		wantMsg    string
+	}{
+		{name: "all healthy", healthy: 3, total: 3, wantStatus: platformstatus.Healthy, wantMsg: "etcd is healthy"},
+		{name: "partially healthy", healthy: 2, total: 3, wantStatus: platformstatus.Degraded, wantMsg: "some etcd endpoints are unavailable"},
+		{name: "all unavailable", total: 3, wantStatus: platformstatus.Unhealthy, wantMsg: "etcd is unavailable"},
+		{name: "no configuration", wantStatus: platformstatus.Unknown, wantMsg: "no endpoints configured"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			status, message := aggregateEtcdEndpoints(test.healthy, test.total)
+			if status != test.wantStatus || message != test.wantMsg {
+				t.Fatalf("aggregateEtcdEndpoints() = (%q, %q), want (%q, %q)", status, message, test.wantStatus, test.wantMsg)
 			}
 		})
 	}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Replaces fixed deployment sleeps with native etcd endpoint health checks before kc-server installation. Each configured endpoint is checked through an mTLS client using a linearizable read, matching `etcdctl endpoint health` semantics.

Also removes the duplicate top-level deploy JWT field. The generated authentication JWT is now stored, validated, and rendered exclusively through `authentication.jwtSecret`.

### Which issue(s) this PR fixes:

N/A

### Special notes for reviewers:

- All etcd endpoints must pass the health request before deployment proceeds.
- The total wait uses the existing kc-server health-check timeout; each request is limited to five seconds.
- Validated by redeploying a three-node platform with the previous offline package and the new kcctl.

### Does this PR introduced a user-facing change?

```release-note
`kcctl deploy` now waits for all etcd endpoints to become healthy before starting kc-server.
```

### Additional documentation, usage docs, etc.:

```docs
None
```