### PR TITLE
fix(operationv2): serve safety-boundary reads from quorum storage

### DIFF
--- a/pkg/models/operationv2/store.go
+++ b/pkg/models/operationv2/store.go
@@ -97,14 +97,25 @@ type StoreOptions struct {
 	Operations rest.StandardStorage
 	Tasks      rest.StandardStorage
 	Locks      rest.StandardStorage
-	Now        func() time.Time
+	// OperationsStrong/TasksStrong/LocksStrong serve safety-boundary reads
+	// (target ordering, attempt creation, lock acquisition/release checks) from
+	// storages that bypass the watch cache: the cache may lag behind etcd and
+	// must never back an irreversible conclusion. When nil, the cacher-backed
+	// storages above are used instead (test fakes).
+	OperationsStrong rest.StandardStorage
+	TasksStrong      rest.StandardStorage
+	LocksStrong      rest.StandardStorage
+	Now              func() time.Time
 }
 
 type store struct {
-	operations rest.StandardStorage
-	tasks      rest.StandardStorage
-	locks      rest.StandardStorage
-	now        func() time.Time
+	operations       rest.StandardStorage
+	tasks            rest.StandardStorage
+	locks            rest.StandardStorage
+	operationsStrong rest.StandardStorage
+	tasksStrong      rest.StandardStorage
+	locksStrong      rest.StandardStorage
+	now              func() time.Time
 }
 
 var _ Store = (*store)(nil)
@@ -116,7 +127,25 @@ func NewStore(opts StoreOptions) (Store, error) {
 	if opts.Now == nil {
 		opts.Now = time.Now
 	}
-	return &store{operations: opts.Operations, tasks: opts.Tasks, locks: opts.Locks, now: opts.Now}, nil
+	s := &store{
+		operations: opts.Operations,
+		tasks:      opts.Tasks,
+		locks:      opts.Locks,
+		now:        opts.Now,
+	}
+	s.operationsStrong = opts.OperationsStrong
+	if s.operationsStrong == nil {
+		s.operationsStrong = opts.Operations
+	}
+	s.tasksStrong = opts.TasksStrong
+	if s.tasksStrong == nil {
+		s.tasksStrong = opts.Tasks
+	}
+	s.locksStrong = opts.LocksStrong
+	if s.locksStrong == nil {
+		s.locksStrong = opts.Locks
+	}
+	return s, nil
 }
 
 func withNamespace(ctx context.Context) context.Context {
@@ -150,12 +179,26 @@ func (s *store) CreateOperation(ctx context.Context, op *operations.Operation) (
 	return result, nil
 }
 
+// ListOperations is a safety-boundary read (target ordering, latest-operation
+// guards) and is served by the quorum storage, bypassing the watch cache.
 func (s *store) ListOperations(ctx context.Context, targetUID types.UID, resourceVersion string) (*operations.OperationList, error) {
 	options := metav1.ListOptions{ResourceVersion: resourceVersion}
 	if targetUID != "" {
 		options.FieldSelector = fields.OneTermEqualSelector("spec.targetRef.uid", string(targetUID)).String()
 	}
-	return s.ListOperationsWithOptions(ctx, &options)
+	internal, err := internalListOptions(&options)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := s.operationsStrong.List(withNamespace(ctx), internal)
+	if err != nil {
+		return nil, err
+	}
+	list, ok := obj.(*operations.OperationList)
+	if !ok {
+		return nil, fmt.Errorf("operation storage returned %T", obj)
+	}
+	return list, nil
 }
 
 func (s *store) ListOperationsWithOptions(ctx context.Context, options *metav1.ListOptions) (*operations.OperationList, error) {
@@ -317,23 +360,53 @@ func (s *store) CreateTask(ctx context.Context, task *operations.OperationTask) 
 	return result, nil
 }
 
+// ListTasksByOperationUID is a safety-boundary read (terminal transition,
+// attempt creation, lock-release re-check) and is served by the quorum
+// storage, bypassing the watch cache.
 func (s *store) ListTasksByOperationUID(
 	ctx context.Context,
 	operationUID types.UID,
 	resourceVersion string,
 ) (*operations.OperationTaskList, error) {
-	return s.ListTasksWithOptions(
-		ctx,
-		"",
-		&metav1.ListOptions{
-			FieldSelector:   fields.OneTermEqualSelector("spec.operationRef.uid", string(operationUID)).String(),
-			ResourceVersion: resourceVersion,
-		},
-	)
+	options := metav1.ListOptions{
+		FieldSelector:   fields.OneTermEqualSelector("spec.operationRef.uid", string(operationUID)).String(),
+		ResourceVersion: resourceVersion,
+	}
+	internal, err := internalListOptions(&options)
+	if err != nil {
+		return nil, err
+	}
+	obj, err := s.tasksStrong.List(withNamespace(ctx), internal)
+	if err != nil {
+		return nil, err
+	}
+	list, ok := obj.(*operations.OperationTaskList)
+	if !ok {
+		return nil, fmt.Errorf("task storage returned %T", obj)
+	}
+	return list, nil
 }
 
+// ListTasksByNode backs the agent's task discovery and is served by the
+// quorum storage, bypassing the watch cache.
 func (s *store) ListTasksByNode(ctx context.Context, nodeName, resourceVersion string) (*operations.OperationTaskList, error) {
-	return s.ListTasksWithOptions(ctx, nodeName, &metav1.ListOptions{ResourceVersion: resourceVersion})
+	options := metav1.ListOptions{ResourceVersion: resourceVersion}
+	internal, err := internalListOptions(&options)
+	if err != nil {
+		return nil, err
+	}
+	if nodeName != "" {
+		internal.FieldSelector = fields.OneTermEqualSelector("spec.nodeRef.name", nodeName)
+	}
+	obj, err := s.tasksStrong.List(withNamespace(ctx), internal)
+	if err != nil {
+		return nil, err
+	}
+	list, ok := obj.(*operations.OperationTaskList)
+	if !ok {
+		return nil, fmt.Errorf("task storage returned %T", obj)
+	}
+	return list, nil
 }
 
 func (s *store) ListTasksWithOptions(
@@ -590,7 +663,11 @@ func (s *store) AcquireLock(ctx context.Context, lock *operations.ExecutionLock)
 }
 
 func (s *store) GetLock(ctx context.Context, name, resourceVersion string) (*operations.ExecutionLock, error) {
-	obj, err := s.locks.Get(withNamespace(ctx), name, &metav1.GetOptions{ResourceVersion: resourceVersion})
+	// Lock ownership is an irreversible safety boundary: AcquireLock uses this
+	// read after an AlreadyExists result and ReleaseLock uses it before Delete.
+	// A cacher can return a deleted predecessor after a lock is recreated, so
+	// this must read the quorum storage.
+	obj, err := s.locksStrong.Get(withNamespace(ctx), name, &metav1.GetOptions{ResourceVersion: resourceVersion})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/models/operationv2/store_test.go
+++ b/pkg/models/operationv2/store_test.go
@@ -1,0 +1,151 @@
+/*
+ *
+ *  * Copyright 2026 KubeClipper Authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package operationv2
+
+import (
+	"context"
+	"testing"
+
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
+)
+
+// recordingStorage records which of the store's call paths reach it. Methods
+// that are not overridden panic via the embedded nil interface, which also
+// documents that the store must only call the interfaces it declares.
+type recordingStorage struct {
+	rest.StandardStorage
+	listCalls int
+	getCalls  int
+	listObj   runtime.Object
+	getObj    runtime.Object
+}
+
+func (r *recordingStorage) List(_ context.Context, _ *metainternalversion.ListOptions) (runtime.Object, error) {
+	r.listCalls++
+	if r.listObj == nil {
+		panic("recordingStorage requires listObj")
+	}
+	return r.listObj, nil
+}
+
+func (r *recordingStorage) Get(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+	r.getCalls++
+	if r.getObj == nil {
+		panic("recordingStorage requires getObj")
+	}
+	return r.getObj, nil
+}
+
+// Safety-boundary reads (target ordering, attempt creation, lock ownership
+// checks) must be served by the quorum storage; the cacher-backed storages
+// are reserved for routine reads and public routes.
+func TestSafetyBoundaryReadsUseStrongStorage(t *testing.T) {
+	ops := &recordingStorage{listObj: &operations.OperationList{}, getObj: &operations.Operation{}}
+	tasks := &recordingStorage{listObj: &operations.OperationTaskList{}}
+	locks := &recordingStorage{getObj: &operations.ExecutionLock{}}
+	opsStrong := &recordingStorage{listObj: &operations.OperationList{}}
+	tasksStrong := &recordingStorage{listObj: &operations.OperationTaskList{}}
+	locksStrong := &recordingStorage{getObj: &operations.ExecutionLock{}}
+
+	s, err := NewStore(StoreOptions{
+		Operations:       ops,
+		Tasks:            tasks,
+		Locks:            locks,
+		OperationsStrong: opsStrong,
+		TasksStrong:      tasksStrong,
+		LocksStrong:      locksStrong,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for _, call := range []func() error{
+		func() error { _, err := s.ListOperations(ctx, "target-uid", ""); return err },
+		func() error { _, err := s.ListTasksByOperationUID(ctx, "op-uid", ""); return err },
+		func() error { _, err := s.ListTasksByNode(ctx, "node-1", ""); return err },
+		func() error { _, err := s.GetLock(ctx, "lock-1", ""); return err },
+	} {
+		if err := call(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if ops.listCalls != 0 || tasks.listCalls != 0 || locks.getCalls != 0 {
+		t.Fatalf("safety-boundary reads reached cacher-backed storages: ops=%d tasks=%d locks=%d", ops.listCalls, tasks.listCalls, locks.getCalls)
+	}
+	if opsStrong.listCalls != 1 || tasksStrong.listCalls != 2 || locksStrong.getCalls != 1 {
+		t.Fatalf("strong storage calls = ops:%d tasks:%d locks:%d, want 1, 2 and 1", opsStrong.listCalls, tasksStrong.listCalls, locksStrong.getCalls)
+	}
+}
+
+// Routine reads keep the cacher-backed storages so agent watch traffic stays
+// off etcd.
+func TestRoutineReadsUseCacherBackedStorage(t *testing.T) {
+	ops := &recordingStorage{listObj: &operations.OperationList{}, getObj: &operations.Operation{}}
+	tasks := &recordingStorage{listObj: &operations.OperationTaskList{}}
+	s, err := NewStore(StoreOptions{
+		Operations: ops,
+		Tasks:      tasks,
+		Locks:      &recordingStorage{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	for _, call := range []func() error{
+		func() error { _, err := s.GetOperation(ctx, "op-1", ""); return err },
+		func() error { _, err := s.ListOperationsWithOptions(ctx, &metav1.ListOptions{}); return err },
+		func() error { _, err := s.ListTasksWithOptions(ctx, "node-1", &metav1.ListOptions{}); return err },
+	} {
+		if err := call(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if ops.getCalls != 1 || ops.listCalls != 1 || tasks.listCalls != 1 {
+		t.Fatalf("cacher-backed storage calls = get:%d ops-list:%d tasks-list:%d", ops.getCalls, ops.listCalls, tasks.listCalls)
+	}
+}
+
+// StoreOptions without dedicated strong storages must keep working (test
+// fakes and legacy wiring) by falling back to the injected storages.
+func TestStrongStoragesFallBackToInjected(t *testing.T) {
+	ops := &recordingStorage{listObj: &operations.OperationList{}}
+	tasks := &recordingStorage{listObj: &operations.OperationTaskList{}}
+	locks := &recordingStorage{getObj: &operations.ExecutionLock{}}
+	s, err := NewStore(StoreOptions{Operations: ops, Tasks: tasks, Locks: locks})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ListOperations(context.Background(), "target-uid", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ListTasksByOperationUID(context.Background(), "op-uid", ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.GetLock(context.Background(), "lock-1", ""); err != nil {
+		t.Fatal(err)
+	}
+	if ops.listCalls != 1 || tasks.listCalls != 1 || locks.getCalls != 1 {
+		t.Fatalf("fallback storage calls = ops:%d tasks:%d locks:%d, want 1, 1 and 1", ops.listCalls, tasks.listCalls, locks.getCalls)
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -105,6 +105,7 @@ type APIServer struct {
 	cache                 cache.Interface
 	RESTOptionsGetter     *etcdRESTOptions.StorageFactoryRestOptionsFactory
 	storageFactory        registry.SharedStorageFactory
+	strongStorageFactory  registry.SharedStorageFactory
 	rbacAuthorizer        authorizer.Authorizer
 	databaseAuditBackend  auditing.Backend
 	internalInformerUser  string
@@ -120,6 +121,13 @@ func (s *APIServer) PrepareRun(stopCh <-chan struct{}) error {
 	s.internalInformerUser = "system:kc-server"
 	s.InternalInformerToken = uuid.New().String()
 	s.storageFactory = registry.NewSharedStorageFactory(s.RESTOptionsGetter)
+	// Operation v2 safety-boundary checks (lock release, attempt creation,
+	// target ordering) must read quorum etcd state: the watch cache can lag
+	// behind etcd and must never back an irreversible conclusion. Build a
+	// second factory without the cacher for those reads.
+	strongOptionsGetter := *s.RESTOptionsGetter
+	strongOptionsGetter.Options.EnableWatchCache = false
+	s.strongStorageFactory = registry.NewSharedStorageFactory(&strongOptionsGetter)
 
 	var err error
 	switch s.Config.CacheOptions.CacheProvider {
@@ -287,9 +295,12 @@ func (s *APIServer) installAPIs(stopCh <-chan struct{}) error {
 
 	var err error
 	s.operationV2Store, err = operationv2.NewStore(operationv2.StoreOptions{
-		Operations: s.storageFactory.OperationV2(),
-		Tasks:      s.storageFactory.OperationTasksV2(),
-		Locks:      s.storageFactory.ExecutionLocksV2(),
+		Operations:       s.storageFactory.OperationV2(),
+		Tasks:            s.storageFactory.OperationTasksV2(),
+		Locks:            s.storageFactory.ExecutionLocksV2(),
+		OperationsStrong: s.strongStorageFactory.OperationV2(),
+		TasksStrong:      s.strongStorageFactory.OperationTasksV2(),
+		LocksStrong:      s.strongStorageFactory.ExecutionLocksV2(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

The Operation v2 controller makes irreversible decisions from Operation and Task lists, and verifies ExecutionLock ownership after lock contention and before lock release. Those reads previously used cacher-decorated storage. A lagging cache could therefore support an irreversible conclusion, for example releasing the cluster lock while an agent had just moved a task to Running, or treating a deleted lock predecessor as the current holder.

This change builds a second set of Operation, OperationTask, and ExecutionLock storages without the watch cacher, using the same etcd configuration and keys. It routes these safety-boundary reads to quorum storage:

- ListOperations: target ordering and latest-operation guards
- ListTasksByOperationUID: terminal transition, attempt creation, and lock-release re-check
- GetLock: lock ownership verification after contention and before release

Routine reads and public List/Watch routes remain cacher-backed, so Agent watch traffic stays off etcd. StoreOptions continues to fall back to the injected storages for test fakes.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

The routing is covered by pkg/models/operationv2/store_test.go. The server wiring clones StorageFactoryRestOptionsFactory with EnableWatchCache=false for only the strong Operation v2 storages.

### Does this PR introduced a user-facing change?

release-note: None

### Additional documentation, usage docs, etc.:

docs: None