### PR TITLE
fix(operationv2): index target event fan-out

### DIFF
--- a/pkg/controller/backupcontroller/controller.go
+++ b/pkg/controller/backupcontroller/controller.go
@@ -25,7 +25,6 @@ import (
 
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
@@ -49,12 +48,8 @@ import (
 )
 
 type BackupReconciler struct {
-	ClusterLister listerv1.ClusterLister
-	BackupLister  listerv1.BackupLister
-	// BackupIndexer indexes Backups by their operation-name label; nil falls
-	// back to the full lister scan in findObjectsForOperation. Wired from the
-	// server composition, where the backup informer index is registered.
-	BackupIndexer   cache.Indexer
+	ClusterLister   listerv1.ClusterLister
+	BackupLister    listerv1.BackupLister
 	OperationLister operationslister.OperationLister
 	OperationStore  operationv2store.Store
 	BackupWriter    cluster.BackupWriter
@@ -77,7 +72,22 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	return ctrl.Result{}, r.updateBackupStatus(ctx, log, b)
 }
 
-func (r *BackupReconciler) SetupWithManager(mgr manager.Manager, cache informers.InformerCache) error {
+func (r *BackupReconciler) SetupWithManager(mgr manager.Manager, informerCache informers.InformerCache) error {
+	backupInformer, err := informerCache.GetInformer(context.Background(), &v1.Backup{})
+	if err != nil {
+		return err
+	}
+	if err := backupInformer.AddIndexers(cache.Indexers{
+		OperationNameIndex: func(raw any) ([]string, error) {
+			backup, ok := raw.(*v1.Backup)
+			if !ok || backup.Labels[common.LabelOperationName] == "" {
+				return nil, nil
+			}
+			return []string{backup.Labels[common.LabelOperationName]}, nil
+		},
+	}); err != nil {
+		return err
+	}
 	c, err := controller.NewUnmanaged("backup", controller.Options{
 		MaxConcurrentReconciles: 2,
 		Reconciler:              r,
@@ -87,12 +97,12 @@ func (r *BackupReconciler) SetupWithManager(mgr manager.Manager, cache informers
 	if err != nil {
 		return err
 	}
-	if err = c.Watch(source.NewKindWithCache(&v1.Backup{}, cache), &handler.EnqueueRequestForObject{}); err != nil {
+	if err = c.Watch(source.NewKindWithCache(&v1.Backup{}, informerCache), &handler.EnqueueRequestForObject{}); err != nil {
 		return err
 	}
 	if watchErr := c.Watch(
-		source.NewKindWithCache(&operations.Operation{}, cache),
-		handler.EnqueueRequestsFromMapFunc(r.findObjectsForOperation),
+		source.NewKindWithCache(&operations.Operation{}, informerCache),
+		handler.EnqueueRequestsFromMapFunc(mapObjectsForOperation(backupInformer.GetIndexer())),
 	); watchErr != nil {
 		return watchErr
 	}
@@ -213,39 +223,24 @@ func (r *BackupReconciler) updateBackupStatus(ctx context.Context, log logger.Lo
 // events fan out to the matching backups without a full lister scan.
 const OperationNameIndex = "operationNameIndex"
 
-func (r *BackupReconciler) findObjectsForOperation(clu client.Object) []reconcile.Request {
-	if r.BackupIndexer == nil {
-		backups, err := r.BackupLister.List(labels.Everything())
+func mapObjectsForOperation(indexer cache.Indexer) handler.MapFunc {
+	return func(clu client.Object) []reconcile.Request {
+		matched, err := indexer.ByIndex(OperationNameIndex, clu.GetName())
 		if err != nil {
 			return []reconcile.Request{}
 		}
-		requests := make([]reconcile.Request, 0)
-		for _, backup := range backups {
-			if backup.Labels[common.LabelOperationName] != clu.GetName() {
+		requests := make([]reconcile.Request, 0, len(matched))
+		for _, raw := range matched {
+			backup, ok := raw.(*v1.Backup)
+			if !ok {
 				continue
 			}
 			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{Name: backup.Name},
+				NamespacedName: types.NamespacedName{
+					Name: backup.Name,
+				},
 			})
 		}
 		return requests
 	}
-
-	matched, err := r.BackupIndexer.ByIndex(OperationNameIndex, clu.GetName())
-	if err != nil {
-		return []reconcile.Request{}
-	}
-	requests := make([]reconcile.Request, 0, len(matched))
-	for _, raw := range matched {
-		backup, ok := raw.(*v1.Backup)
-		if !ok {
-			continue
-		}
-		requests = append(requests, reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name: backup.Name,
-			},
-		})
-	}
-	return requests
 }

--- a/pkg/controller/backupcontroller/controller.go
+++ b/pkg/controller/backupcontroller/controller.go
@@ -77,16 +77,17 @@ func (r *BackupReconciler) SetupWithManager(mgr manager.Manager, informerCache i
 	if err != nil {
 		return err
 	}
-	if err := backupInformer.AddIndexers(cache.Indexers{
+	indexErr := backupInformer.AddIndexers(cache.Indexers{
 		OperationNameIndex: func(raw any) ([]string, error) {
 			backup, ok := raw.(*v1.Backup)
-			if !ok || backup.Labels[common.LabelOperationName] == "" {
+			if !ok || backup.Labels == nil || backup.Labels[common.LabelOperationName] == "" {
 				return nil, nil
 			}
 			return []string{backup.Labels[common.LabelOperationName]}, nil
 		},
-	}); err != nil {
-		return err
+	})
+	if indexErr != nil {
+		return indexErr
 	}
 	c, err := controller.NewUnmanaged("backup", controller.Options{
 		MaxConcurrentReconciles: 2,
@@ -97,8 +98,9 @@ func (r *BackupReconciler) SetupWithManager(mgr manager.Manager, informerCache i
 	if err != nil {
 		return err
 	}
-	if err = c.Watch(source.NewKindWithCache(&v1.Backup{}, informerCache), &handler.EnqueueRequestForObject{}); err != nil {
-		return err
+	watchErr := c.Watch(source.NewKindWithCache(&v1.Backup{}, informerCache), &handler.EnqueueRequestForObject{})
+	if watchErr != nil {
+		return watchErr
 	}
 	if watchErr := c.Watch(
 		source.NewKindWithCache(&operations.Operation{}, informerCache),

--- a/pkg/controller/backupcontroller/controller.go
+++ b/pkg/controller/backupcontroller/controller.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubeclipper/kubeclipper/pkg/client/informers"
 	listerv1 "github.com/kubeclipper/kubeclipper/pkg/client/lister/core/v1"
@@ -48,8 +49,12 @@ import (
 )
 
 type BackupReconciler struct {
-	ClusterLister   listerv1.ClusterLister
-	BackupLister    listerv1.BackupLister
+	ClusterLister listerv1.ClusterLister
+	BackupLister  listerv1.BackupLister
+	// BackupIndexer indexes Backups by their operation-name label; nil falls
+	// back to the full lister scan in findObjectsForOperation. Wired from the
+	// server composition, where the backup informer index is registered.
+	BackupIndexer   cache.Indexer
 	OperationLister operationslister.OperationLister
 	OperationStore  operationv2store.Store
 	BackupWriter    cluster.BackupWriter
@@ -204,20 +209,43 @@ func (r *BackupReconciler) updateBackupStatus(ctx context.Context, log logger.Lo
 	return nil
 }
 
+// operationNameIndex keys Backups by their operation-name label so operation
+// events fan out to the matching backups without a full lister scan.
+const OperationNameIndex = "operationNameIndex"
+
 func (r *BackupReconciler) findObjectsForOperation(clu client.Object) []reconcile.Request {
-	backups, err := r.BackupLister.List(labels.Everything())
+	if r.BackupIndexer == nil {
+		backups, err := r.BackupLister.List(labels.Everything())
+		if err != nil {
+			return []reconcile.Request{}
+		}
+		requests := make([]reconcile.Request, 0)
+		for _, backup := range backups {
+			if backup.Labels[common.LabelOperationName] != clu.GetName() {
+				continue
+			}
+			requests = append(requests, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: backup.Name},
+			})
+		}
+		return requests
+	}
+
+	matched, err := r.BackupIndexer.ByIndex(OperationNameIndex, clu.GetName())
 	if err != nil {
 		return []reconcile.Request{}
 	}
-	var requests []reconcile.Request
-	for _, backup := range backups {
-		if backup.Labels[common.LabelOperationName] == clu.GetName() {
-			requests = append(requests, reconcile.Request{
-				NamespacedName: types.NamespacedName{
-					Name: backup.Name,
-				},
-			})
+	requests := make([]reconcile.Request, 0, len(matched))
+	for _, raw := range matched {
+		backup, ok := raw.(*v1.Backup)
+		if !ok {
+			continue
 		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: backup.Name,
+			},
+		})
 	}
 	return requests
 }

--- a/pkg/controller/backupcontroller/controller_test.go
+++ b/pkg/controller/backupcontroller/controller_test.go
@@ -24,14 +24,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
-	listerv1 "github.com/kubeclipper/kubeclipper/pkg/client/lister/core/v1"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
 )
 
-func TestFindObjectsForOperationFallsBackToListerWithoutIndex(t *testing.T) {
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+func TestMapObjectsForOperationUsesOperationNameIndex(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		OperationNameIndex: func(raw any) ([]string, error) {
+			backup := raw.(*corev1.Backup)
+			return []string{backup.Labels[common.LabelOperationName]}, nil
+		},
+	})
 	for _, backup := range []*corev1.Backup{
 		{ObjectMeta: metav1.ObjectMeta{Name: "matching", Labels: map[string]string{common.LabelOperationName: "operation-1"}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "other", Labels: map[string]string{common.LabelOperationName: "operation-2"}}},
@@ -41,8 +45,7 @@ func TestFindObjectsForOperationFallsBackToListerWithoutIndex(t *testing.T) {
 		}
 	}
 
-	reconciler := &BackupReconciler{BackupLister: listerv1.NewBackupLister(indexer)}
-	requests := reconciler.findObjectsForOperation(&operations.Operation{ObjectMeta: metav1.ObjectMeta{Name: "operation-1"}})
+	requests := mapObjectsForOperation(indexer)(&operations.Operation{ObjectMeta: metav1.ObjectMeta{Name: "operation-1"}})
 	if len(requests) != 1 || requests[0].Name != "matching" {
 		t.Fatalf("requests = %#v, want only matching backup", requests)
 	}

--- a/pkg/controller/backupcontroller/controller_test.go
+++ b/pkg/controller/backupcontroller/controller_test.go
@@ -32,7 +32,10 @@ import (
 func TestMapObjectsForOperationUsesOperationNameIndex(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		OperationNameIndex: func(raw any) ([]string, error) {
-			backup := raw.(*corev1.Backup)
+			backup, ok := raw.(*corev1.Backup)
+			if !ok || backup.Labels == nil {
+				return nil, nil
+			}
 			return []string{backup.Labels[common.LabelOperationName]}, nil
 		},
 	})

--- a/pkg/controller/backupcontroller/controller_test.go
+++ b/pkg/controller/backupcontroller/controller_test.go
@@ -1,0 +1,49 @@
+/*
+ *
+ *  * Copyright 2026 KubeClipper Authors.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package backupcontroller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	listerv1 "github.com/kubeclipper/kubeclipper/pkg/client/lister/core/v1"
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
+)
+
+func TestFindObjectsForOperationFallsBackToListerWithoutIndex(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	for _, backup := range []*corev1.Backup{
+		{ObjectMeta: metav1.ObjectMeta{Name: "matching", Labels: map[string]string{common.LabelOperationName: "operation-1"}}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "other", Labels: map[string]string{common.LabelOperationName: "operation-2"}}},
+	} {
+		if err := indexer.Add(backup); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	reconciler := &BackupReconciler{BackupLister: listerv1.NewBackupLister(indexer)}
+	requests := reconciler.findObjectsForOperation(&operations.Operation{ObjectMeta: metav1.ObjectMeta{Name: "operation-1"}})
+	if len(requests) != 1 || requests[0].Name != "matching" {
+		t.Fatalf("requests = %#v, want only matching backup", requests)
+	}
+}

--- a/pkg/controller/operationv2/controller.go
+++ b/pkg/controller/operationv2/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -43,12 +42,6 @@ const (
 type OperationReconciler struct {
 	Store Store
 	Now   func() time.Time
-	// conflictCounts tracks consecutive CAS conflicts per Operation so the
-	// requeue grows exponentially instead of spinning at the 200ms floor.
-	// Only the single controller goroutine family touches one key at a time,
-	// but the map itself is guarded for the two reconcile workers.
-	conflictMu     sync.Mutex
-	conflictCounts map[string]int
 }
 
 // Store is the narrow persistence contract needed by the reconciler. The
@@ -69,42 +62,6 @@ type Store interface {
 }
 
 func (r *OperationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	result, err := r.reconcile(ctx, req)
-	if err == nil && result.RequeueAfter == conflictRequeue {
-		// A CAS conflict: escalate the requeue exponentially so contended
-		// keys do not spin at the 200ms floor. The workqueue rate limiter is
-		// not engaged by RequeueAfter, so the backoff is applied here.
-		result.RequeueAfter = r.bumpConflictBackoff(req.Name)
-		return result, nil
-	}
-	r.forgetConflict(req.Name)
-	return result, err
-}
-
-func (r *OperationReconciler) bumpConflictBackoff(key string) time.Duration {
-	r.conflictMu.Lock()
-	defer r.conflictMu.Unlock()
-	if r.conflictCounts == nil {
-		r.conflictCounts = make(map[string]int)
-	}
-	r.conflictCounts[key]++
-	backoff := conflictRequeue
-	for i := 1; i < r.conflictCounts[key] && backoff < defaultWaitRequeue; i++ {
-		backoff *= 2
-	}
-	if backoff > defaultWaitRequeue {
-		backoff = defaultWaitRequeue
-	}
-	return backoff
-}
-
-func (r *OperationReconciler) forgetConflict(key string) {
-	r.conflictMu.Lock()
-	defer r.conflictMu.Unlock()
-	delete(r.conflictCounts, key)
-}
-
-func (r *OperationReconciler) reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	if r.Store == nil {
 		return reconcile.Result{}, fmt.Errorf("operation v2 store is required")
 	}

--- a/pkg/controller/operationv2/controller.go
+++ b/pkg/controller/operationv2/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -42,6 +43,12 @@ const (
 type OperationReconciler struct {
 	Store Store
 	Now   func() time.Time
+	// conflictCounts tracks consecutive CAS conflicts per Operation so the
+	// requeue grows exponentially instead of spinning at the 200ms floor.
+	// Only the single controller goroutine family touches one key at a time,
+	// but the map itself is guarded for the two reconcile workers.
+	conflictMu     sync.Mutex
+	conflictCounts map[string]int
 }
 
 // Store is the narrow persistence contract needed by the reconciler. The
@@ -62,6 +69,42 @@ type Store interface {
 }
 
 func (r *OperationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	result, err := r.reconcile(ctx, req)
+	if err == nil && result.RequeueAfter == conflictRequeue {
+		// A CAS conflict: escalate the requeue exponentially so contended
+		// keys do not spin at the 200ms floor. The workqueue rate limiter is
+		// not engaged by RequeueAfter, so the backoff is applied here.
+		result.RequeueAfter = r.bumpConflictBackoff(req.Name)
+		return result, nil
+	}
+	r.forgetConflict(req.Name)
+	return result, err
+}
+
+func (r *OperationReconciler) bumpConflictBackoff(key string) time.Duration {
+	r.conflictMu.Lock()
+	defer r.conflictMu.Unlock()
+	if r.conflictCounts == nil {
+		r.conflictCounts = make(map[string]int)
+	}
+	r.conflictCounts[key]++
+	backoff := conflictRequeue
+	for i := 1; i < r.conflictCounts[key] && backoff < defaultWaitRequeue; i++ {
+		backoff *= 2
+	}
+	if backoff > defaultWaitRequeue {
+		backoff = defaultWaitRequeue
+	}
+	return backoff
+}
+
+func (r *OperationReconciler) forgetConflict(key string) {
+	r.conflictMu.Lock()
+	defer r.conflictMu.Unlock()
+	delete(r.conflictCounts, key)
+}
+
+func (r *OperationReconciler) reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	if r.Store == nil {
 		return reconcile.Result{}, fmt.Errorf("operation v2 store is required")
 	}

--- a/pkg/controller/operationv2/controller_test.go
+++ b/pkg/controller/operationv2/controller_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/reconcile"
 	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
@@ -601,4 +602,54 @@ func (f *fakeStore) CleanupByTargetUID(_ context.Context, targetUID types.UID) e
 		}
 	}
 	return nil
+}
+
+func TestConflictBackoffEscalatesAndResets(t *testing.T) {
+	r := &OperationReconciler{}
+	want := []time.Duration{200 * time.Millisecond, 400 * time.Millisecond, 800 * time.Millisecond,
+		1600 * time.Millisecond, 3200 * time.Millisecond, 5 * time.Second, 5 * time.Second}
+	for i, d := range want {
+		if got := r.bumpConflictBackoff("op-1"); got != d {
+			t.Fatalf("backoff[%d] = %v, want %v", i, got, d)
+		}
+	}
+	r.forgetConflict("op-1")
+	if got := r.bumpConflictBackoff("op-1"); got != 200*time.Millisecond {
+		t.Fatalf("backoff after forget = %v, want the 200ms floor", got)
+	}
+}
+
+func TestMapTargetOperationsUsesTargetUIDIndex(t *testing.T) {
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
+		targetUIDIndex: func(raw any) ([]string, error) {
+			op, ok := raw.(*operations.Operation)
+			if !ok || op.Spec.TargetRef.UID == "" {
+				return nil, nil
+			}
+			return []string{string(op.Spec.TargetRef.UID)}, nil
+		},
+	})
+	newOp := func(name, uid string) *operations.Operation {
+		return &operations.Operation{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       operations.OperationSpec{TargetRef: operations.ObjectReference{Kind: "Cluster", UID: types.UID(uid), Name: "cluster"}},
+		}
+	}
+	self := newOp("op-self", "uid-1")
+	sibling := newOp("op-sibling", "uid-1")
+	other := newOp("op-other", "uid-2")
+	for _, op := range []*operations.Operation{self, sibling, other} {
+		if err := indexer.Add(op); err != nil {
+			t.Fatal(err)
+		}
+	}
+	requests := mapTargetOperations(indexer)(self)
+	names := make([]string, 0, len(requests))
+	for _, req := range requests {
+		names = append(names, req.Name)
+	}
+	sort.Strings(names)
+	if len(names) != 2 || names[0] != "op-self" || names[1] != "op-sibling" {
+		t.Fatalf("mapped requests = %v, want the operation itself and its same-target sibling only", names)
+	}
 }

--- a/pkg/controller/operationv2/controller_test.go
+++ b/pkg/controller/operationv2/controller_test.go
@@ -604,21 +604,6 @@ func (f *fakeStore) CleanupByTargetUID(_ context.Context, targetUID types.UID) e
 	return nil
 }
 
-func TestConflictBackoffEscalatesAndResets(t *testing.T) {
-	r := &OperationReconciler{}
-	want := []time.Duration{200 * time.Millisecond, 400 * time.Millisecond, 800 * time.Millisecond,
-		1600 * time.Millisecond, 3200 * time.Millisecond, 5 * time.Second, 5 * time.Second}
-	for i, d := range want {
-		if got := r.bumpConflictBackoff("op-1"); got != d {
-			t.Fatalf("backoff[%d] = %v, want %v", i, got, d)
-		}
-	}
-	r.forgetConflict("op-1")
-	if got := r.bumpConflictBackoff("op-1"); got != 200*time.Millisecond {
-		t.Fatalf("backoff after forget = %v, want the 200ms floor", got)
-	}
-}
-
 func TestMapTargetOperationsUsesTargetUIDIndex(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{
 		targetUIDIndex: func(raw any) ([]string, error) {

--- a/pkg/controller/operationv2/setup.go
+++ b/pkg/controller/operationv2/setup.go
@@ -17,11 +17,10 @@
 package operationv2
 
 import (
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
 
 	"github.com/kubeclipper/kubeclipper/pkg/client/informers"
-	operationslister "github.com/kubeclipper/kubeclipper/pkg/client/lister/operations/v1alpha1"
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/client"
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/controller"
 	"github.com/kubeclipper/kubeclipper/pkg/controller-runtime/handler"
@@ -38,6 +37,20 @@ func (r *OperationReconciler) SetupWithManager(mgr manager.Manager, factory info
 	// for them during controller startup.
 	operationInformer.Informer()
 	taskInformer.Informer()
+	// Index Operations by target UID so the terminal-event map function can
+	// enqueue same-target Pending operations without a full lister scan; the
+	// scan degrades as history accumulates.
+	if err := operationInformer.Informer().AddIndexers(cache.Indexers{
+		targetUIDIndex: func(raw any) ([]string, error) {
+			op, ok := raw.(*operations.Operation)
+			if !ok || op.Spec.TargetRef.UID == "" {
+				return nil, nil
+			}
+			return []string{string(op.Spec.TargetRef.UID)}, nil
+		},
+	}); err != nil {
+		return err
+	}
 
 	c, err := controller.NewUnmanaged("operation-v2", controller.Options{
 		MaxConcurrentReconciles: 2,
@@ -50,7 +63,7 @@ func (r *OperationReconciler) SetupWithManager(mgr manager.Manager, factory info
 	}
 	if err := c.Watch(
 		source.NewKindWithCache(&operations.Operation{}, factory),
-		handler.EnqueueRequestsFromMapFunc(mapTargetOperations(operationInformer.Lister())),
+		handler.EnqueueRequestsFromMapFunc(mapTargetOperations(operationInformer.Informer().GetIndexer())),
 	); err != nil {
 		return err
 	}
@@ -64,26 +77,26 @@ func (r *OperationReconciler) SetupWithManager(mgr manager.Manager, factory info
 	return nil
 }
 
-func mapTargetOperations(lister operationslister.OperationLister) handler.MapFunc {
+// targetUIDIndex keys Operations by spec.targetRef.uid for O(1) same-target
+// fan-out on terminal events.
+const targetUIDIndex = "spec.targetRef.uid"
+
+func mapTargetOperations(indexer cache.Indexer) handler.MapFunc {
 	return func(object client.Object) []reconcile.Request {
 		op, ok := object.(*operations.Operation)
 		if !ok {
 			return nil
 		}
 		result := []reconcile.Request{{NamespacedName: types.NamespacedName{Name: op.Name}}}
-		all, err := lister.List(labels.Everything())
+		matched, err := indexer.ByIndex(targetUIDIndex, string(op.Spec.TargetRef.UID))
 		if err != nil {
 			return result
 		}
-		seen := map[string]struct{}{op.Name: {}}
-		for _, candidate := range all {
-			if candidate.Spec.TargetRef.UID != op.Spec.TargetRef.UID {
+		for _, raw := range matched {
+			candidate, ok := raw.(*operations.Operation)
+			if !ok || candidate.Name == op.Name {
 				continue
 			}
-			if _, exists := seen[candidate.Name]; exists {
-				continue
-			}
-			seen[candidate.Name] = struct{}{}
 			result = append(result, reconcile.Request{NamespacedName: types.NamespacedName{Name: candidate.Name}})
 		}
 		return result

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -153,7 +153,7 @@ func (s *APIServer) PrepareRun(stopCh <-chan struct{}) error {
 	s.container.DoNotRecover(false)
 	s.container.Filter(filters.LogRequestAndResponse)
 	s.container.Router(restful.CurlyRouter{})
-	s.container.RecoverHandler(func(panicReason interface{}, httpWriter http.ResponseWriter) {
+	s.container.RecoverHandler(func(panicReason any, httpWriter http.ResponseWriter) {
 		filters.LogStackOnRecover(panicReason, httpWriter)
 	})
 	if err := s.installAPIs(stopCh); err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,7 +35,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	unionauth "k8s.io/apiserver/pkg/authentication/request/union"
 	etcdRESTOptions "k8s.io/apiserver/pkg/server/options"
+	clientgocache "k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/version"
+
+	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
+	schemecore "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
 	auditingv1 "github.com/kubeclipper/kubeclipper/pkg/apis/auditing/v1"
@@ -153,7 +157,7 @@ func (s *APIServer) PrepareRun(stopCh <-chan struct{}) error {
 	s.container.DoNotRecover(false)
 	s.container.Filter(filters.LogRequestAndResponse)
 	s.container.Router(restful.CurlyRouter{})
-	s.container.RecoverHandler(func(panicReason interface{}, httpWriter http.ResponseWriter) {
+	s.container.RecoverHandler(func(panicReason any, httpWriter http.ResponseWriter) {
 		filters.LogStackOnRecover(panicReason, httpWriter)
 	})
 	if err := s.installAPIs(stopCh); err != nil {
@@ -511,12 +515,26 @@ func (s *APIServer) SetupController(
 	}).SetupWithManager(mgr, informerFactory); err != nil {
 		return err
 	}
+	backupInformer := informerFactory.Core().V1().Backups().Informer()
+	addBackupIndexErr := backupInformer.AddIndexers(clientgocache.Indexers{
+		backupcontroller.OperationNameIndex: func(raw any) ([]string, error) {
+			backup, ok := raw.(*schemecore.Backup)
+			if !ok || backup.Labels[common.LabelOperationName] == "" {
+				return nil, nil
+			}
+			return []string{backup.Labels[common.LabelOperationName]}, nil
+		},
+	})
+	if addBackupIndexErr != nil {
+		return addBackupIndexErr
+	}
 	if err = (&backupcontroller.BackupReconciler{
 		ClusterLister:   informerFactory.Core().V1().Clusters().Lister(),
 		BackupLister:    informerFactory.Core().V1().Backups().Lister(),
 		OperationLister: informerFactory.Operations().V1alpha1().Operations().Lister(),
 		OperationStore:  s.operationV2Store,
 		BackupWriter:    clusterOperator,
+		BackupIndexer:   backupInformer.GetIndexer(),
 	}).SetupWithManager(mgr, informerFactory); err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,11 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	unionauth "k8s.io/apiserver/pkg/authentication/request/union"
 	etcdRESTOptions "k8s.io/apiserver/pkg/server/options"
-	clientgocache "k8s.io/client-go/tools/cache"
 	"k8s.io/component-base/version"
-
-	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
-	schemecore "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 
 	"github.com/kubeclipper/kubeclipper/cmd/kcctl/app/options"
 	auditingv1 "github.com/kubeclipper/kubeclipper/pkg/apis/auditing/v1"
@@ -157,7 +153,7 @@ func (s *APIServer) PrepareRun(stopCh <-chan struct{}) error {
 	s.container.DoNotRecover(false)
 	s.container.Filter(filters.LogRequestAndResponse)
 	s.container.Router(restful.CurlyRouter{})
-	s.container.RecoverHandler(func(panicReason any, httpWriter http.ResponseWriter) {
+	s.container.RecoverHandler(func(panicReason interface{}, httpWriter http.ResponseWriter) {
 		filters.LogStackOnRecover(panicReason, httpWriter)
 	})
 	if err := s.installAPIs(stopCh); err != nil {
@@ -515,26 +511,12 @@ func (s *APIServer) SetupController(
 	}).SetupWithManager(mgr, informerFactory); err != nil {
 		return err
 	}
-	backupInformer := informerFactory.Core().V1().Backups().Informer()
-	addBackupIndexErr := backupInformer.AddIndexers(clientgocache.Indexers{
-		backupcontroller.OperationNameIndex: func(raw any) ([]string, error) {
-			backup, ok := raw.(*schemecore.Backup)
-			if !ok || backup.Labels[common.LabelOperationName] == "" {
-				return nil, nil
-			}
-			return []string{backup.Labels[common.LabelOperationName]}, nil
-		},
-	})
-	if addBackupIndexErr != nil {
-		return addBackupIndexErr
-	}
 	if err = (&backupcontroller.BackupReconciler{
 		ClusterLister:   informerFactory.Core().V1().Clusters().Lister(),
 		BackupLister:    informerFactory.Core().V1().Backups().Lister(),
 		OperationLister: informerFactory.Operations().V1alpha1().Operations().Lister(),
 		OperationStore:  s.operationV2Store,
 		BackupWriter:    clusterOperator,
-		BackupIndexer:   backupInformer.GetIndexer(),
 	}).SetupWithManager(mgr, informerFactory); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Operation and Backup controllers previously scanned every cached object when an Operation event needed to wake resources for the same target. This change adds informer indexes for Operation target UID and Backup operation name, then uses `ByIndex` for event fan-out.

The behavior is unchanged; only the event lookup avoids an unnecessary full lister scan as resource history grows.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

The indexes are registered during controller setup, before the shared informers start.

### Does this PR introduce a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
None
```