### PR TITLE
fix(agent): retry the terminal status write instead of re-running the executor

### DIFF
--- a/pkg/agent/operationv2/worker.go
+++ b/pkg/agent/operationv2/worker.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"time"
 
+	"net/http"
+
 	"golang.org/x/sys/unix"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,6 +72,13 @@ type WorkerOptions struct {
 	LockFile string
 }
 
+// pendingTerminalState is a terminal phase/result computed by an executor
+// whose status write has not been confirmed yet.
+type pendingTerminalState struct {
+	phase  operations.TaskPhase
+	result operations.TaskResult
+}
+
 type Worker struct {
 	agentID  string
 	nodeUID  types.UID
@@ -79,6 +88,12 @@ type Worker struct {
 	lockPath string
 	runCtx   context.Context
 	cancel   context.CancelFunc
+	// pendingTerminal remembers a terminal status that was computed but whose
+	// status write has not been confirmed yet. While an entry exists the
+	// worker retries only the status write and never re-runs the executor:
+	// re-running the command list would repeat side effects for a command
+	// that already finished. Accessed from the single worker goroutine only.
+	pendingTerminal map[types.UID]pendingTerminalState
 
 	informer cache.SharedIndexInformer
 	queue    workqueue.RateLimitingInterface
@@ -101,15 +116,16 @@ func NewWorker(opts *WorkerOptions) (*Worker, error) {
 	}
 	runCtx, cancel := context.WithCancel(context.Background())
 	w := &Worker{
-		agentID:  opts.AgentID,
-		nodeUID:  opts.NodeUID,
-		client:   opts.Client,
-		registry: opts.Registry,
-		oplog:    opts.OpLog,
-		lockPath: opts.LockFile,
-		runCtx:   runCtx,
-		cancel:   cancel,
-		queue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "operation-v2-agent"),
+		agentID:         opts.AgentID,
+		nodeUID:         opts.NodeUID,
+		client:          opts.Client,
+		registry:        opts.Registry,
+		oplog:           opts.OpLog,
+		lockPath:        opts.LockFile,
+		runCtx:          runCtx,
+		cancel:          cancel,
+		pendingTerminal: make(map[types.UID]pendingTerminalState),
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "operation-v2-agent"),
 	}
 	selector := fields.OneTermEqualSelector("spec.nodeRef.name", opts.AgentID).String()
 	w.informer = cache.NewSharedIndexInformer(&cache.ListWatch{
@@ -303,6 +319,13 @@ func selectTask(tasks []*operations.OperationTask) (*operations.OperationTask, e
 }
 
 func (w *Worker) execute(parent context.Context, task *operations.OperationTask) error {
+	// A terminal status was already computed for this task but its write has
+	// not been confirmed: retry only the status write. Re-running the
+	// executor would repeat the command's side effects for a command that
+	// already finished.
+	if pending, ok := w.pendingTerminal[task.UID]; ok {
+		return w.finish(parent, task, pending.phase, pending.result)
+	}
 	executor, ok := w.registry.Get(task.Spec.Executor)
 	if !ok {
 		return w.finish(parent, task, operations.TaskFailed, operations.TaskResult{
@@ -367,13 +390,42 @@ func (w *Worker) finish(
 		latest, getErr := w.client.Get(getCtx, task.Name, metav1.GetOptions{})
 		getCancel()
 		if getErr == nil && latest.UID == task.UID && latest.Status.Phase.IsTerminal() {
+			delete(w.pendingTerminal, task.UID)
 			w.queue.Add(syncKey)
+			return nil
+		}
+		// Remember the computed terminal state: resync retries only this
+		// status write and never re-runs the executor, whose commands have
+		// already produced their side effects.
+		w.pendingTerminal[task.UID] = pendingTerminalState{phase: phase, result: result}
+		if isPermanentTerminalWriteFailure(err) {
+			// The server rejected the terminal status with a client error a
+			// retry cannot fix (invalid result, forbidden). Requeueing would
+			// loop without progress; the controller's deadline force-timeout
+			// converges the Running task on the server side instead.
+			logger.Errorf("task %s terminal status write rejected permanently, giving up: %v", task.Name, err)
 			return nil
 		}
 		return err
 	}
+	delete(w.pendingTerminal, task.UID)
 	w.queue.Add(syncKey)
 	return nil
+}
+
+// isPermanentTerminalWriteFailure reports whether the server rejected the
+// terminal status write with a client error that a retry cannot fix.
+func isPermanentTerminalWriteFailure(err error) bool {
+	if apierrors.IsConflict(err) || apierrors.IsNotFound(err) || apierrors.IsTooManyRequests(err) ||
+		apierrors.IsServerTimeout(err) || apierrors.IsServiceUnavailable(err) || apierrors.IsInternalError(err) {
+		return false
+	}
+	var status apierrors.APIStatus
+	if errors.As(err, &status) {
+		code := int(status.Status().Code)
+		return code >= http.StatusBadRequest && code < http.StatusInternalServerError
+	}
+	return false
 }
 
 func boundedMessage(message string) string {

--- a/pkg/agent/operationv2/worker_test.go
+++ b/pkg/agent/operationv2/worker_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -298,5 +299,67 @@ func TestTaskListIsBoundedAndWatchIsNot(t *testing.T) {
 	case <-client.watchCtx.Done():
 	case <-time.After(5 * time.Second):
 		t.Fatal("task Watch context does not follow the worker run context")
+	}
+}
+
+// statusRejectingClient accepts the Pending→Running claim but permanently
+// rejects every terminal status write with a 400, mirroring a server that
+// considers the computed result invalid.
+type statusRejectingClient struct {
+	fakeTaskClient
+	terminalPUTs int
+}
+
+func (c *statusRejectingClient) UpdateStatus(
+	_ context.Context,
+	task *operations.OperationTask,
+) (*operations.OperationTask, error) {
+	if task.Status.Phase != operations.TaskRunning {
+		c.terminalPUTs++
+		return nil, apierrors.NewBadRequest("terminal result rejected: invalid")
+	}
+	return c.fakeTaskClient.UpdateStatus(context.Background(), task)
+}
+
+type countingExecutor struct {
+	calls int
+}
+
+func (e *countingExecutor) Reconcile(_ context.Context, _ *operations.OperationTask, _ io.Writer) (operations.TaskResult, error) {
+	e.calls++
+	return operations.TaskResult{Message: "done"}, nil
+}
+
+// A terminal status that the server keeps rejecting must be retried as a
+// status write only: the executor — whose commands already produced their
+// side effects — must never run again, and a permanent 4xx stops the retry
+// loop instead of queueing forever.
+func TestTerminalWriteFailureDoesNotReexecuteExecutor(t *testing.T) {
+	client := &statusRejectingClient{fakeTaskClient: fakeTaskClient{task: newTestTask(operations.TaskPending)}}
+	executor := &countingExecutor{}
+	worker := newTestWorker(t, &client.fakeTaskClient, executor)
+	worker.client = client
+
+	// First sync: claims the task, runs the executor once, and hits the
+	// permanent rejection on the terminal status write.
+	if err := worker.sync(worker.runCtx); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("executor calls after first sync = %d, want 1", executor.calls)
+	}
+
+	// Second sync: only the status write may be retried.
+	if err := worker.sync(worker.runCtx); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+	if executor.calls != 1 {
+		t.Fatalf("executor re-executed: calls = %d, want 1", executor.calls)
+	}
+	if client.terminalPUTs != 2 {
+		t.Fatalf("terminal status writes = %d, want 2 (one per sync)", client.terminalPUTs)
+	}
+	if _, pending := worker.pendingTerminal[client.task.UID]; !pending {
+		t.Fatal("pending terminal state must be retained while the write is rejected")
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

When the terminal status write of a finished task failed, every rate-limited
resync re-invoked the executor from scratch. For the CommandStep executor that
meant repeatedly re-running the full command list of a task whose side effects
had already happened. Persistent failures (status rejected as invalid or
forbidden, etcd outage 5xx) became an endless re-execution loop: the backoff
is capped but never gives up, so install commands kept re-running indefinitely.
The design requires terminal-status errors to get bounded *communication*
retries — the executor must not run again, and new attempts are expressed only
by the controller through new tasks.

This PR remembers the computed terminal phase/result per task UID while its
status write is unconfirmed (`pendingTerminal`):

- the resync short-circuits the executor and retries only the status write,
  built from the freshly fetched task so the resourceVersion CAS converges as
  the server state advances;
- a write the server rejects with a non-retryable 4xx (invalid result,
  forbidden, bad request) stops requeueing the task entirely — the
  controller's deadline force-timeout converges the Running task server-side —
  and the failure is logged;
- the retained state is cleared once a terminal status is confirmed on the
  server.

Because retries after the first terminal computation can no longer re-run the
executor, a separate re-execution circuit breaker is unnecessary: every retry
is a side-effect-free status PUT.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
Regression test TestTerminalWriteFailureDoesNotReexecuteExecutor: a client that
accepts the Pending→Running claim but permanently 400s terminal writes must see
the executor run exactly once across repeated syncs, with only the status write
retried.
```

### Does this PR introduced a user-facing change?

```release-note
Fixed: the agent no longer re-executes a finished task's commands when its
terminal status write keeps failing.
```

### Additional documentation, usage docs, etc.:

```docs
None
```
