### PR TITLE
fix(agent): stop severing the task watch with a client-wide timeout

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -91,25 +91,30 @@ func (s *Server) PrepareRun(stopCh <-chan struct{}) error {
 	if s.Config.APIServer == nil {
 		return fmt.Errorf("apiServer configuration is required")
 	}
+	// No client-wide Timeout: http.Client.Timeout covers the whole response
+	// body and would sever the informer's long-lived task watch on every
+	// interval. One-shot calls carry per-call deadlines instead
+	// (nodeStatusUpdateTimeout here, serverCallTimeout in the task worker).
 	restConfig := &rest.Config{
 		Host: s.Config.APIServer.Endpoint,
 		TLSClientConfig: rest.TLSClientConfig{
 			CAFile: s.Config.APIServer.CAFile, CertFile: s.Config.APIServer.CertFile,
 			KeyFile: s.Config.APIServer.KeyFile, ServerName: s.Config.APIServer.ServerName,
 		},
-		Timeout: 30 * time.Second,
-		QPS:     20, Burst: 40,
+		QPS: 20, Burst: 40,
 	}
 	client, err := clientset.NewForConfig(restConfig)
 	if err != nil {
 		return fmt.Errorf("create kc-server client: %w", err)
 	}
 	s.client = client
-	node, err := client.CoreV1().Nodes().Get(context.Background(), s.Config.AgentID, metav1.GetOptions{})
+	nodeCtx, nodeCancel := context.WithTimeout(context.Background(), nodeStatusUpdateTimeout)
+	defer nodeCancel()
+	node, err := client.CoreV1().Nodes().Get(nodeCtx, s.Config.AgentID, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) && s.Config.RegisterNode {
-		node, err = client.CoreV1().Nodes().Create(context.Background(), s.initialNode(), &metav1.CreateOptions{})
+		node, err = client.CoreV1().Nodes().Create(nodeCtx, s.initialNode(), &metav1.CreateOptions{})
 		if apierrors.IsAlreadyExists(err) {
-			node, err = client.CoreV1().Nodes().Get(context.Background(), s.Config.AgentID, metav1.GetOptions{})
+			node, err = client.CoreV1().Nodes().Get(nodeCtx, s.Config.AgentID, metav1.GetOptions{})
 		}
 	}
 	if err != nil {

--- a/pkg/agent/operationv2/worker.go
+++ b/pkg/agent/operationv2/worker.go
@@ -43,6 +43,10 @@ import (
 const (
 	syncKey        = "tasks"
 	workerLockMode = 0600
+	// serverCallTimeout bounds each one-shot server round trip. The shared
+	// rest config carries no client-wide timeout because http.Client.Timeout
+	// would sever the informer's long-lived watch on every interval.
+	serverCallTimeout = 30 * time.Second
 )
 
 type TaskClient interface {
@@ -111,11 +115,11 @@ func NewWorker(opts *WorkerOptions) (*Worker, error) {
 	w.informer = cache.NewSharedIndexInformer(&cache.ListWatch{
 		ListFunc: func(listOptions metav1.ListOptions) (runtime.Object, error) {
 			listOptions.FieldSelector = selector
-			return w.client.List(context.Background(), &listOptions)
+			return w.listTasks(&listOptions)
 		},
 		WatchFunc: func(listOptions metav1.ListOptions) (watch.Interface, error) {
 			listOptions.FieldSelector = selector
-			return w.client.Watch(context.Background(), &listOptions)
+			return w.watchTasks(&listOptions)
 		},
 	}, &operations.OperationTask{}, 0, cache.Indexers{})
 	if _, err := w.informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -208,6 +212,23 @@ func (w *Worker) sync(ctx context.Context) error {
 	return w.execute(ctx, live)
 }
 
+// listTasks serves the reflector's initial List. It is a one-shot round trip
+// and carries its own deadline; a client-wide timeout must not be used because
+// it would also sever the long-lived watch below.
+func (w *Worker) listTasks(listOptions *metav1.ListOptions) (runtime.Object, error) {
+	ctx, cancel := context.WithTimeout(w.runCtx, serverCallTimeout)
+	defer cancel()
+	return w.client.List(ctx, listOptions)
+}
+
+// watchTasks serves the reflector's long-lived Watch. It inherits only the
+// worker's run context, so the stream lives until the worker stops and the
+// reflector owns reconnects; bounding it here would kill the watch on every
+// timeout and turn event delivery into polling.
+func (w *Worker) watchTasks(listOptions *metav1.ListOptions) (watch.Interface, error) {
+	return w.client.Watch(w.runCtx, listOptions)
+}
+
 func (w *Worker) eligibleTasks() []*operations.OperationTask {
 	objects := w.informer.GetStore().List()
 	tasks := make([]*operations.OperationTask, 0, len(objects))
@@ -222,7 +243,9 @@ func (w *Worker) eligibleTasks() []*operations.OperationTask {
 }
 
 func (w *Worker) getLiveTask(ctx context.Context, selected *operations.OperationTask) (*operations.OperationTask, error) {
-	live, err := w.client.Get(ctx, selected.Name, metav1.GetOptions{})
+	getCtx, cancel := context.WithTimeout(ctx, serverCallTimeout)
+	defer cancel()
+	live, err := w.client.Get(getCtx, selected.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -243,7 +266,9 @@ func (w *Worker) startPendingTask(ctx context.Context, live *operations.Operatio
 	if live.Status.Phase == operations.TaskPending {
 		runningTask := live.DeepCopy()
 		runningTask.Status = operations.OperationTaskStatus{Phase: operations.TaskRunning}
-		return w.client.UpdateStatus(ctx, runningTask)
+		putCtx, cancel := context.WithTimeout(ctx, serverCallTimeout)
+		defer cancel()
+		return w.client.UpdateStatus(putCtx, runningTask)
 	}
 	return live, nil
 }
@@ -334,9 +359,13 @@ func (w *Worker) finish(
 	updatedTask := task.DeepCopy()
 	updatedTask.Status.Phase = phase
 	updatedTask.Status.Result = &result
-	_, err := w.client.UpdateStatus(ctx, updatedTask)
+	putCtx, cancel := context.WithTimeout(ctx, serverCallTimeout)
+	defer cancel()
+	_, err := w.client.UpdateStatus(putCtx, updatedTask)
 	if err != nil {
-		latest, getErr := w.client.Get(context.Background(), task.Name, metav1.GetOptions{})
+		getCtx, getCancel := context.WithTimeout(ctx, serverCallTimeout)
+		latest, getErr := w.client.Get(getCtx, task.Name, metav1.GetOptions{})
+		getCancel()
 		if getErr == nil && latest.UID == task.UID && latest.Status.Phase.IsTerminal() {
 			w.queue.Add(syncKey)
 			return nil

--- a/pkg/agent/operationv2/worker_test.go
+++ b/pkg/agent/operationv2/worker_test.go
@@ -225,3 +225,78 @@ func TestSelectTaskResumesRunningBeforePending(t *testing.T) {
 		t.Fatalf("selected %s, want Running task %s", selected.UID, running.UID)
 	}
 }
+
+// deadlineRecordingClient captures the contexts the worker uses for its
+// one-shot List and long-lived Watch round trips.
+type deadlineRecordingClient struct {
+	listCtx  context.Context
+	watchCtx context.Context
+}
+
+func (*deadlineRecordingClient) Get(_ context.Context, _ string, _ metav1.GetOptions) (*operations.OperationTask, error) {
+	return &operations.OperationTask{}, nil
+}
+
+func (c *deadlineRecordingClient) List(ctx context.Context, _ *metav1.ListOptions) (*operations.OperationTaskList, error) {
+	c.listCtx = ctx
+	return &operations.OperationTaskList{}, nil
+}
+
+func (c *deadlineRecordingClient) Watch(ctx context.Context, _ *metav1.ListOptions) (watch.Interface, error) {
+	c.watchCtx = ctx
+	return watch.NewEmptyWatch(), nil
+}
+
+func (*deadlineRecordingClient) UpdateStatus(_ context.Context, task *operations.OperationTask) (*operations.OperationTask, error) {
+	return task, nil
+}
+
+// The rest config no longer sets a client-wide timeout because it would sever
+// the informer's long-lived watch on every interval. Instead the one-shot List
+// carries its own deadline and the Watch inherits only the worker run context.
+func TestTaskListIsBoundedAndWatchIsNot(t *testing.T) {
+	registry := NewRegistry()
+	if err := registry.Register(NoopExecutorName, NoopExecutor{}); err != nil {
+		t.Fatal(err)
+	}
+	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), SingleThreshold: oplog.DefaultThreshold})
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := &deadlineRecordingClient{}
+	w, err := NewWorker(&WorkerOptions{
+		AgentID:  "agent-1",
+		NodeUID:  types.UID("node-uid"),
+		Client:   client,
+		Registry: registry,
+		OpLog:    logStore,
+		LockFile: t.TempDir() + "/worker.lock",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := w.listTasks(&metav1.ListOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	deadline, ok := client.listCtx.Deadline()
+	if !ok {
+		t.Fatal("task List context carries no deadline; a hung server would block the reflector forever")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > 2*serverCallTimeout {
+		t.Fatalf("task List deadline remaining = %v, want within %v", remaining, 2*serverCallTimeout)
+	}
+
+	if _, err := w.watchTasks(&metav1.ListOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if d, ok := client.watchCtx.Deadline(); ok {
+		t.Fatalf("task Watch context must not carry a deadline (would sever the watch on every interval), got %v", d)
+	}
+	w.cancel()
+	select {
+	case <-client.watchCtx.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("task Watch context does not follow the worker run context")
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

The agent's rest config set `http.Client Timeout` to 30s. Go's client timeout covers
the whole response body, so the informer's long-lived OperationTask watch was
force-closed exactly 30 seconds after every establishment — by design, not by
failure. The reflector reconnected at least twice per minute per agent:

- standing reconnect load on kc-server (new watch stream + server-side watcher
  bookkeeping) that scales linearly with the agent fleet;
- reconnect error noise in agent logs that is indistinguishable from real network
  failures;
- extra delivery latency for task events that land inside a reconnect window.

Events are not lost (the reflector re-watches from LastSyncResourceVersion and the
server replays), which is why this never showed up as a functional failure — it is a
self-inflicted load and observability problem.

This PR drops the client-wide timeout and bounds the individual round trips
instead:

- the reflector's initial List (`listTasks`) carries a 30s per-call deadline derived
  from the worker run context;
- the Watch (`watchTasks`) inherits only the worker run context — the reflector owns
  its lifetime and reconnects;
- the live-task Get, the Pending→Running and terminal status PUTs, and the node
  bootstrap GET/Create are individually bounded;
- the node status and lease paths already used `nodeStatusUpdateTimeout` and are
  unchanged.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
Regression test TestTaskListIsBoundedAndWatchIsNot (pkg/agent/operationv2/worker_test.go)
asserts that the List context carries a deadline while the Watch context carries none
and follows the worker run context.
```

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
None
```
