### PR TITLE
fix(agent): configure and report per-node task log ports

### DIFF
--- a/cmd/kcctl/app/options/options.go
+++ b/cmd/kcctl/app/options/options.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/kubeclipper/kubeclipper/pkg/auditing/option"
 	"github.com/kubeclipper/kubeclipper/pkg/authentication/options"
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/autodetection"
 	"github.com/kubeclipper/kubeclipper/pkg/utils/sliceutil"
 
@@ -244,9 +245,20 @@ func (a Agents) Add(ip string, metadata Metadata) {
 
 // Metadata user custom node info,region will use by filter,use label,others use annotation.
 type Metadata struct {
-	AgentID string `json:"agentID" yaml:"agentID,omitempty"`
-	Region  string `json:"region" yaml:"region,omitempty"`
-	FloatIP string `json:"floatIP" yaml:"floatIP,omitempty"`
+	AgentID      string `json:"agentID" yaml:"agentID,omitempty"`
+	Region       string `json:"region" yaml:"region,omitempty"`
+	FloatIP      string `json:"floatIP" yaml:"floatIP,omitempty"`
+	AgentLogPort int    `json:"agentLogPort" yaml:"agentLogPort,omitempty"`
+}
+
+func (m Metadata) LogPort() (int, error) {
+	if m.AgentLogPort == 0 {
+		return constatns.DefaultAgentLogPort, nil
+	}
+	if m.AgentLogPort < 1 || m.AgentLogPort > 65535 {
+		return 0, fmt.Errorf("agent log port %d must be between 1 and 65535", m.AgentLogPort)
+	}
+	return m.AgentLogPort, nil
 }
 
 type DeployConfig struct {
@@ -508,6 +520,11 @@ func (c *DeployConfig) GetKcAgentConfigTemplateContent(metadata Metadata) (strin
 	data["AgentID"] = metadata.AgentID
 	data["Region"] = metadata.Region
 	data["FloatIP"] = metadata.FloatIP
+	logPort, err := metadata.LogPort()
+	if err != nil {
+		return "", err
+	}
+	data["AgentLogPort"] = logPort
 	data["IPDetect"] = c.IPDetect
 	data["NodeIPDetect"] = c.NodeIPDetect
 	data["StaticServerAddress"] = fmt.Sprintf("http://%s:%d", c.ServerIPs[0], c.StaticServerPort)

--- a/cmd/kcctl/app/options/options_test.go
+++ b/cmd/kcctl/app/options/options_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import "testing"
+
+func TestMetadataLogPort(t *testing.T) {
+	tests := []struct {
+		name string
+		port int
+		want int
+		ok   bool
+	}{
+		{name: "default", want: 10260, ok: true},
+		{name: "configured", port: 18080, want: 18080, ok: true},
+		{name: "zero is default", port: 0, want: 10260, ok: true},
+		{name: "negative", port: -1},
+		{name: "too large", port: 65536},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := (Metadata{AgentLogPort: tt.port}).LogPort()
+			if tt.ok {
+				if err != nil || got != tt.want {
+					t.Fatalf("LogPort() = (%d, %v), want (%d, nil)", got, err, tt.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("LogPort() = (%d, nil), want validation error", got)
+			}
+		})
+	}
+}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -21,8 +21,10 @@ package agent
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"runtime"
+	"strconv"
 	"time"
 
 	coordinationv1 "k8s.io/api/coordination/v1"
@@ -169,7 +171,10 @@ func (s *Server) initialNode() *corev1.Node {
 			common.LabelOSStable: runtime.GOOS, common.LabelArchStable: runtime.GOARCH,
 			common.LabelTopologyRegion: s.Config.Metadata.Region, common.LabelHostname: hostname,
 		}},
-		Status: corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{Hostname: hostname, OS: runtime.GOOS, Arch: runtime.GOARCH}},
+		Status: corev1.NodeStatus{
+			AgentLogPort: s.agentLogPort(),
+			NodeInfo:     corev1.NodeSystemInfo{Hostname: hostname, OS: runtime.GOOS, Arch: runtime.GOARCH},
+		},
 	}
 	if ip, err := netutil.GetDefaultIP(true, s.Config.IPDetect); err == nil {
 		node.Status.Ipv4DefaultIP = ip.String()
@@ -183,6 +188,22 @@ func (s *Server) initialNode() *corev1.Node {
 		logger.Errorf("collect node machine information: %v", err)
 	}
 	return node
+}
+
+func (s *Server) agentLogPort() int32 {
+	address := operationv2.DefaultAgentLogAddress
+	if s.Config != nil && s.Config.APIServer != nil && s.Config.APIServer.LogAddress != "" {
+		address = s.Config.APIServer.LogAddress
+	}
+	_, rawPort, err := net.SplitHostPort(address)
+	if err != nil {
+		return 0
+	}
+	port, err := strconv.ParseInt(rawPort, 10, 32)
+	if err != nil || port < 1 || port > 65535 {
+		return 0
+	}
+	return int32(port)
 }
 
 func (s *Server) Run(stopCh <-chan struct{}) error {

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -50,6 +50,19 @@ func TestInitialNodePublishesHostnameLabel(t *testing.T) {
 	if _, found := node.Status.Capacity[corev1.ResourceMemory]; !found {
 		t.Fatal("expected memory capacity in node status")
 	}
+	if got, want := node.Status.AgentLogPort, int32(10260); got != want {
+		t.Fatalf("agent log port = %d, want %d", got, want)
+	}
+}
+
+func TestInitialNodePublishesConfiguredAgentLogPort(t *testing.T) {
+	cfg := config.New()
+	cfg.AgentID = "agent-1"
+	cfg.APIServer.LogAddress = ":18080"
+
+	if got, want := (&Server{Config: cfg}).initialNode().Status.AgentLogPort, int32(18080); got != want {
+		t.Fatalf("agent log port = %d, want %d", got, want)
+	}
 }
 
 func TestNewNodeLease(t *testing.T) {

--- a/pkg/apis/operations/v1alpha1/handler.go
+++ b/pkg/apis/operations/v1alpha1/handler.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -38,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	userapi "k8s.io/apiserver/pkg/authentication/user"
 
+	"github.com/kubeclipper/kubeclipper/pkg/constatns"
 	"github.com/kubeclipper/kubeclipper/pkg/models/cluster"
 	operationv2 "github.com/kubeclipper/kubeclipper/pkg/models/operationv2"
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
@@ -358,12 +360,11 @@ func (h *handler) getTaskLogs(req *restful.Request, resp *restful.Response) {
 	query := url.Values{}
 	query.Set("offset", req.QueryParameter("offset"))
 	query.Set("limit", req.QueryParameter("limit"))
-	endpoint := fmt.Sprintf(
-		"https://%s:10260/v1/tasks/%s/logs?%s",
-		node.Status.Ipv4DefaultIP,
-		url.PathEscape(string(task.UID)),
-		query.Encode(),
-	)
+	endpoint, err := taskLogEndpoint(node, task, query)
+	if err != nil {
+		writeError(resp, apierrors.NewConflict(operations.Resource(operations.ResourceTasks), task.Name, err))
+		return
+	}
 	request, err := http.NewRequestWithContext(req.Request.Context(), http.MethodGet, endpoint, http.NoBody)
 	if err != nil {
 		writeError(resp, apierrors.NewInternalError(err))
@@ -397,6 +398,22 @@ func (h *handler) getTaskLogs(req *restful.Request, resp *restful.Response) {
 	if _, err := resp.Write(body); err != nil {
 		return
 	}
+}
+
+func taskLogEndpoint(node *corev1.Node, task *operations.OperationTask, query url.Values) (string, error) {
+	port := node.Status.AgentLogPort
+	if port == 0 {
+		port = constatns.DefaultAgentLogPort
+	}
+	if port < 1 || port > 65535 {
+		return "", fmt.Errorf("agent log port %d is invalid", port)
+	}
+	return fmt.Sprintf(
+		"https://%s/v1/tasks/%s/logs?%s",
+		net.JoinHostPort(node.Status.Ipv4DefaultIP, strconv.Itoa(int(port))),
+		url.PathEscape(string(task.UID)),
+		query.Encode(),
+	), nil
 }
 
 func newLogClient(caFile, certFile, keyFile string) (*http.Client, error) {

--- a/pkg/apis/operations/v1alpha1/handler_test.go
+++ b/pkg/apis/operations/v1alpha1/handler_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"net/url"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
+)
+
+func TestTaskLogEndpointUsesReportedAgentPort(t *testing.T) {
+	node := &corev1.Node{Status: corev1.NodeStatus{Ipv4DefaultIP: "192.0.2.10", AgentLogPort: 18080}}
+	task := &operations.OperationTask{ObjectMeta: metav1.ObjectMeta{UID: "task-uid"}}
+	query := url.Values{"offset": {"64"}, "limit": {"128"}}
+
+	endpoint, err := taskLogEndpoint(node, task, query)
+	if err != nil {
+		t.Fatalf("taskLogEndpoint() error = %v", err)
+	}
+	if want := "https://192.0.2.10:18080/v1/tasks/task-uid/logs?limit=128&offset=64"; endpoint != want {
+		t.Fatalf("taskLogEndpoint() = %q, want %q", endpoint, want)
+	}
+}
+
+func TestTaskLogEndpointDefaultsAndRejectsInvalidPort(t *testing.T) {
+	task := &operations.OperationTask{ObjectMeta: metav1.ObjectMeta{UID: "task-uid"}}
+	query := url.Values{}
+
+	endpoint, err := taskLogEndpoint(&corev1.Node{Status: corev1.NodeStatus{Ipv4DefaultIP: "192.0.2.10"}}, task, query)
+	if err != nil {
+		t.Fatalf("taskLogEndpoint() error = %v", err)
+	}
+	if want := "https://192.0.2.10:10260/v1/tasks/task-uid/logs?"; endpoint != want {
+		t.Fatalf("taskLogEndpoint() = %q, want %q", endpoint, want)
+	}
+	if _, err := taskLogEndpoint(&corev1.Node{Status: corev1.NodeStatus{Ipv4DefaultIP: "192.0.2.10", AgentLogPort: 65536}}, task, query); err == nil {
+		t.Fatal("taskLogEndpoint() succeeded with invalid port")
+	}
+}

--- a/pkg/cli/config/template.go
+++ b/pkg/cli/config/template.go
@@ -269,7 +269,7 @@ apiServer:
   certFile: {{.AgentCertFile}}
   keyFile: {{.AgentKeyFile}}
   serverName: server.kubeclipper.io
-  logAddress: ":10260"
+  logAddress: ":{{.AgentLogPort}}"
 oplog:
   dir: {{.OpLogDir}}
   singleThreshold: {{.OpLogThreshold}}

--- a/pkg/cli/deploy/config.go
+++ b/pkg/cli/deploy/config.go
@@ -86,6 +86,7 @@ agents:
   #192.168.10.10:
      #region: us-west
      #fip: 172.20.150.199
+     #agentLogPort: 10260
   # with region metadata
   #192.168.10.11:
      #region: us-west

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -375,7 +375,7 @@ var (
 	}
 )
 
-func precheckPortFunc(port int, serviceName string) precheckFunc {
+func PrecheckPortFunc(port int, serviceName string) precheckFunc {
 	return func(sshConfig *sshutils.SSH, host string) error {
 		ret, err := sshutils.SSHCmdWithSudo(sshConfig, host, "ss -tlnp")
 		if err != nil {
@@ -614,25 +614,17 @@ func (d *DeployOptions) precheckTimeLag() error {
 }
 
 func (d *DeployOptions) precheckPorts() error {
-	var (
-		missingToolHosts = make(map[string]bool)
-		mu               sync.Mutex
-	)
 	toolCheck := func(sshConfig *sshutils.SSH, host string) error {
 		_, err := sshutils.SSHCmdWithSudo(sshConfig, host, "which ss")
 		if err != nil {
 			_, err = sshutils.SSHCmdWithSudo(sshConfig, host, "which netstat")
 			if err != nil {
-				mu.Lock()
-				missingToolHosts[host] = true
-				mu.Unlock()
-				return fmt.Errorf("port check tool (ss or netstat) not found, " +
-					"skip port availability check, deployment may fail if port is occupied")
+				return fmt.Errorf("port precheck requires ss or netstat: %w", err)
 			}
 		}
 		return nil
 	}
-	if err := d.precheckService("PORT-TOOL", d.deployConfig.ServerIPs, toolCheck); err != nil {
+	if err := d.precheckService("PORT-TOOL", d.allNodes, toolCheck); err != nil {
 		return err
 	}
 
@@ -651,22 +643,24 @@ func (d *DeployOptions) precheckPorts() error {
 		if err := d.precheckService(
 			fmt.Sprintf("PORT-%d(%s)", p.port, p.name),
 			d.deployConfig.ServerIPs,
-			func(port int, svc string) precheckFunc {
-				return func(sshConfig *sshutils.SSH, host string) error {
-					mu.Lock()
-					missing := missingToolHosts[host]
-					mu.Unlock()
-					if missing {
-						return nil
-					}
-					return precheckPortFunc(port, svc)(sshConfig, host)
-				}
-			}(p.port, p.name),
+			PrecheckPortFunc(p.port, p.name),
 		); err != nil {
 			return err
 		}
 	}
-	return nil
+	// Only configured Agent nodes run kc-agent. A server-only node can use this
+	// port for an unrelated service.
+	return d.precheckService(
+		"PORT(kc-agent-log)",
+		d.deployConfig.Agents.ListIP(),
+		func(sshConfig *sshutils.SSH, host string) error {
+			logPort, err := d.deployConfig.Agents[host].LogPort()
+			if err != nil {
+				return err
+			}
+			return PrecheckPortFunc(logPort, "kc-agent-log")(sshConfig, host)
+		},
+	)
 }
 
 func (d *DeployOptions) preCheck() error {

--- a/pkg/cli/join/join.go
+++ b/pkg/cli/join/join.go
@@ -97,9 +97,11 @@ agents:
   192.168.234.41:
     #region: default
     #floatIP:
+    #agentLogPort: 10260
   192.168.234.42:
     #region: default2
     #floatIP:
+    #agentLogPort: 10260
   kcctl join --join-config join-config.yaml
   Please read 'kcctl join -h' get more deploy flags`
 )
@@ -259,6 +261,17 @@ func (c *JoinOptions) preCheck() bool {
 	// check if the node is already added
 	for _, agent := range c.parseAgent.ListIP() {
 		if !c.preCheckKcAgent(agent) {
+			return false
+		}
+		// kc-agent aborts startup when it cannot bind the task log port, so
+		// verify it is free before installing the node.
+		logPort, err := c.parseAgent[agent].LogPort()
+		if err != nil {
+			logger.Errorf("check node %s failed: %s", agent, err.Error())
+			return false
+		}
+		if err := deploy.PrecheckPortFunc(logPort, "kc-agent-log")(c.sshConfig, agent); err != nil {
+			logger.Errorf("check node %s failed: %s", agent, err.Error())
 			return false
 		}
 	}
@@ -424,6 +437,11 @@ func (c *JoinOptions) getKcAgentConfigTemplateContent(metadata options.Metadata)
 	var data = make(map[string]interface{})
 	data["Region"] = metadata.Region
 	data["FloatIP"] = metadata.FloatIP
+	logPort, err := metadata.LogPort()
+	if err != nil {
+		logger.Fatalf("invalid agent log port: %s", err.Error())
+	}
+	data["AgentLogPort"] = logPort
 	data["IPDetect"] = c.deployConfig.IPDetect
 	data["NodeIPDetect"] = c.deployConfig.NodeIPDetect
 	data["AgentID"] = metadata.AgentID

--- a/pkg/constatns/constats.go
+++ b/pkg/constatns/constats.go
@@ -36,6 +36,11 @@ const (
 	ClusterPodSubnet     = "172.25.0.0/16"
 )
 
+// DefaultAgentLogPort must match the logAddress in the agent config template
+// (pkg/cli/config/template.go) and the agent default in
+// pkg/agent/config/config.go.
+const DefaultAgentLogPort = 10260
+
 const (
 	KubeClipperOSSEndpoint        = "https://kubeclipper.oss-ap-southeast-1.aliyuncs.com"
 	KubeClipperKCDownloadBaseURL  = KubeClipperOSSEndpoint + "/kc"

--- a/pkg/scheme/core/v1/node_types.go
+++ b/pkg/scheme/core/v1/node_types.go
@@ -167,6 +167,9 @@ type NodeStatus struct {
 	// Note: It is usually used for routing between kc nodes and belongs to the operation and maintenance management network.
 	Ipv4DefaultIP string `json:"ipv4DefaultIP" description:"node ipv4 default gateway interface ip"`
 	Ipv4DefaultGw string `json:"ipv4DefaultGw" description:"node ipv4 default gateway ip"`
+	// AgentLogPort is the port of this Node's mTLS task-log server.
+	// +optional
+	AgentLogPort int32 `json:"agentLogPort,omitempty"`
 	// Note: It is commonly used for routing between nodes in a kubernetes cluster.
 	// If the `--node-ip-detect` parameter is not specified at deployment time, it is the same as `Ipv4DefaultIP`;
 	// otherwise, it depends on the ip detect method.


### PR DESCRIPTION
## What changed

- Add `agents.<node-ip>.agentLogPort` to deploy and join configuration. It defaults to `10260` and is validated as a TCP port.
- Render that port into each Agent configuration, then report it through `Node.status.agentLogPort`.
- Route operation task-log proxy requests to the port reported by the target Node, allowing different nodes to use different ports.
- Precheck the configured log port only on Agent nodes; server-only nodes do not run `kc-agent` and are not required to reserve it.

## Verification

- `go test ./cmd/kcctl/app/options ./pkg/agent ./pkg/apis/operations/v1alpha1 ./pkg/cli/deploy ./pkg/cli/join`
- `gofmt -s -w ./pkg ./cmd ./tools ./test`
- `golangci-lint run`