### PR TITLE
fix(deploy): make package staging directory configurable

### DIFF
--- a/cmd/kcctl/app/options/options.go
+++ b/cmd/kcctl/app/options/options.go
@@ -263,6 +263,7 @@ type DeployConfig struct {
 	TLS                        bool                           `json:"tls" yaml:"tls,omitempty"`
 	StaticServerPort           int                            `json:"staticServerPort" yaml:"staticServerPort,omitempty"`
 	StaticServerPath           string                         `json:"staticServerPath" yaml:"staticServerPath,omitempty"`
+	TempDir                    string                         `json:"tempDir" yaml:"tempDir,omitempty"`
 	Pkg                        string                         `json:"pkg" yaml:"pkg,omitempty"`
 	ConsolePort                int                            `json:"consolePort" yaml:"consolePort,omitempty"`
 	AuditOpts                  *option.AuditOptions           `json:"audit" yaml:"audit,omitempty"`
@@ -326,6 +327,7 @@ func NewDeployOptions() *DeployConfig {
 		TLS:              true,
 		StaticServerPort: 8081,
 		StaticServerPath: "/opt/kubeclipper-server/resource",
+		TempDir:          config.DefaultPkgPath,
 		AuditOpts:        option.NewAuditOptions(),
 		ConsolePort:      80,
 		OpLog: &OpLog{
@@ -430,6 +432,7 @@ func (c *DeployConfig) AddFlags(flags *pflag.FlagSet) {
 	flags.IntVar(&c.ServerPort, "server-port", c.ServerPort, "Kc server port")
 	flags.IntVar(&c.StaticServerPort, "static-server-port", c.StaticServerPort, "Kc static server port")
 	flags.StringVar(&c.StaticServerPath, "static-server-path", c.StaticServerPath, "Kc static server path(absolute path")
+	flags.StringVar(&c.TempDir, "temp-dir", c.TempDir, "Temporary directory used for deployment files (absolute path)")
 	flags.StringSliceVar(&c.ServerIPs, "server", c.ServerIPs, "Kc server ips")
 	flags.IntVar(&c.EtcdConfig.ClientPort, "etcd-port", c.EtcdConfig.ClientPort, "Etcd port")
 	flags.IntVar(&c.EtcdConfig.PeerPort, "etcd-peer-port", c.EtcdConfig.PeerPort, "Etcd peer port")

--- a/pkg/cli/deploy/config.go
+++ b/pkg/cli/deploy/config.go
@@ -107,6 +107,9 @@ agents:
 # static package directory.
 #staticServerPath: /opt/kubeclipper-server/resource
 
+# temporary directory for deployment packages and extracted files.
+#tempDir: /tmp
+
 # deploy resource package,support url or file absolute path.
 #pkg: ` + constatns.KubeClipperReleaseBaseURL + `/v1.1.0/kc-amd64.tar.gz
 pkg: /tmp/kc-minimal.tar.gz

--- a/pkg/cli/deploy/config_test.go
+++ b/pkg/cli/deploy/config_test.go
@@ -32,6 +32,9 @@ func TestDeployOptions_GenDefaultConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	d := options.NewDeployOptions()
+	if d.TempDir != "/tmp" {
+		t.Fatalf("default tempDir = %q, want /tmp", d.TempDir)
+	}
 	err = yaml.Unmarshal(omitempty, d)
 	if err != nil {
 		return
@@ -41,4 +44,14 @@ func TestDeployOptions_GenDefaultConfig(t *testing.T) {
 		return
 	}
 	t.Log(string(marshal))
+}
+
+func TestDeployOptionsConfigTempDir(t *testing.T) {
+	d := options.NewDeployOptions()
+	if err := yaml.Unmarshal([]byte("tempDir: /var/lib/kubeclipper/tmp\n"), d); err != nil {
+		t.Fatalf("unmarshal deploy config: %v", err)
+	}
+	if d.TempDir != "/var/lib/kubeclipper/tmp" {
+		t.Fatalf("tempDir = %q", d.TempDir)
+	}
 }

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -313,6 +313,15 @@ func (d *DeployOptions) ValidateArgs() error {
 	if d.deployConfig.Pkg == "" {
 		return fmt.Errorf("--pkg must be specified")
 	}
+	if d.deployConfig.TempDir == "" {
+		d.deployConfig.TempDir = config.DefaultPkgPath
+	}
+	if !filepath.IsAbs(d.deployConfig.TempDir) {
+		return fmt.Errorf("temp directory must be an absolute path")
+	}
+	if filepath.Clean(d.deployConfig.TempDir) == string(filepath.Separator) {
+		return fmt.Errorf("temp directory must not be the filesystem root")
+	}
 	if !d.aio && d.deployConfig.SSHConfig.PkFile == "" && d.deployConfig.SSHConfig.Password == "" {
 		return fmt.Errorf("one of --pk-file or --passwd must be specified")
 	}
@@ -639,13 +648,15 @@ func (d *DeployOptions) RunDeploy() error {
 }
 
 func (d *DeployOptions) sendPackage() {
-	tar := fmt.Sprintf("rm -rf %s && tar -xvf %s -C %s", filepath.Join(config.DefaultPkgPath, "kc"),
-		filepath.Join(config.DefaultPkgPath, path.Base(d.deployConfig.Pkg)), config.DefaultPkgPath)
-	cp := sshutils.WrapSh(fmt.Sprintf("cp -rf %s /usr/local/bin/", filepath.Join(config.DefaultPkgPath, "kc/bin/*")))
+	tar := fmt.Sprintf("rm -rf %s && tar -xvf %s -C %s", filepath.Join(d.deployConfig.TempDir, "kc"),
+		filepath.Join(d.deployConfig.TempDir, path.Base(d.deployConfig.Pkg)), d.deployConfig.TempDir)
+	cp := sshutils.WrapSh(fmt.Sprintf("cp -rf %s /usr/local/bin/", filepath.Join(d.deployConfig.TempDir, "kc", "bin", "*")))
 	mkdir := "mkdir -p /usr/lib/systemd/system"
 	// rm -rf /root/kc && tar -xvf /root/kc/pkg/kc.tar -C ~/kc/pkg && /bin/bash -c 'cp -rf /root/kc/pkg/kc/bin/* /usr/local/bin/' && mkdir -p /usr/lib/systemd/system
 	hook := sshutils.Combine([]string{tar, cp, mkdir})
-	err := utils.SendPackage(d.deployConfig.SSHConfig, d.deployConfig.Pkg, d.allNodes, config.DefaultPkgPath, nil, &hook)
+	err := utils.SendPackageWithTempDir(
+		d.deployConfig.SSHConfig, d.deployConfig.Pkg, d.allNodes, d.deployConfig.TempDir, nil, &hook, d.deployConfig.TempDir,
+	)
 	if err != nil {
 		logger.Fatalf("sendPackage err:%s", err.Error())
 	}
@@ -976,8 +987,8 @@ func (d *DeployOptions) deployKcServer() {
 		"mkdir -pv /etc/kubeclipper-server",
 		sshutils.WrapEcho(config.KcServerService, "/usr/lib/systemd/system/kc-server.service"),
 		fmt.Sprintf("mkdir -pv %s/kc", d.deployConfig.StaticServerPath),
-		sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/resource/* %s/", config.DefaultPkgPath, d.deployConfig.StaticServerPath)),
-		sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/bin/* %s/kc/", config.DefaultPkgPath, d.deployConfig.StaticServerPath)),
+		sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/resource/* %s/", d.deployConfig.TempDir, d.deployConfig.StaticServerPath)),
+		sshutils.WrapSh(fmt.Sprintf("cp -rf %s/kc/bin/* %s/kc/", d.deployConfig.TempDir, d.deployConfig.StaticServerPath)),
 	}
 	for _, cmd := range cmdList {
 		err := sshutils.CmdBatchWithSudo(d.deployConfig.SSHConfig, d.deployConfig.ServerIPs, cmd, sshutils.DefaultWalk)
@@ -1061,7 +1072,7 @@ func (d *DeployOptions) deployKcConsole() {
 	data := d.getKcConsoleTemplateContent()
 
 	cmdList := []string{
-		fmt.Sprintf("mkdir -pv /etc/kc-console && cp -rf %s/kc/kc-console /etc/kc-console/dist", config.DefaultPkgPath),
+		fmt.Sprintf("mkdir -pv /etc/kc-console && cp -rf %s/kc/kc-console /etc/kc-console/dist", d.deployConfig.TempDir),
 		sshutils.WrapEcho(config.KcConsoleServiceTmpl, "/usr/lib/systemd/system/kc-console.service"),
 		sshutils.WrapEcho(data, "/etc/kc-console/Caddyfile") + " && systemctl daemon-reload && systemctl enable kc-console --now",
 	}
@@ -1106,7 +1117,9 @@ func (d *DeployOptions) sendAgentIdentity(agentIP string, cert, ca *certutils.Co
 		path.Join(ca.Path, ca.BaseName+".crt"),
 	}
 	for _, source := range sources {
-		if err := utils.SendPackageV2(d.deployConfig.SSHConfig, source, []string{agentIP}, destination, nil, nil); err != nil {
+		if err := utils.SendPackageV2WithTempDir(
+			d.deployConfig.SSHConfig, source, []string{agentIP}, destination, nil, nil, d.deployConfig.TempDir,
+		); err != nil {
 			return err
 		}
 	}
@@ -1115,7 +1128,7 @@ func (d *DeployOptions) sendAgentIdentity(agentIP string, cert, ca *certutils.Co
 
 func (d *DeployOptions) removeTempFile() {
 	cmdList := []string{
-		fmt.Sprintf("rm -rf %s/kc", config.DefaultPkgPath),
+		fmt.Sprintf("rm -rf %s/kc", d.deployConfig.TempDir),
 	}
 	for _, cmd := range cmdList {
 		err := sshutils.CmdBatchWithSudo(d.deployConfig.SSHConfig, d.allNodes, cmd, sshutils.DefaultWalk)
@@ -1134,17 +1147,17 @@ func (d *DeployOptions) dumpConfig() {
 
 func (d *DeployOptions) sendCertAndKey(contents []certutils.Config, pki string) error {
 	for _, content := range contents {
-		err := utils.SendPackageV2(d.deployConfig.SSHConfig,
+		err := utils.SendPackageV2WithTempDir(d.deployConfig.SSHConfig,
 			path.Join(content.Path, content.BaseName+".key"),
 			d.deployConfig.ServerIPs,
-			filepath.Join(options.DefaultKcServerConfigPath, pki), nil, nil)
+			filepath.Join(options.DefaultKcServerConfigPath, pki), nil, nil, d.deployConfig.TempDir)
 		if err != nil {
 			return err
 		}
-		err = utils.SendPackageV2(d.deployConfig.SSHConfig,
+		err = utils.SendPackageV2WithTempDir(d.deployConfig.SSHConfig,
 			path.Join(content.Path, content.BaseName+".crt"),
 			d.deployConfig.ServerIPs,
-			filepath.Join(options.DefaultKcServerConfigPath, pki), nil, nil)
+			filepath.Join(options.DefaultKcServerConfigPath, pki), nil, nil, d.deployConfig.TempDir)
 		if err != nil {
 			return err
 		}
@@ -1154,17 +1167,17 @@ func (d *DeployOptions) sendCertAndKey(contents []certutils.Config, pki string) 
 
 func (d *DeployOptions) sendAgentCertAndKey(contents []certutils.Config, pki string) error {
 	for _, content := range contents {
-		err := utils.SendPackageV2(d.deployConfig.SSHConfig,
+		err := utils.SendPackageV2WithTempDir(d.deployConfig.SSHConfig,
 			path.Join(content.Path, content.BaseName+".key"),
 			d.deployConfig.Agents.ListIP(),
-			filepath.Join(options.DefaultKcAgentConfigPath, pki), nil, nil)
+			filepath.Join(options.DefaultKcAgentConfigPath, pki), nil, nil, d.deployConfig.TempDir)
 		if err != nil {
 			return err
 		}
-		err = utils.SendPackageV2(d.deployConfig.SSHConfig,
+		err = utils.SendPackageV2WithTempDir(d.deployConfig.SSHConfig,
 			path.Join(content.Path, content.BaseName+".crt"),
 			d.deployConfig.Agents.ListIP(),
-			filepath.Join(options.DefaultKcAgentConfigPath, pki), nil, nil)
+			filepath.Join(options.DefaultKcAgentConfigPath, pki), nil, nil, d.deployConfig.TempDir)
 		if err != nil {
 			return err
 		}
@@ -1174,10 +1187,10 @@ func (d *DeployOptions) sendAgentCertAndKey(contents []certutils.Config, pki str
 
 func (d *DeployOptions) sendConsoleCert(contents []certutils.Config, pki string) error {
 	for _, content := range contents {
-		err := utils.SendPackageV2(d.deployConfig.SSHConfig,
+		err := utils.SendPackageV2WithTempDir(d.deployConfig.SSHConfig,
 			path.Join(content.Path, content.BaseName+".crt"),
 			d.deployConfig.ServerIPs,
-			filepath.Join(options.DefaultKcConsoleConfigPath, pki), nil, nil)
+			filepath.Join(options.DefaultKcConsoleConfigPath, pki), nil, nil, d.deployConfig.TempDir)
 		if err != nil {
 			return err
 		}
@@ -1244,10 +1257,10 @@ func (d *DeployOptions) sendDefaultAdminConf() error {
 		path.Join(options.DefaultKcServerConfigPath, options.DefaultConfig),
 		options.DefaultKcServerConfigPath,
 	)
-	err := utils.SendPackage(d.deployConfig.SSHConfig,
+	err := utils.SendPackageWithTempDir(d.deployConfig.SSHConfig,
 		options.DefaultConfigPath,
 		d.deployConfig.ServerIPs,
-		options.DefaultKcServerConfigPath, nil, &afterHook)
+		options.DefaultKcServerConfigPath, nil, &afterHook, d.deployConfig.TempDir)
 	return err
 }
 

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -112,6 +112,34 @@ func TestDeployOptionsCompleteGeneratesAuthenticationJWTSecret(t *testing.T) {
 	}
 }
 
+func TestDeployOptionsValidateTempDir(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		tempDir string
+		wantErr string
+	}{
+		{name: "absolute path", tempDir: "/var/lib/kubeclipper/tmp"},
+		{name: "relative path", tempDir: "kubeclipper/tmp", wantErr: "absolute"},
+		{name: "filesystem root", tempDir: "/", wantErr: "must not be the filesystem root"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDeployOptions(options.IOStreams{})
+			d.aio = true
+			d.deployConfig.Pkg = "/tmp/kc-amd64.tar.gz"
+			d.deployConfig.ServerIPs = []string{"192.0.2.10"}
+			d.deployConfig.TempDir = tt.tempDir
+
+			err := d.ValidateArgs()
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("ValidateArgs() error = %v", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("ValidateArgs() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestKcServerConfigUsesAuthenticationJWTSecret(t *testing.T) {
 	d := NewDeployOptions(options.IOStreams{})
 	d.deployConfig.ServerIPs = []string{"192.0.2.10"}

--- a/pkg/cli/utils/download.go
+++ b/pkg/cli/utils/download.go
@@ -21,7 +21,10 @@ package utils
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"path"
+	"path/filepath"
 	"sync"
 
 	"github.com/vbauerster/mpb/v8"
@@ -36,15 +39,41 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/cli/logger"
 )
 
+const defaultTempDir = "/tmp"
+
+const (
+	stagingDirPerm = 0700
+	stagedFilePerm = 0600
+)
+
 // SendPackageV2 scp file to remote host
 // Deprecated
 func SendPackageV2(sshConfig *sshutils.SSH, location string, hosts []string, dstDir string, before, after *string) error {
+	return SendPackageV2WithTempDir(sshConfig, location, hosts, dstDir, before, after, defaultTempDir)
+}
+
+// SendPackageV2WithTempDir scp a package to remote hosts using tempDir for local staging.
+//
+//nolint:funlen,gocyclo // preserve the existing transfer state machine while adding configurable staging.
+func SendPackageV2WithTempDir(
+	sshConfig *sshutils.SSH,
+	location string,
+	hosts []string,
+	dstDir string,
+	before, after *string,
+	tempDir string,
+) error {
 	var md5 string
-	// download pkg to /tmp/kc/
-	location, md5, err := downloadFile(location)
+	location, md5, err := downloadFile(location, tempDir)
 	if err != nil {
 		return errors.Wrap(err, "downloadFile")
 	}
+	stagedLocation, cleanup, err := stagePackage(location, tempDir)
+	if err != nil {
+		return errors.Wrap(err, "stagePackage")
+	}
+	defer cleanup()
+	location = stagedLocation
 	pkg := path.Base(location)
 	// scp to ~/kc/kc-bj-cd.tar.gz
 	fullPath := fmt.Sprintf("%s/%s", dstDir, pkg)
@@ -95,7 +124,7 @@ func SendPackageV2(sshConfig *sshutils.SSH, location string, hosts []string, dst
 						logger.Errorf("[%s]remove old file(%s) err %s", host, fullPath, err.Error())
 						return
 					}
-					ok, err := sshConfig.CopyForMD5V2(host, location, fullPath, md5)
+					ok, err := sshConfig.CopyForMD5V2WithTempDir(host, location, fullPath, md5, tempDir)
 					if err != nil {
 						logger.Errorf("[%s]copy file(%s) md5 validate failed err %s", host, location, err.Error())
 						return
@@ -107,7 +136,7 @@ func SendPackageV2(sshConfig *sshutils.SSH, location string, hosts []string, dst
 					}
 				}
 			} else {
-				ok, err := sshConfig.CopyForMD5V2(host, location, fullPath, md5)
+				ok, err := sshConfig.CopyForMD5V2WithTempDir(host, location, fullPath, md5, tempDir)
 				if err != nil {
 					logger.Errorf("[%s]copy file(%s) md5 validate failed err %s", host, fullPath, err.Error())
 					return
@@ -151,9 +180,10 @@ func SendPackageV2(sshConfig *sshutils.SSH, location string, hosts []string, dst
 	}
 }
 
-func downloadFile(location string) (filePATH, md5 string, err error) {
+func downloadFile(location, tempDir string) (filePATH, md5 string, err error) {
 	if _, ok := httputil.IsURL(location); ok {
-		absPATH := "/tmp/kc/" + path.Base(location)
+		sourceDir := filepath.Join(tempDir, "kc-source")
+		absPATH := filepath.Join(sourceDir, path.Base(location))
 		exist, err := sshutils.IsFileExist(absPATH)
 		if err != nil {
 			return "", "", err
@@ -162,8 +192,8 @@ func downloadFile(location string) (filePATH, md5 string, err error) {
 			// generator download cmd
 			dwnCmd := downloadCmd(location)
 			// os exec download command
-			if err = sshutils.Cmd("/bin/sh", "-c", "mkdir -p /tmp/kc && cd /tmp/kc && "+dwnCmd); err != nil {
-				return "", "", err
+			if downloadErr := sshutils.Cmd("/bin/sh", "-c", "mkdir -p "+sourceDir+" && cd "+sourceDir+" && "+dwnCmd); downloadErr != nil {
+				return "", "", downloadErr
 			}
 		}
 		location = absPATH
@@ -189,12 +219,34 @@ func downloadCmd(url string) string {
 }
 
 func SendPackage(sshConfig *sshutils.SSH, location string, hosts []string, dstDir string, before, after *string) error {
+	return SendPackageWithTempDir(sshConfig, location, hosts, dstDir, before, after, defaultTempDir)
+}
+
+// SendPackageWithTempDir scp a package to remote hosts using tempDir for local staging.
+//
+//nolint:funlen,gocyclo // preserve the existing transfer state machine while adding configurable staging.
+func SendPackageWithTempDir(
+	sshConfig *sshutils.SSH,
+	location string,
+	hosts []string,
+	dstDir string,
+	before, after *string,
+	tempDir string,
+) error {
 	var md5 string
-	// download pkg to /tmp/kc/
-	location, md5, err := downloadFile(location)
+	location, md5, err := downloadFile(location, tempDir)
 	if err != nil {
 		return errors.Wrap(err, "downloadFile")
 	}
+	// Keep the local source separate from the remote extraction directory. A
+	// target host may be the machine running kcctl and remove tempDir/kc while
+	// other hosts are still copying the package.
+	stagedLocation, cleanup, err := stagePackage(location, tempDir)
+	if err != nil {
+		return errors.Wrap(err, "stagePackage")
+	}
+	defer cleanup()
+	location = stagedLocation
 	pkg := path.Base(location)
 	// scp to ~/kc/kc-bj-cd.tar.gz
 	fullPath := fmt.Sprintf("%s/%s", dstDir, pkg)
@@ -330,13 +382,17 @@ func SendPackage(sshConfig *sshutils.SSH, location string, hosts []string, dstDi
 				} else {
 					rm := fmt.Sprintf("rm -rf %s", fullPath)
 					ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, rm)
-					if err != nil || ret.Error() != nil {
+					if err != nil {
+						errCh <- errors.WithMessage(err, "remove remote old files")
+						return
+					}
+					if err = ret.Error(); err != nil {
 						errCh <- errors.WithMessage(err, "remove remote old files")
 						return
 					}
 					checkmd5bar.SetTotal(-1, true)
-					if err := sshConfig.CopySudoWithBar(downloadbar, host, location, fullPath); err != nil {
-						errCh <- errors.WithMessage(err, "download")
+					if copyErr := sshConfig.CopySudoWithBarWithTempDir(downloadbar, host, location, fullPath, tempDir); copyErr != nil {
+						errCh <- errors.WithMessage(copyErr, "download")
 						return
 					}
 					if downloadbar.IsRunning() {
@@ -356,7 +412,7 @@ func SendPackage(sshConfig *sshutils.SSH, location string, hosts []string, dstDi
 				}
 			} else {
 				checkmd5bar.SetTotal(-1, true)
-				if err := sshConfig.CopySudoWithBar(downloadbar, host, location, fullPath); err != nil {
+				if err := sshConfig.CopySudoWithBarWithTempDir(downloadbar, host, location, fullPath, tempDir); err != nil {
 					errCh <- errors.WithMessage(err, "download")
 					return
 				}
@@ -404,11 +460,62 @@ func SendPackage(sshConfig *sshutils.SSH, location string, hosts []string, dstDi
 	}
 }
 
+// Keep staging isolated from the remote extraction directory.
+func stagePackage(location, tempDir string) (stagedPath string, cleanup func(), err error) {
+	sourceDir := filepath.Join(tempDir, "kc-source")
+	if mkdirErr := os.MkdirAll(sourceDir, stagingDirPerm); mkdirErr != nil {
+		return "", func() {}, mkdirErr
+	}
+	dir, err := os.MkdirTemp(sourceDir, "stage-")
+	if err != nil {
+		return "", func() {}, err
+	}
+	cleanup = func() { _ = os.RemoveAll(dir) }
+	staged := filepath.Join(dir, path.Base(location))
+
+	if linkErr := os.Link(location, staged); linkErr == nil {
+		return staged, cleanup, nil
+	}
+
+	src, err := os.Open(location)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	defer src.Close()
+	dst, err := os.OpenFile(staged, os.O_WRONLY|os.O_CREATE|os.O_EXCL, stagedFilePerm)
+	if err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	if _, err = io.Copy(dst, src); err != nil {
+		_ = dst.Close()
+		cleanup()
+		return "", func() {}, err
+	}
+	if err = dst.Close(); err != nil {
+		cleanup()
+		return "", func() {}, err
+	}
+	return staged, cleanup, nil
+}
+
 func SendPackageLocal(location string, dstDir string, after *string) error {
-	location, _, err := downloadFile(location)
+	return SendPackageLocalWithTempDir(location, dstDir, after, defaultTempDir)
+}
+
+// SendPackageLocalWithTempDir copies a package locally using tempDir for local staging.
+func SendPackageLocalWithTempDir(location, dstDir string, after *string, tempDir string) error {
+	location, _, err := downloadFile(location, tempDir)
 	if err != nil {
 		return errors.Wrap(err, "downloadFile")
 	}
+	stagedLocation, cleanup, err := stagePackage(location, tempDir)
+	if err != nil {
+		return errors.Wrap(err, "stagePackage")
+	}
+	defer cleanup()
+	location = stagedLocation
 
 	mkDstDir := fmt.Sprintf("mkdir -p %s || true", dstDir)
 	if err = sshutils.Cmd("/bin/sh", "-c", mkDstDir); err != nil {

--- a/pkg/cli/utils/download_test.go
+++ b/pkg/cli/utils/download_test.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStagePackageKeepsSourceIndependentFromCleanupDirectory(t *testing.T) {
+	sourceDir := t.TempDir()
+	source := filepath.Join(sourceDir, "kc-amd64.tar.gz")
+	contents := []byte("package contents")
+	if err := os.WriteFile(source, contents, 0600); err != nil {
+		t.Fatalf("write source package: %v", err)
+	}
+
+	tempDir := t.TempDir()
+	staged, cleanup, err := stagePackage(source, tempDir)
+	if err != nil {
+		t.Fatalf("stage package: %v", err)
+	}
+	defer cleanup()
+	if staged == source {
+		t.Fatalf("staged package reused source path %q", source)
+	}
+	wantPrefix := filepath.Join(tempDir, "kc-source") + string(filepath.Separator)
+	if !strings.HasPrefix(staged, wantPrefix) {
+		t.Fatalf("staged package path = %q, want under %q", staged, wantPrefix)
+	}
+
+	if removeErr := os.Remove(source); removeErr != nil {
+		t.Fatalf("remove source package: %v", removeErr)
+	}
+	got, err := os.ReadFile(staged)
+	if err != nil {
+		t.Fatalf("read staged package after source removal: %v", err)
+	}
+	if !bytes.Equal(got, contents) {
+		t.Fatalf("staged package contents = %q, want %q", got, contents)
+	}
+}

--- a/pkg/utils/sshutils/scp.go
+++ b/pkg/utils/sshutils/scp.go
@@ -35,9 +35,15 @@ import (
 
 const KB = 1024
 const MB = 1024 * 1024
+const defaultCopyTempDir = "/tmp"
 
 // CopyForMD5V2 copy and check md5
 func (ss *SSH) CopyForMD5V2(host, localFilePath, remoteFilePath, localMD5 string) (bool, error) {
+	return ss.CopyForMD5V2WithTempDir(host, localFilePath, remoteFilePath, localMD5, defaultCopyTempDir)
+}
+
+// CopyForMD5V2WithTempDir copies a file through tempDir when sudo is required.
+func (ss *SSH) CopyForMD5V2WithTempDir(host, localFilePath, remoteFilePath, localMD5, tempDir string) (bool, error) {
 	var err error
 	if localMD5 == "" {
 		localMD5, err = MD5FromLocal(localFilePath)
@@ -45,7 +51,7 @@ func (ss *SSH) CopyForMD5V2(host, localFilePath, remoteFilePath, localMD5 string
 			return false, err
 		}
 	}
-	err = ss.CopySudo(host, localFilePath, remoteFilePath)
+	err = ss.CopySudoWithTempDir(host, localFilePath, remoteFilePath, tempDir)
 	if err != nil {
 		return false, err
 	}
@@ -60,11 +66,16 @@ func (ss *SSH) CopyForMD5V2(host, localFilePath, remoteFilePath, localMD5 string
 }
 
 func (ss *SSH) CopySudo(host, localFilePath, remoteFilePath string) error {
+	return ss.CopySudoWithTempDir(host, localFilePath, remoteFilePath, defaultCopyTempDir)
+}
+
+// CopySudoWithTempDir copies a file through tempDir when sudo is required.
+func (ss *SSH) CopySudoWithTempDir(host, localFilePath, remoteFilePath, tempDir string) error {
 	if ss.User == "root" { // root user,need not transit
 		return ss.Copy(host, localFilePath, remoteFilePath)
 	}
-	// 	if not root,first scp to /tmp,then sudo mv to target
-	middle := filepath.Join("/tmp", remoteFilePath)
+	// if not root, first scp to the configured temp directory, then sudo mv to target
+	middle := filepath.Join(tempDir, remoteFilePath)
 	err := ss.Copy(host, localFilePath, middle)
 	if err != nil {
 		return errors.Wrap(err, "copy")
@@ -142,7 +153,7 @@ func (ss *SSH) DownloadSudo(host, localFilePath, remoteFilePath string) error {
 	if ss.User == "root" { // root user,need not transit
 		return ss.download(host, localFilePath, remoteFilePath)
 	}
-	// 	if not root,first scp to /tmp,then sudo mv to target
+	// if not root, first scp to /tmp, then sudo mv to target
 	middle := filepath.Join("/tmp", localFilePath)
 	err := ss.download(host, middle, remoteFilePath)
 	if err != nil {
@@ -237,11 +248,16 @@ func toSizeFromInt(length int) (float64, string) {
 }
 
 func (ss *SSH) CopySudoWithBar(bar *mpb.Bar, host, localFilePath, remoteFilePath string) error {
+	return ss.CopySudoWithBarWithTempDir(bar, host, localFilePath, remoteFilePath, defaultCopyTempDir)
+}
+
+// CopySudoWithBarWithTempDir copies a file with progress through tempDir when sudo is required.
+func (ss *SSH) CopySudoWithBarWithTempDir(bar *mpb.Bar, host, localFilePath, remoteFilePath, tempDir string) error {
 	if ss.User == "root" { // root user,need not transit
 		return ss.CopyWithBar(bar, host, localFilePath, remoteFilePath)
 	}
-	// 	if not root,first scp to /tmp,then sudo mv to target
-	middle := filepath.Join("/tmp", remoteFilePath)
+	// if not root, first scp to the configured temp directory, then sudo mv to target
+	middle := filepath.Join(tempDir, remoteFilePath)
 	err := ss.CopyWithBar(bar, host, localFilePath, middle)
 	if err != nil {
 		return errors.Wrap(err, "copy")


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Adds `tempDir` deployment configuration and the `--temp-dir` flag, defaulting to `/tmp`. Package sources are staged under `<tempDir>/kc-source` before concurrent transfer, while the existing remote extraction path remains `<tempDir>/kc`. This prevents a deployment node from deleting the local source package while other nodes are still receiving it.

### Which issue(s) this PR fixes:

None.

### Special notes for reviewers:

- `tempDir` must be an absolute path and cannot be `/`.
- URL downloads, explicit local packages, certificate transfers, and non-root SSH transfer intermediates use the configured directory.
- Existing deployments retain `/tmp` as the default.

### Does this PR introduced a user-facing change?

```release-note
kcctl deploy supports `tempDir` in deploy configuration and `--temp-dir` to select the directory used for package staging and extraction.
```

### Additional documentation, usage docs, etc.:

```docs
- [Usage]: Set `tempDir: /path/with/sufficient-space` in deploy-config.yaml, or pass `kcctl deploy --temp-dir /path/with/sufficient-space`.
```