### PR TITLE
fix(cli): report per-host transfer failures in SendPackageV2WithTempDir

### DIFF
--- a/pkg/cli/utils/download.go
+++ b/pkg/cli/utils/download.go
@@ -118,34 +118,40 @@ func SendPackageV2WithTempDir(
 					ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, rm)
 					if err != nil {
 						logger.Errorf("[%s]remove old file(%s) err %s", host, fullPath, err.Error())
+						errCh <- errors.WithMessagef(err, "[%s] remove old file %s", host, fullPath)
 						return
 					}
 					if err = ret.Error(); err != nil {
 						logger.Errorf("[%s]remove old file(%s) err %s", host, fullPath, err.Error())
+						errCh <- errors.WithMessagef(err, "[%s] remove old file %s", host, fullPath)
 						return
 					}
 					ok, err := sshConfig.CopyForMD5V2WithTempDir(host, location, fullPath, md5, tempDir)
 					if err != nil {
 						logger.Errorf("[%s]copy file(%s) md5 validate failed err %s", host, location, err.Error())
+						errCh <- errors.WithMessagef(err, "[%s] copy %s", host, fullPath)
 						return
 					}
-					if ok {
-						logger.V(2).Infof("[%s]copy file(%s) md5 validate success", host, location)
-					} else {
+					if !ok {
 						logger.Errorf("[%s]copy file(%s) md5 validate failed", host, location)
+						errCh <- fmt.Errorf("[%s] copy %s md5 validate failed", host, fullPath)
+						return
 					}
+					logger.V(2).Infof("[%s]copy file(%s) md5 validate success", host, location)
 				}
 			} else {
 				ok, err := sshConfig.CopyForMD5V2WithTempDir(host, location, fullPath, md5, tempDir)
 				if err != nil {
 					logger.Errorf("[%s]copy file(%s) md5 validate failed err %s", host, fullPath, err.Error())
+					errCh <- errors.WithMessagef(err, "[%s] copy %s", host, fullPath)
 					return
 				}
-				if ok {
-					logger.V(2).Infof("[%s]copy file(%s) md5 validate success", host, location)
-				} else {
+				if !ok {
 					logger.Errorf("[%s]copy file(%s) md5 validate failed", host, location)
+					errCh <- fmt.Errorf("[%s] copy %s md5 validate failed", host, fullPath)
+					return
 				}
+				logger.V(2).Infof("[%s]copy file(%s) md5 validate success", host, fullPath)
 			}
 
 			if after != nil {
@@ -176,6 +182,15 @@ func SendPackageV2WithTempDir(
 	case err = <-errCh:
 		return err
 	case <-stopCh:
+		// A failure sent just before the last transfer completed may race with
+		// the stop signal; drain it instead of reporting success.
+		select {
+		case err = <-errCh:
+			if err != nil {
+				return err
+			}
+		default:
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

`SendPackageV2WithTempDir` (used by `kcctl deploy` / `kcctl join` to stage
bootstrap binaries, certs and the deploy config onto nodes) starts one
goroutine per host and collects failures in an `errCh`. Six failure paths in
the per-host goroutine only wrote a log line and returned without sending to
the channel:

- both failure paths of the `rm -rf` that removes the remote old file;
- both `CopyForMD5V2WithTempDir` error returns (file-exists and file-missing
  branches);
- worst: a copy that completed but failed remote MD5 validation was only
  logged — the goroutine kept running and even executed the `after` hook
  (e.g. restarting kc-server) on a node that had a missing or corrupted file.

`wg.Wait()` then found an empty `errCh` and the function returned `nil`, so
the deploy continued with half-delivered hosts — the failure surfaced later
as misleading downstream errors ("kubeclipper-server: no such file") or as a
node that silently never joins.

This PR reports every failure path to `errCh`, treats an MD5 mismatch after
copy as a hard error that stops before the after hook, and drains `errCh` in
the stop branch so a failure racing with the completion signal cannot be
reported as success.

The older `SendPackageWithTempDir` (progress-bar variant) already reports all
of its paths and is untouched.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
All other steps of the same goroutine (before hook, file check, MD5 precheck,
after hook) already reported errors correctly; only the transfer-phase paths
above were swallowed.
```

### Does this PR introduced a user-facing change?

```release-note
`kcctl deploy` and `kcctl join` now fail instead of silently continuing when a
package transfer to any node fails or is delivered corrupted.
```

### Additional documentation, usage docs, etc.:

```docs
None
```
