### PR TITLE
fix(server): make watch ERROR events decodable for clients (410 relist)

### DIFF
--- a/pkg/server/restplus/watch.go
+++ b/pkg/server/restplus/watch.go
@@ -58,7 +58,13 @@ func ServeWatch(watcher watch.Interface, gvk schema.GroupVersionKind, request *r
 	}
 	framer := serializer.StreamSerializer.Framer.NewFrameWriter(response.ResponseWriter)
 
-	e := streaming.NewEncoder(framer, scheme.Encoder)
+	// Encode every payload through a versioning codec: it resolves the
+	// payload's kind/apiVersion via the scheme. The storage layer builds
+	// error events (a 410 "too old resource version" Status) with an empty
+	// TypeMeta, and the bare serializer would stream them undecodable — the
+	// client fails with "Object 'Kind' is missing" instead of relisting.
+	versionedEncoder := scheme.Codecs.EncoderForVersion(scheme.Encoder, schema.GroupVersions{gvk.GroupVersion()})
+	e := streaming.NewEncoder(framer, versionedEncoder)
 
 	mediaType := serializer.MediaType
 	if mediaType != "application/json" {
@@ -67,7 +73,7 @@ func ServeWatch(watcher watch.Interface, gvk schema.GroupVersionKind, request *r
 
 	if wssstream.IsWebSocketRequest(request.Request) {
 		response.Header().Set("Content-Type", mediaType)
-		handlerWebsocket(watcher, request, response, serializer.EncodesAsText)
+		handlerWebsocket(watcher, request, response, versionedEncoder)
 		return
 	}
 
@@ -108,10 +114,7 @@ func ServeWatch(watcher watch.Interface, gvk schema.GroupVersionKind, request *r
 				return
 			}
 			obj := event.Object
-			if event.Type == watch.Bookmark {
-				obj.GetObjectKind().SetGroupVersionKind(gvk)
-			}
-			if err := scheme.Encoder.Encode(obj, buf); err != nil {
+			if err := versionedEncoder.Encode(obj, buf); err != nil {
 				HandleInternalError(response, request, fmt.Errorf("unable to encode watch object %T: %v", obj, err))
 				return
 			}
@@ -137,7 +140,9 @@ func ServeWatch(watcher watch.Interface, gvk schema.GroupVersionKind, request *r
 	}
 }
 
-func handlerWebsocket(watcher watch.Interface, request *restful.Request, response *restful.Response, encodesAsText bool) {
+func handlerWebsocket(
+	watcher watch.Interface, request *restful.Request, response *restful.Response, versionedEncoder runtime.Encoder,
+) {
 	upgrade := websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024 * 1024 * 10,
@@ -210,7 +215,7 @@ func handlerWebsocket(watcher watch.Interface, request *restful.Request, respons
 				return
 			}
 			obj := event.Object
-			if err := scheme.Encoder.Encode(obj, buf); err != nil {
+			if err := versionedEncoder.Encode(obj, buf); err != nil {
 				logger.Error("unable to encode watch object", zap.Any("object", obj), zap.Error(err))
 				return
 			}
@@ -225,7 +230,7 @@ func handlerWebsocket(watcher watch.Interface, request *restful.Request, respons
 				logger.Error("unable to convert watch object", zap.Error(err))
 				return
 			}
-			if err := scheme.Encoder.Encode(outEvent, streamBuf); err != nil {
+			if err := versionedEncoder.Encode(outEvent, streamBuf); err != nil {
 				logger.Error("unable to encode event", zap.Error(err))
 				return
 			}

--- a/pkg/server/restplus/watch_test.go
+++ b/pkg/server/restplus/watch_test.go
@@ -1,0 +1,187 @@
+/*
+ *
+ *  * Copyright 2026 KubeClipper Authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package restplus
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/emicklei/go-restful"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	"k8s.io/apimachinery/pkg/watch"
+
+	"github.com/kubeclipper/kubeclipper/pkg/scheme"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+)
+
+// singleEventWatch streams one preloaded event set and then closes the
+// channel, so ServeWatch returns deterministically.
+type singleEventWatch struct {
+	ch chan watch.Event
+}
+
+func newSingleEventWatch(events ...watch.Event) *singleEventWatch {
+	ch := make(chan watch.Event, len(events)+1)
+	for _, e := range events {
+		ch <- e
+	}
+	close(ch)
+	return &singleEventWatch{ch: ch}
+}
+
+func (*singleEventWatch) Stop() {}
+
+func (w *singleEventWatch) ResultChan() <-chan watch.Event { return w.ch }
+
+// A 410 "too old resource version" travels the watch stream as an ERROR event
+// whose payload is an *apierrors.StatusError. It must reach the client as a
+// decodable metav1.Status so the reflector relists instead of failing the
+// stream with "Object 'Kind' is missing".
+func TestServeWatchEncodesErrorEventAsDecodableStatus(t *testing.T) {
+	expired := apierrors.NewResourceExpired("too old resource version: 1, 100")
+	status := expired.Status()
+	watcher := newSingleEventWatch(watch.Event{Type: watch.Error, Object: &status})
+
+	httpReq := httptest.NewRequestWithContext(context.Background(), "GET", "/apis/core.kubeclipper.io/v1/clusters?watch=true", http.NoBody)
+	httpReq.Header.Set("Accept", "application/json")
+	request := restful.NewRequest(httpReq)
+	recorder := httptest.NewRecorder()
+	response := restful.NewResponse(recorder)
+
+	ServeWatch(watcher, corev1.SchemeGroupVersion.WithKind("Cluster"), request, response, 10*time.Second)
+
+	frameReader := json.Framer.NewFrameReader(io.NopCloser(bytes.NewReader(recorder.Body.Bytes())))
+	streamDecoder := streaming.NewDecoder(frameReader, scheme.Codecs.UniversalDeserializer())
+
+	var sawErrorStatus *metav1.Status
+	for {
+		obj, _, err := streamDecoder.Decode(nil, &metav1.WatchEvent{})
+		if err != nil {
+			break
+		}
+		event, ok := obj.(*metav1.WatchEvent)
+		if !ok {
+			continue
+		}
+		if event.Type != string(watch.Error) {
+			continue
+		}
+		decoded, _, err := scheme.Codecs.UniversalDeserializer().Decode(event.Object.Raw, nil, nil)
+		if err != nil {
+			t.Fatalf("client-side decode of the ERROR event payload failed: %v", err)
+		}
+		status, ok := decoded.(*metav1.Status)
+		if !ok {
+			t.Fatalf("decoded ERROR payload = %T, want *metav1.Status", decoded)
+		}
+		sawErrorStatus = status
+		break
+	}
+	if sawErrorStatus == nil {
+		t.Fatal("watch stream contained no decodable ERROR event")
+	}
+	if sawErrorStatus.Code != int32(http.StatusGone) {
+		t.Fatalf("status code = %d, want %d", sawErrorStatus.Code, http.StatusGone)
+	}
+	if sawErrorStatus.Kind != "Status" || sawErrorStatus.APIVersion == "" {
+		t.Fatalf("status TypeMeta = %s/%s, want kind Status with an apiVersion the client can decode",
+			sawErrorStatus.APIVersion, sawErrorStatus.Kind)
+	}
+}
+
+// Normal events decoded by a client must resolve to the typed resource with
+// its kind/apiVersion intact — the versioning codec stamps them at encode time.
+func TestServeWatchInjectsTypeMetaOnNormalEvents(t *testing.T) {
+	cluster := &corev1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1"}}
+	watcher := newSingleEventWatch(watch.Event{Type: watch.Added, Object: cluster})
+
+	httpReq := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/apis/core.kubeclipper.io/v1/clusters?watch=true", http.NoBody)
+	httpReq.Header.Set("Accept", "application/json")
+	recorder := httptest.NewRecorder()
+	ServeWatch(watcher, corev1.SchemeGroupVersion.WithKind("Cluster"),
+		restful.NewRequest(httpReq), restful.NewResponse(recorder), 10*time.Second)
+
+	event := decodeSingleWatchEvent(t, recorder.Body.Bytes(), string(watch.Added))
+	decoded, _, err := scheme.Codecs.UniversalDeserializer().Decode(event.Object.Raw, nil, nil)
+	if err != nil {
+		t.Fatalf("client-side decode of the ADDED payload failed: %v", err)
+	}
+	got, ok := decoded.(*corev1.Cluster)
+	if !ok {
+		t.Fatalf("decoded payload = %T, want *corev1.Cluster", decoded)
+	}
+	if got.Name != "c1" {
+		t.Fatalf("decoded cluster name = %q, want c1", got.Name)
+	}
+}
+
+// Bookmark events must carry the resource GVK so clients can process them
+// without a manual per-event stamp.
+func TestServeWatchBookmarkCarriesGVK(t *testing.T) {
+	cluster := &corev1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "c1", ResourceVersion: "42"}}
+	watcher := newSingleEventWatch(watch.Event{Type: watch.Bookmark, Object: cluster})
+
+	httpReq := httptest.NewRequestWithContext(context.Background(), "GET",
+		"/apis/core.kubeclipper.io/v1/clusters?watch=true", http.NoBody)
+	httpReq.Header.Set("Accept", "application/json")
+	recorder := httptest.NewRecorder()
+	ServeWatch(watcher, corev1.SchemeGroupVersion.WithKind("Cluster"),
+		restful.NewRequest(httpReq), restful.NewResponse(recorder), 10*time.Second)
+
+	event := decodeSingleWatchEvent(t, recorder.Body.Bytes(), string(watch.Bookmark))
+	decoded, gvk, err := scheme.Codecs.UniversalDeserializer().Decode(event.Object.Raw, nil, nil)
+	if err != nil {
+		t.Fatalf("client-side decode of the BOOKMARK payload failed: %v", err)
+	}
+	if gvk.Kind != "Cluster" || gvk.Group != corev1.SchemeGroupVersion.Group {
+		t.Fatalf("bookmark payload gvk = %v, want core.kubeclipper.io/v1 Cluster", gvk)
+	}
+	if _, ok := decoded.(*corev1.Cluster); !ok {
+		t.Fatalf("decoded payload = %T, want *corev1.Cluster", decoded)
+	}
+}
+
+func decodeSingleWatchEvent(t *testing.T, body []byte, wantType string) *metav1.WatchEvent {
+	t.Helper()
+	frameReader := json.Framer.NewFrameReader(io.NopCloser(bytes.NewReader(body)))
+	streamDecoder := streaming.NewDecoder(frameReader, scheme.Codecs.UniversalDeserializer())
+	for {
+		obj, _, err := streamDecoder.Decode(nil, &metav1.WatchEvent{})
+		if err != nil {
+			t.Fatalf("watch stream ended without a %q event: %v", wantType, err)
+		}
+		event, ok := obj.(*metav1.WatchEvent)
+		if !ok {
+			continue
+		}
+		if event.Type != wantType {
+			continue
+		}
+		return event
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

When an agent's resourceVersion expires (guaranteed eventually after etcd
compaction), the storage layer emits a `watch.Error` event whose payload is a
freshly constructed `metav1.Status` with an **empty TypeMeta**
(`transformErrorToEvent` in etcd3 watcher). `ServeWatch` frames that payload
with a bare json serializer that does not inject `kind`/`apiVersion`, so the
frame carried an ERROR object that `runtime.Decode` cannot resolve.

Client-side, `restclientwatch.Decoder` decodes the embedded object with
`runtime.Decode(embeddedDecoder, raw)` — no `into`, no defaults — so the missing
kind fails the whole watch with `Object 'Kind' is missing` instead of
recognizing the 410 and relisting. This is the P4-03 release-gate failure.

This PR normalizes watch ERROR events in both the HTTP and websocket paths of
`ServeWatch`: the payload is stamped with the unversioned `v1` `Status` GVK
(registered on both the server and the clients through
`metav1.AddToGroupVersion`, and verified decodable), and `apierrors.APIStatus`
wrappers are converted to plain `metav1.Status`. A regression test streams an
expired-resourceVersion error through `ServeWatch` and decodes the framed
stream exactly the way a client does, asserting a decodable `Status` with code
410 and a populated TypeMeta.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
Only the ERROR branch is touched; ADDED/MODIFIED/DELETED/BOOKMARK payloads are
unchanged (their objects are full scheme types that already carry or tolerate
the encoding path they use).
```

### Does this PR introduced a user-facing change?

```release-note
Fixed: agents and console watchers now survive expired resourceVersions (410)
instead of dropping the watch stream with "Object 'Kind' is missing".
```

### Additional documentation, usage docs, etc.:

```docs
None
```
