### PR TITLE
fix(agent): bound command output buffers and unblock Wait on pipe-holding grandchildren

### DIFF
--- a/pkg/utils/cmdutil/cmdutil.go
+++ b/pkg/utils/cmdutil/cmdutil.go
@@ -35,7 +35,7 @@ func RunCmdWithContext(ctx context.Context, dryRun bool, command string, args ..
 	ec := NewExecCmd(ctx, command, args...)
 	logger.Debug("running command", zap.String("cmd", ec.String()))
 	if dryRun {
-		_, err := ec.stdOutBuf.WriteString("dry run command")
+		_, err := ec.stdOutBuf.Write([]byte("dry run command"))
 		return ec, err
 	}
 	// check context, get log file if conditions permit

--- a/pkg/utils/cmdutil/command.go
+++ b/pkg/utils/cmdutil/command.go
@@ -29,21 +29,55 @@ import (
 	"time"
 )
 
+// commandOutputBufferSize caps the in-memory tail kept per output stream. The
+// full stream is persisted to the task log file by the executor; the in-memory
+// copy only backs error messages and output parsing, so an unbounded buffer
+// would only grow the agent's RSS until a verbose command OOMs it.
+const commandOutputBufferSize = 1 << 20 // 1 MiB
+
+// tailBuffer keeps at most max bytes: the most recent tail of the stream.
+// Writes beyond the cap drop the oldest bytes in place, so the buffer never
+// exceeds max while staying allocation-free in the steady state.
+type tailBuffer struct {
+	buf   []byte
+	limit int
+}
+
+func newTailBuffer(limit int) *tailBuffer {
+	return &tailBuffer{buf: make([]byte, 0, limit), limit: limit}
+}
+
+func (t *tailBuffer) Write(p []byte) (int, error) {
+	n := len(p)
+	if t.limit > 0 && len(p) > t.limit {
+		p = p[len(p)-t.limit:]
+	}
+	t.buf = append(t.buf, p...)
+	if over := len(t.buf) - t.limit; over > 0 {
+		copy(t.buf, t.buf[over:])
+		t.buf = t.buf[:t.limit]
+	}
+	return n, nil
+}
+
+func (t *tailBuffer) Bytes() []byte  { return t.buf }
+func (t *tailBuffer) String() string { return string(t.buf) }
+
 type ExecCmd struct {
-	stdOutBuf *bytes.Buffer
-	stdErrBuf *bytes.Buffer
+	stdOutBuf *tailBuffer
+	stdErrBuf *tailBuffer
 	startTime time.Time
 	*exec.Cmd
 }
 
 func NewExecCmd(ctx context.Context, command string, args ...string) *ExecCmd {
 	ec := &ExecCmd{
-		stdOutBuf: &bytes.Buffer{},
-		stdErrBuf: &bytes.Buffer{},
+		stdOutBuf: newTailBuffer(commandOutputBufferSize),
+		stdErrBuf: newTailBuffer(commandOutputBufferSize),
 		Cmd:       exec.CommandContext(ctx, command, args...),
 		startTime: time.Now(),
 	}
-	ec.Cmd.Stdout, ec.Cmd.Stderr = ec.stdOutBuf, ec.stdErrBuf
+	ec.Stdout, ec.Stderr = ec.stdOutBuf, ec.stdErrBuf
 	return ec
 }
 
@@ -66,10 +100,19 @@ func (ec *ExecCmd) StdErr() string { return ec.stdErrBuf.String() }
 func (ec *ExecCmd) CommandString() string { return ec.Cmd.String() }
 
 func (ec *ExecCmd) Run() error {
-	if ec.Cmd.Process != nil {
+	if ec.Process != nil {
 		return errors.New("exec: already started")
 	}
-	ec.Cmd.Env = os.Environ()
+	// Stdout/Stderr are os.Pipes (the buffers plus the log file writer), so
+	// Cmd.Wait blocks until every pipe writer closes — including grandchildren
+	// that inherited the fds and outlive the command, which would wedge the
+	// single task worker forever. WaitDelay gives up on the pipe drains after
+	// the command itself has exited; the process-group TERM/KILL path in
+	// configureProcessGroup still owns killing a command that hangs.
+	if ec.WaitDelay == 0 {
+		ec.WaitDelay = commandTerminationGrace
+	}
+	ec.Env = os.Environ()
 	return ec.Cmd.Run()
 }
 

--- a/pkg/utils/cmdutil/command_test.go
+++ b/pkg/utils/cmdutil/command_test.go
@@ -21,7 +21,10 @@ package cmdutil
 import (
 	"context"
 	"errors"
+	"os/exec"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -137,3 +140,52 @@ rm limit.conf
 	}
 }
 */
+
+func TestTailBufferKeepsMostRecentTail(t *testing.T) {
+	tb := newTailBuffer(16)
+	if _, err := tb.Write([]byte("0123456789abcdef")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tb.Write([]byte("XYZ")); err != nil {
+		t.Fatal(err)
+	}
+	if got := tb.String(); got != "3456789abcdefXYZ" {
+		t.Fatalf("tail = %q, want the most recent 16 bytes", got)
+	}
+}
+
+func TestTailBufferReportsFullWriteWhenInputExceedsLimit(t *testing.T) {
+	tb := newTailBuffer(16)
+	input := strings.Repeat("x", 32)
+	n, err := tb.Write([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(input) {
+		t.Fatalf("Write returned %d, want %d", n, len(input))
+	}
+	if got := tb.String(); got != input[len(input)-16:] {
+		t.Fatalf("tail = %q, want the most recent 16 bytes", got)
+	}
+}
+
+// A grandchild that inherits the command's stdout pipe and outlives it used to
+// block Cmd.Wait forever (single worker wedge). WaitDelay must make Run return
+// once the command itself exited.
+func TestRunReturnsWhenGrandchildHoldsPipe(t *testing.T) {
+	ec := NewExecCmd(context.Background(), "/bin/sh", "-c", "echo started; sleep 30 & exit 0")
+	// Shorten the grace so the test does not wait for the 30s default.
+	ec.WaitDelay = 500 * time.Millisecond
+	start := time.Now()
+	err := ec.Run()
+	elapsed := time.Since(start)
+	if err != nil && !errors.Is(err, exec.ErrWaitDelay) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed > 10*time.Second {
+		t.Fatalf("Run blocked for %v; WaitDelay did not give up on the pipe", elapsed)
+	}
+	if !strings.Contains(ec.StdOut(), "started") {
+		t.Fatalf("stdout = %q, want the child's output", ec.StdOut())
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Two hardening gaps in the agent's single-worker command runner:

**1. Unbounded in-memory output buffers.** `ExecCmd` kept stdout/stderr in
`bytes.Buffer` instances with no cap. The CommandStep executor tees the full
stream into these buffers in addition to the task log file, so a verbose
command (`tar -v`, `kubeadm` debug, a runaway loop) grew the agent's RSS
without limit — and because the worker runs exactly one command at a time, one
bad task could OOM the agent, taking down Node reporting, Lease renewal and
the log endpoint with it. The design requires a *bounded* local spool.

Replaced with a `tailBuffer` that keeps at most the most recent 1 MiB per
stream (dropped in place, allocation-free in the steady state). The full
stream still reaches the task log file through the existing multi-writer; the
in-memory tail backs `StdOut()`/`StdErr()` error reporting and output parsing
(the kubeadm join-command extraction parses short trailing output, well within
the tail).

**2. `Cmd.Wait` can block forever on pipe-holding grandchildren.** Stdout/
Stderr are os.Pipes, and `Wait` waits until every pipe writer closes —
including grandchildren that inherited the fds. A daemonizing grandchild
outliving the command wedged `Wait` forever, stopping all task processing on
the node while the agent process looked healthy; only the controller's
force-timeout path would recover it.

`Cmd.WaitDelay` is now set to the command termination grace (respecting any
caller-provided value), so `Wait` gives up on the pipe drains once the command
itself has exited. The process-group TERM/KILL path in
`configureProcessGroup` still owns killing a command that hangs.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
Regression tests: TestTailBufferKeepsMostRecentTail and
TestRunReturnsWhenGrandchildHoldsPipe (a grandchild holding the pipe must not
block Run beyond the WaitDelay).
Pdeathsig on the child was considered and deliberately skipped: Go only
guarantees Pdeathsig correctness for the creating OS thread, and systemd's
KillMode=control-group already reaps orphans when the agent exits.
```

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
None
```
