### PR TITLE
fix(deploy): preserve precheck failure details

### DIFF
--- a/cmd/kcctl/app/root.go
+++ b/cmd/kcctl/app/root.go
@@ -68,9 +68,11 @@ kcctl controls the Kubeclipper platform.`
 
 func NewKubeClipperCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
-		Use:   "kcctl",
-		Short: "kcctl is kubeclipper command line tool",
-		Long:  longDescription,
+		Use:           "kcctl",
+		Short:         "kcctl is kubeclipper command line tool",
+		Long:          longDescription,
+		SilenceErrors: true,
+		SilenceUsage:  true,
 		Run: func(cmd *cobra.Command, args []string) {
 			_ = cmd.Help()
 		},

--- a/cmd/kcctl/main.go
+++ b/cmd/kcctl/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app"
+	"github.com/kubeclipper/kubeclipper/pkg/cli/logger"
 )
 
 func main() {
@@ -35,7 +36,7 @@ func main() {
 			code = exitError.ExitCode()
 		}
 		if err.Error() != "" {
-			_, _ = fmt.Fprintln(os.Stderr, err)
+			_, _ = fmt.Fprintln(os.Stderr, logger.ColorizeError(err.Error()))
 		}
 		os.Exit(code)
 	}

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -197,8 +197,8 @@ func NewCmdDeploy(streams options.IOStreams) *cobra.Command {
 				return err
 			}
 			o.preRun()
-			if !o.preCheck() {
-				return fmt.Errorf("deploy precheck failed")
+			if err := o.preCheck(); err != nil {
+				return &deployPrecheckError{cause: err}
 			}
 			return o.RunDeploy()
 		},
@@ -395,19 +395,85 @@ func precheckPortFunc(port int, serviceName string) precheckFunc {
 
 func generateCommonPreCheckFunc(name string) precheckFunc {
 	return func(sshConfig *sshutils.SSH, host string) error {
-		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, fmt.Sprintf("systemctl --all --type service | grep %s | wc -l", name))
+		command := fmt.Sprintf(
+			"systemctl show --no-pager --property=LoadState --property=ActiveState "+
+				"--property=SubState --value %s.service", name)
+		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, command)
 		logger.V(2).Infof("exit code %d, err %v", ret.ExitCode, err)
 		if err != nil {
 			return err
 		}
-		if ret.StdoutToString("") != "0" {
-			err = fmt.Errorf("%s service exist, please clean old environment", name)
+		state, err := parseSystemdUnitState(ret.Stdout)
+		if err != nil {
+			return fmt.Errorf("read %s.service state: %w", name, err)
 		}
-		return err
+		if state.load != "not-found" {
+			return &existingServiceError{name: name, state: state}
+		}
+		return nil
 	}
 }
 
-func (d *DeployOptions) precheckService(name string, nodes []string, fn precheckFunc) bool {
+type systemdUnitState struct {
+	load   string
+	active string
+	sub    string
+}
+
+type existingServiceError struct {
+	name  string
+	state systemdUnitState
+}
+
+func (e *existingServiceError) Error() string {
+	return fmt.Sprintf("%s.service already exists", e.name)
+}
+
+type precheckFailure struct {
+	check string
+	node  string
+	cause error
+}
+
+func (e *precheckFailure) Error() string {
+	if serviceErr, ok := e.cause.(*existingServiceError); ok {
+		return fmt.Sprintf("check: %s\nnode: %s\nreason: %s.service already exists\nstate: load=%s, active=%s, sub=%s",
+			e.check, e.node, serviceErr.name, serviceErr.state.load, serviceErr.state.active, serviceErr.state.sub)
+	}
+	return fmt.Sprintf("check: %s\nnode: %s\nreason: %v", e.check, e.node, e.cause)
+}
+
+func (e *precheckFailure) Unwrap() error { return e.cause }
+
+type deployPrecheckError struct {
+	cause error
+}
+
+func (e *deployPrecheckError) Error() string {
+	message := "deploy precheck failed:\n  " + strings.ReplaceAll(e.cause.Error(), "\n", "\n  ")
+	if failure, ok := e.cause.(*precheckFailure); ok {
+		if _, ok := failure.cause.(*existingServiceError); ok {
+			return message + "\nclean old environment before deploying"
+		}
+	}
+	return message
+}
+
+func (e *deployPrecheckError) Unwrap() error { return e.cause }
+
+func parseSystemdUnitState(output string) (systemdUnitState, error) {
+	values := strings.Split(strings.TrimSpace(output), "\n")
+	if len(values) != 3 {
+		return systemdUnitState{}, fmt.Errorf("expected load, active, and sub state, got %q", strings.TrimSpace(output))
+	}
+	return systemdUnitState{
+		load:   values[0],
+		active: values[1],
+		sub:    values[2],
+	}, nil
+}
+
+func (d *DeployOptions) precheckService(name string, nodes []string, fn precheckFunc) error {
 	logger.Infof("============>%s PRECHECK ...", name)
 	errs := make([]error, len(nodes))
 	wg := sync.WaitGroup{}
@@ -431,7 +497,7 @@ func (d *DeployOptions) precheckService(name string, nodes []string, fn precheck
 	}
 	if !hasError {
 		logger.Infof("============>%s PRECHECK OK!", name)
-		return true
+		return nil
 	}
 
 	groups := make(map[string][]string)
@@ -459,15 +525,33 @@ func (d *DeployOptions) precheckService(name string, nodes []string, fn precheck
 			logger.Warnf("  - %s", ref)
 		}
 	}
-	logger.Errorf("===========>%s PRECHECK FAILED!", name)
-	return false
+	for i, err := range errs {
+		if err == nil {
+			continue
+		}
+		logger.Errorf("===========>%s PRECHECK FAILED!", name)
+		return &precheckFailure{check: name, node: d.nodeReference(nodes, i), cause: err}
+	}
+	return fmt.Errorf("%s precheck failed", name)
 }
 
-func (d *DeployOptions) precheckTimeLag() bool {
+func (d *DeployOptions) nodeReference(nodes []string, index int) string {
+	if index < 0 || index >= len(nodes) {
+		return "[unknown node]"
+	}
+	host := nodes[index]
+	role := d.nodeRole(host)
+	if role == "" {
+		return fmt.Sprintf("[%s]", host)
+	}
+	return fmt.Sprintf("[%s@%s]", role, host)
+}
+
+func (d *DeployOptions) precheckTimeLag() error {
 	logger.Infof("============>TIME-LAG PRECHECK ...")
 	type timeLagEntry struct {
 		lag float64
-		ok  bool
+		err error
 	}
 	entries := make([]timeLagEntry, len(d.allNodes))
 	wg := sync.WaitGroup{}
@@ -480,60 +564,56 @@ func (d *DeployOptions) precheckTimeLag() bool {
 			ret, err := sshutils.SSHCmd(d.deployConfig.SSHConfig, host, "date +%s")
 			if err != nil {
 				logger.Errorf("get timestamp from %s failed: %s", host, err.Error())
-				entries[idx] = timeLagEntry{ok: true}
+				entries[idx] = timeLagEntry{err: fmt.Errorf("get timestamp: %w", err)}
 				return
 			}
 			output := ret.StdoutToString("")
 			ts, err := strconv.ParseInt(output, 10, 64)
 			if err != nil {
 				logger.Errorf("parse timestamp from %s failed: %s", host, err.Error())
-				entries[idx] = timeLagEntry{ok: true}
+				entries[idx] = timeLagEntry{err: fmt.Errorf("parse timestamp %q: %w", output, err)}
 				return
 			}
 			t := time.Unix(ts, 0)
 			diff := t.Sub(now).Seconds()
 			logger.Infof("[%s] %v seconds", host, diff)
 			if math.Abs(diff) > float64(5) {
-				entries[idx] = timeLagEntry{lag: diff, ok: true}
+				entries[idx] = timeLagEntry{lag: diff}
 			}
 		}(i, node)
 	}
 	wg.Wait()
 
-	hasLag := false
-	for _, e := range entries {
-		if e.ok {
-			hasLag = true
-			break
-		}
-	}
-	if !hasLag {
-		logger.Infof("all nodes time lag less then 5 seconds")
-		logger.Infof("============>TIME-LAG PRECHECK OK!")
-		return true
-	}
-	logger.Warnf("time lag exceeds 5s threshold:")
-	for i, e := range entries {
-		if !e.ok {
+	var failures []string
+	for i, entry := range entries {
+		if entry.err == nil && entry.lag == 0 {
 			continue
 		}
-		host := d.allNodes[i]
-		role := d.nodeRole(host)
-		ref := fmt.Sprintf("[%s@%s]", role, host)
+		role := d.nodeRole(d.allNodes[i])
+		ref := fmt.Sprintf("[%s@%s]", role, d.allNodes[i])
 		if role == "" {
-			ref = fmt.Sprintf("[%s]", host)
+			ref = fmt.Sprintf("[%s]", d.allNodes[i])
 		}
-		if e.lag != 0 {
-			logger.Warnf("  - %s %.1fs", ref, e.lag)
-		} else {
-			logger.Warnf("  - %s (failed to get time)", ref)
+		if entry.err != nil {
+			failures = append(failures, fmt.Sprintf("%s %v", ref, entry.err))
+			continue
 		}
+		failures = append(failures, fmt.Sprintf("%s time lag %.1fs exceeds 5s", ref, entry.lag))
+	}
+	if len(failures) == 0 {
+		logger.Infof("all nodes time lag less then 5 seconds")
+		logger.Infof("============>TIME-LAG PRECHECK OK!")
+		return nil
+	}
+	logger.Warnf("time lag exceeds 5s threshold:")
+	for _, failure := range failures {
+		logger.Warnf("  - %s", failure)
 	}
 	logger.Errorf("===========>TIME-LAG PRECHECK FAILED!")
-	return false
+	return fmt.Errorf("TIME-LAG precheck failed: %s", strings.Join(failures, "; "))
 }
 
-func (d *DeployOptions) precheckPorts() bool {
+func (d *DeployOptions) precheckPorts() error {
 	var (
 		missingToolHosts = make(map[string]bool)
 		mu               sync.Mutex
@@ -552,8 +632,8 @@ func (d *DeployOptions) precheckPorts() bool {
 		}
 		return nil
 	}
-	if !d.precheckService("PORT-TOOL", d.deployConfig.ServerIPs, toolCheck) {
-		return false
+	if err := d.precheckService("PORT-TOOL", d.deployConfig.ServerIPs, toolCheck); err != nil {
+		return err
 	}
 
 	serverPorts := []struct {
@@ -568,7 +648,7 @@ func (d *DeployOptions) precheckPorts() bool {
 		{d.deployConfig.ConsolePort, "kc-console"},
 	}
 	for _, p := range serverPorts {
-		if !d.precheckService(
+		if err := d.precheckService(
 			fmt.Sprintf("PORT-%d(%s)", p.port, p.name),
 			d.deployConfig.ServerIPs,
 			func(port int, svc string) precheckFunc {
@@ -582,39 +662,42 @@ func (d *DeployOptions) precheckPorts() bool {
 					return precheckPortFunc(port, svc)(sshConfig, host)
 				}
 			}(p.port, p.name),
-		) {
-			return false
+		); err != nil {
+			return err
 		}
 	}
-	return true
+	return nil
 }
 
-func (d *DeployOptions) preCheck() bool {
-	if !d.precheckService("kc-etcd", d.deployConfig.ServerIPs, precheckKcEtcdFunc) {
-		return false
+func (d *DeployOptions) preCheck() error {
+	if err := d.precheckService("kc-etcd", d.deployConfig.ServerIPs, precheckKcEtcdFunc); err != nil {
+		return err
 	}
-	if !d.precheckService("kc-server", d.deployConfig.ServerIPs, precheckKcServerFunc) {
-		return false
+	if err := d.precheckService("kc-server", d.deployConfig.ServerIPs, precheckKcServerFunc); err != nil {
+		return err
 	}
-	if !d.precheckService("kc-agent", d.allNodes, precheckKcAgentFunc) {
-		return false
+	if err := d.precheckService("kc-agent", d.allNodes, precheckKcAgentFunc); err != nil {
+		return err
 	}
-	if !d.precheckTimeLag() {
-		return false
+	if err := d.precheckTimeLag(); err != nil {
+		return err
 	}
-	if !d.precheckPorts() {
-		return false
+	if err := d.precheckPorts(); err != nil {
+		return err
 	}
-	if !d.precheckService("NTP", d.allNodes, precheckNtpFunc) {
-		return false
+	if err := d.precheckService("NTP", d.allNodes, precheckNtpFunc); err != nil {
+		return err
 	}
-	if !sudo.PreCheck("sudo", d.deployConfig.SSHConfig, d.IOStreams, d.allNodes) {
-		return false
+	if err := sudo.PreCheckError("sudo", d.deployConfig.SSHConfig, d.IOStreams, d.allNodes); err != nil {
+		return err
 	}
-	if !sudo.MultiNIC("ipDetect", d.deployConfig.SSHConfig, d.IOStreams, d.deployConfig.Agents.ListIP(), d.deployConfig.IPDetect) {
-		return false
+	if err := sudo.MultiNICError(
+		"ipDetect", d.deployConfig.SSHConfig, d.IOStreams,
+		d.deployConfig.Agents.ListIP(), d.deployConfig.IPDetect,
+	); err != nil {
+		return err
 	}
-	return true
+	return nil
 }
 
 func (d *DeployOptions) RunDeploy() error {

--- a/pkg/cli/deploy/deploy_test.go
+++ b/pkg/cli/deploy/deploy_test.go
@@ -53,10 +53,47 @@ func TestPrecheckServiceDoesNotIgnoreFailureWithAssumeYes(t *testing.T) {
 	t.Cleanup(func() { options.AssumeYes = originalAssumeYes })
 
 	d := NewDeployOptions(options.IOStreams{})
-	if d.precheckService("test", []string{"192.0.2.1"}, func(*sshutils.SSH, string) error {
+	err := d.precheckService("test", []string{"192.0.2.1"}, func(*sshutils.SSH, string) error {
 		return errors.New("precheck failed")
-	}) {
+	})
+	if err == nil {
 		t.Fatal("precheckService() succeeded with --assumeyes after a precheck failure")
+	}
+	if !strings.Contains(err.Error(), "check: test") || !strings.Contains(err.Error(), "node: [192.0.2.1]") || !strings.Contains(err.Error(), "reason: precheck failed") {
+		t.Fatalf("precheckService() error = %v, want check, node, and root cause", err)
+	}
+}
+
+func TestDeployPrecheckErrorFormatsServiceFailure(t *testing.T) {
+	err := (&deployPrecheckError{cause: &precheckFailure{
+		check: "kc-etcd",
+		node:  "[server+agent@172.16.131.208]",
+		cause: &existingServiceError{
+			name:  "kc-etcd",
+			state: systemdUnitState{load: "loaded", active: "active", sub: "running"},
+		},
+	}}).Error()
+	want := "deploy precheck failed:\n" +
+		"  check: kc-etcd\n" +
+		"  node: [server+agent@172.16.131.208]\n" +
+		"  reason: kc-etcd.service already exists\n" +
+		"  state: load=loaded, active=active, sub=running\n" +
+		"clean old environment before deploying"
+	if err != want {
+		t.Fatalf("deploy precheck error = %q, want %q", err, want)
+	}
+}
+
+func TestParseSystemdUnitState(t *testing.T) {
+	state, err := parseSystemdUnitState("loaded\nactive\nrunning\n")
+	if err != nil {
+		t.Fatalf("parseSystemdUnitState() error = %v", err)
+	}
+	if got, want := state, (systemdUnitState{load: "loaded", active: "active", sub: "running"}); got != want {
+		t.Fatalf("parseSystemdUnitState() = %#v, want %#v", got, want)
+	}
+	if _, err := parseSystemdUnitState("loaded\nactive"); err == nil {
+		t.Fatal("parseSystemdUnitState() succeeded with incomplete state")
 	}
 }
 

--- a/pkg/cli/logger/logger.go
+++ b/pkg/cli/logger/logger.go
@@ -316,6 +316,28 @@ func Errorf(format string, args ...interface{}) {
 	_logging.printf(errorLog, format, args...)
 }
 
+// ColorizeError formats structured CLI errors for terminal output while preserving
+// plain text when color output is disabled.
+func ColorizeError(message string) string {
+	if !_logging.Colorful {
+		return message
+	}
+	lines := strings.Split(message, "\n")
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(trimmed, "deploy precheck failed:"):
+			lines[i] = color.RedString(line)
+		case strings.HasPrefix(trimmed, "clean old environment before deploying"):
+			lines[i] = color.YellowString(line)
+		case strings.HasPrefix(trimmed, "check:"), strings.HasPrefix(trimmed, "node:"),
+			strings.HasPrefix(trimmed, "reason:"), strings.HasPrefix(trimmed, "state:"):
+			lines[i] = color.CyanString(line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 func Fatal(args ...interface{}) {
 	_logging.println(fatalLog, args...)
 }

--- a/pkg/cli/operation/tui/app.go
+++ b/pkg/cli/operation/tui/app.go
@@ -70,9 +70,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.height = msg.Height
 		m.ready = true
 		m.listModel = NewListModel(m.operations, m.width, m.height)
-		if m.currentView == viewLog {
-			m.logModel = NewLogModel(m.client, m.logModel.operation, m.width, m.height)
-		}
 
 	case selectOpMsg:
 		m.currentView = viewLog

--- a/pkg/cli/operation/tui/log_view.go
+++ b/pkg/cli/operation/tui/log_view.go
@@ -51,6 +51,8 @@ type LogModel struct {
 	cursor     int
 	followMode bool
 	lastOffset map[string]int64
+	logContent map[string]string
+	displayed  string
 	viewport   viewport.Model
 	rawContent string
 	width      int
@@ -68,7 +70,7 @@ func NewLogModel(client *kc.Client, op *operationsv1alpha1.Operation, width, hei
 	logPanelWidth = max(minLogPanelWidth, logPanelWidth)
 	return LogModel{
 		client: client, operation: op, steps: buildStepEntries(op, nil),
-		lastOffset: make(map[string]int64), viewport: viewport.New(logPanelWidth, height-3),
+		lastOffset: make(map[string]int64), logContent: make(map[string]string), viewport: viewport.New(logPanelWidth, height-3),
 		width: width, height: height,
 	}
 }
@@ -193,10 +195,25 @@ func (m *LogModel) currentTask() *TaskEntry {
 	return &m.steps[m.cursor].Tasks[len(m.steps[m.cursor].Tasks)-1]
 }
 
+func (m *LogModel) showCurrentLog() bool {
+	task := m.currentTask()
+	if task == nil {
+		m.displayed = ""
+		m.rawContent = "(no Task has been created for this step)\n"
+		m.viewport.SetContent(m.rawContent)
+		return false
+	}
+	m.displayed = task.Name
+	m.rawContent = m.logContent[task.Name]
+	m.viewport.SetContent(m.rawContent)
+	m.viewport.GotoTop()
+	return true
+}
+
 func (m *LogModel) fetchCurrentLogCmd() tea.Cmd {
 	task := m.currentTask()
 	if task == nil {
-		return func() tea.Msg { return logFetchedMsg{content: "(no Task has been created for this step)\n"} }
+		return nil
 	}
 	offset := m.lastOffset[task.Name]
 	return func() tea.Msg {
@@ -240,14 +257,15 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 		m.viewport.Width = maxInt(minLogPanelWidth, m.width-m.width*35/100-2)
 		m.viewport.Height = m.height - 3
 	case logFetchedMsg:
-		if msg.content != "" {
-			m.rawContent += msg.content
-			m.viewport.SetContent(m.rawContent)
-			if msg.key != "" {
-				m.lastOffset[msg.key] = msg.offset
-			}
-			if m.followMode {
-				m.viewport.GotoBottom()
+		if msg.content != "" && msg.key != "" {
+			m.logContent[msg.key] += msg.content
+			m.lastOffset[msg.key] = msg.offset
+			if msg.key == m.displayed {
+				m.rawContent = m.logContent[msg.key]
+				m.viewport.SetContent(m.rawContent)
+				if m.followMode {
+					m.viewport.GotoBottom()
+				}
 			}
 		}
 	case tickMsg:
@@ -261,7 +279,11 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 			if m.cursor >= len(m.steps) {
 				m.cursor = maxInt(0, len(m.steps)-1)
 			}
-			if m.rawContent == "" {
+			if m.currentTask() == nil || m.currentTask().Name != m.displayed {
+				if m.showCurrentLog() {
+					cmds = append(cmds, m.fetchCurrentLogCmd())
+				}
+			} else if m.rawContent == "" {
 				cmds = append(cmds, m.fetchCurrentLogCmd())
 			}
 			if msg.operation.Status.Phase.IsTerminal() {
@@ -273,14 +295,16 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 		case DefaultKeyMap.Up, "k":
 			if m.cursor > 0 {
 				m.cursor--
-				m.resetLog()
-				cmds = append(cmds, m.fetchCurrentLogCmd())
+				if m.showCurrentLog() {
+					cmds = append(cmds, m.fetchCurrentLogCmd())
+				}
 			}
 		case DefaultKeyMap.Down, "j":
 			if m.cursor < len(m.steps)-1 {
 				m.cursor++
-				m.resetLog()
-				cmds = append(cmds, m.fetchCurrentLogCmd())
+				if m.showCurrentLog() {
+					cmds = append(cmds, m.fetchCurrentLogCmd())
+				}
 			}
 		case DefaultKeyMap.PageUp:
 			m.viewport.HalfPageUp()
@@ -305,8 +329,6 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 	}
 	return m, tea.Batch(cmds...)
 }
-
-func (m *LogModel) resetLog() { m.rawContent = ""; m.viewport.SetContent("") }
 
 type backMsg struct{}
 

--- a/pkg/cli/operation/tui/operation_v2_test.go
+++ b/pkg/cli/operation/tui/operation_v2_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	tea "github.com/charmbracelet/bubbletea"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operationsv1alpha1 "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
@@ -43,5 +44,54 @@ func TestTaskStatusMarks(t *testing.T) {
 	}
 	if stepStatusMark(string(operationsv1alpha1.TaskTimedOut)) != StepFailedMark {
 		t.Fatal("TimedOut mark")
+	}
+}
+
+func TestLogModelRestoresTaskLogAfterNavigation(t *testing.T) {
+	m := NewLogModel(nil, &operationsv1alpha1.Operation{}, 100, 20)
+	m.steps = []StepEntry{
+		{ID: "first", Tasks: []TaskEntry{{Name: "first-task"}}},
+		{ID: "second", Tasks: []TaskEntry{{Name: "second-task"}}},
+	}
+	if !m.showCurrentLog() {
+		t.Fatal("expected first task to be selected")
+	}
+
+	m, _ = m.Update(logFetchedMsg{content: "first log\n", offset: 10, key: "first-task"})
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = m.Update(logFetchedMsg{content: "second log\n", offset: 11, key: "second-task"})
+	m.viewport.SetContent(strings.Repeat("second log\n", 50))
+	m.viewport.GotoBottom()
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+
+	if m.rawContent != "first log\n" {
+		t.Fatalf("restored log = %q, want first task log", m.rawContent)
+	}
+	if m.lastOffset["first-task"] != 10 {
+		t.Fatalf("first task offset = %d, want 10", m.lastOffset["first-task"])
+	}
+	if m.viewport.YOffset != 0 {
+		t.Fatalf("viewport offset = %d, want top of restored log", m.viewport.YOffset)
+	}
+}
+
+func TestLogModelIgnoresStaleLogForAnotherTask(t *testing.T) {
+	m := NewLogModel(nil, &operationsv1alpha1.Operation{}, 100, 20)
+	m.steps = []StepEntry{
+		{ID: "first", Tasks: []TaskEntry{{Name: "first-task"}}},
+		{ID: "second", Tasks: []TaskEntry{{Name: "second-task"}}},
+	}
+	if !m.showCurrentLog() {
+		t.Fatal("expected first task to be selected")
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m, _ = m.Update(logFetchedMsg{content: "first log\n", offset: 10, key: "first-task"})
+
+	if m.rawContent != "" {
+		t.Fatalf("displayed log = %q, want empty second task log", m.rawContent)
+	}
+	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	if m.rawContent != "first log\n" {
+		t.Fatalf("restored log = %q, want stale first task response", m.rawContent)
 	}
 }

--- a/pkg/cli/sudo/sudo.go
+++ b/pkg/cli/sudo/sudo.go
@@ -33,11 +33,17 @@ import (
 )
 
 func PreCheck(name string, sshConfig *sshutils.SSH, streams options.IOStreams, allNodes []string) bool {
+	return PreCheckError(name, sshConfig, streams, allNodes) == nil
+}
+
+// PreCheckError verifies sudo access and preserves the reason when the user declines to continue.
+func PreCheckError(name string, sshConfig *sshutils.SSH, streams options.IOStreams, allNodes []string) error {
 	logger.Infof("============>%s PRECHECK ...", name)
 	if sshConfig.User == "root" {
 		logger.Infof("============>%s PRECHECK OK!", name)
-		return true
+		return nil
 	}
+	var lastErr error
 	for {
 		// need enter passwd to run sudo
 		if sshConfig.Password == "" {
@@ -81,6 +87,7 @@ func PreCheck(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 			// if user can't access sudo,break
 			if strings.Contains(err.Error(), "is not in the sudoers file") {
 				_, _ = streams.Out.Write([]byte(err.Error() + "\n"))
+				lastErr = err
 				break
 			}
 			// if error is username or password incorrect,we reset it.
@@ -91,20 +98,41 @@ func PreCheck(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 			continue
 		}
 		logger.Infof("============>%s PRECHECK OK!", name)
-		return true
+		return nil
 	}
 
 	_, _ = streams.Out.Write([]byte("Ignore this error, still exec cmd? Please input (yes/no)"))
-	return utils.AskForConfirmation()
+	if utils.AskForConfirmation() {
+		return nil
+	}
+	return fmt.Errorf("%s precheck failed: %w", name, lastErr)
 }
 
 // MultiNIC check node has multi NIC but node specify ip-detect flag.
 func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, allNodes []string, ipDetect string) bool {
+	return MultiNICError(name, sshConfig, streams, allNodes, ipDetect) == nil
+}
+
+// MultiNICError verifies IP detection safety and preserves the reason when the user declines to continue.
+func MultiNICError(name string, sshConfig *sshutils.SSH, streams options.IOStreams, allNodes []string, ipDetect string) error {
 	logger.Infof("============>%s PRECHECK ...", name)
 	if ipDetect != "" && ipDetect != autodetection.MethodFirst {
 		logger.Infof("============>%s PRECHECK OK!", name)
-		return true
+		return nil
 	}
+	hasMultiNIC, errs := checkMultiNIC(sshConfig, allNodes)
+	if firstErr := firstError(errs); firstErr != nil {
+		return handleMultiNICError(name, streams, firstErr)
+	}
+	multiNICNodes := collectMultiNICNodes(allNodes, hasMultiNIC)
+	if len(multiNICNodes) == 0 {
+		logger.Infof("============>%s PRECHECK OK!", name)
+		return nil
+	}
+	return handleMultiNICWarning(name, streams, multiNICNodes)
+}
+
+func checkMultiNIC(sshConfig *sshutils.SSH, allNodes []string) ([]bool, []error) {
 	hasMultiNIC := make([]bool, len(allNodes))
 	errs := make([]error, len(allNodes))
 	wg := sync.WaitGroup{}
@@ -136,50 +164,62 @@ func MultiNIC(name string, sshConfig *sshutils.SSH, streams options.IOStreams, a
 		}(i, node)
 	}
 	wg.Wait()
+	return hasMultiNIC, errs
+}
 
-	var firstErr error
+func firstError(errs []error) error {
 	for _, err := range errs {
 		if err != nil {
-			firstErr = err
-			break
+			return err
 		}
 	}
+	return nil
+}
 
-	if firstErr != nil {
-		logger.Error(firstErr)
-		if options.AssumeYes {
-			logger.Infof("skip this error,continue exec cmd")
-			return true
-		}
-		logger.Errorf("===========>%s PRECHECK FAILED!", name)
-		_, _ = streams.Out.Write([]byte("Ignore this error, still exec cmd? Please input (yes/no)"))
-		return utils.AskForConfirmation()
-	}
-
-	var multiNICNodes []string
+func collectMultiNICNodes(allNodes []string, hasMultiNIC []bool) []string {
+	var nodes []string
 	for i, host := range allNodes {
-		if hasMultiNIC[i] {
-			multiNICNodes = append(multiNICNodes, host)
+		if i < len(hasMultiNIC) && hasMultiNIC[i] {
+			nodes = append(nodes, host)
 		}
 	}
-	if len(multiNICNodes) == 0 {
-		logger.Infof("============>%s PRECHECK OK!", name)
-		return true
-	}
+	return nodes
+}
 
+func handleMultiNICError(name string, streams options.IOStreams, firstErr error) error {
+	logger.Error(firstErr)
+	if options.AssumeYes {
+		logger.Infof("skip this error,continue exec cmd")
+		return nil
+	}
+	logger.Errorf("===========>%s PRECHECK FAILED!", name)
+	fmt.Fprint(streams.Out, "Ignore this error, still exec cmd? Please input (yes/no)")
+	if utils.AskForConfirmation() {
+		return nil
+	}
+	return fmt.Errorf("%s precheck failed: %w", name, firstErr)
+}
+
+func handleMultiNICWarning(name string, streams options.IOStreams, multiNICNodes []string) error {
 	logger.Warnf("node has multiple network interfaces, --ip-detect not specified (default: first-found may choose wrong interface):")
 	for _, host := range multiNICNodes {
 		logger.Warnf("  - [agent@%s]", host)
 	}
 	if options.AssumeYes {
 		logger.Infof("skip this error,continue exec cmd")
-		return true
+		return nil
 	}
 	logger.Errorf("===========>%s PRECHECK FAILED!", name)
 	fmt.Fprintln(streams.Out, "node has multi nic,and --ip-detect flag not specified,default ip "+
 		"detect method is 'first-found',which maybe chose a wrong one,you can add --ip-detect flag to specify it.")
 	fmt.Fprint(streams.Out, "Ignore this error, still exec cmd? Please input (yes/no)")
-	return utils.AskForConfirmation()
+	if utils.AskForConfirmation() {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s precheck failed: nodes have multiple network interfaces and "+
+			"--ip-detect is first-found: %s", name, strings.Join(multiNICNodes, ", "),
+	)
 }
 
 func filterLogicIface(ifcaes []string) []string {


### PR DESCRIPTION
## Summary
- return the failing deploy precheck with its check name, node role/IP, and root cause
- report exact systemd unit state for existing kc services
- suppress Usage for runtime precheck failures and avoid duplicate Cobra error output
- retain detailed failure causes for time, sudo, and multi-NIC prechecks

## Verification
- `go test ./pkg/cli/...`
- Built Linux amd64 `kcctl` and verified on `sh-dev-2` against the existing running `kc-etcd.service`

The verified failure now reports `load=loaded, active=active, sub=running` without Usage or a duplicate final error.