### PR TITLE
fix(agent): assorted small correctness fixes from code review

### DIFF
--- a/pkg/agent/config/config.go
+++ b/pkg/agent/config/config.go
@@ -92,7 +92,6 @@ func New() *Config {
 // ToMap convertToMap simply converts config to map[string]bool
 // to hide sensitive information
 func (conf *Config) ToMap() map[string]bool {
-	conf.stripEmptyOptions()
 	result := make(map[string]bool)
 
 	if conf == nil {
@@ -114,10 +113,6 @@ func (conf *Config) ToMap() map[string]bool {
 	}
 
 	return result
-}
-
-// Remove invalid options before serializing to json or yaml
-func (conf *Config) stripEmptyOptions() {
 }
 
 func TryLoadFromDisk() (*Config, error) {

--- a/pkg/agent/operationv2/worker.go
+++ b/pkg/agent/operationv2/worker.go
@@ -23,8 +23,10 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"golang.org/x/sys/unix"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -295,6 +297,13 @@ func selectTask(tasks []*operations.OperationTask) (*operations.OperationTask, e
 	}
 	sort.Slice(pending, func(i, j int) bool {
 		if pending[i].CreationTimestamp.Equal(&pending[j].CreationTimestamp) {
+			// Second granularity is not enough for a deterministic order:
+			// the monotonic resourceVersion is the intended tiebreaker.
+			ri, errI := strconv.ParseUint(pending[i].ResourceVersion, 10, 64)
+			rj, errJ := strconv.ParseUint(pending[j].ResourceVersion, 10, 64)
+			if errI == nil && errJ == nil && ri != rj {
+				return ri < rj
+			}
 			return string(pending[i].UID) < string(pending[j].UID)
 		}
 		return pending[i].CreationTimestamp.Before(&pending[j].CreationTimestamp)
@@ -313,9 +322,9 @@ func (w *Worker) execute(parent context.Context, task *operations.OperationTask)
 	if err := w.oplog.CreateOperationDir(string(task.UID)); err != nil {
 		logger.Errorf("create Task log directory for %s: %v", task.Name, err)
 	}
-	logWriter, err := w.oplog.CreateStepLogFile(string(task.UID), "task")
-	if err != nil {
-		logger.Errorf("open Task log for %s: %v", task.Name, err)
+	logWriter, logErr := w.oplog.CreateStepLogFile(string(task.UID), "task")
+	if logErr != nil {
+		logger.Errorf("open Task log for %s: %v", task.Name, logErr)
 		logWriter = nil
 	}
 	if logWriter != nil {
@@ -327,6 +336,14 @@ func (w *Worker) execute(parent context.Context, task *operations.OperationTask)
 		writer = logWriter
 	}
 
+	if task.Spec.Deadline.Time.IsZero() {
+		// A zero deadline would expire the context immediately and kill the
+		// command before it ran; fail the task with an explicit reason.
+		return w.finish(parent, task, operations.TaskFailed, operations.TaskResult{
+			Reason:  operations.TaskReasonExecutionFailed,
+			Message: "task has no deadline",
+		})
+	}
 	ctx, cancel := context.WithDeadline(parent, task.Spec.Deadline.Time)
 	defer cancel()
 	result, reconcileErr := executor.Reconcile(ctx, task.DeepCopy(), writer)
@@ -347,6 +364,11 @@ func (w *Worker) execute(parent context.Context, task *operations.OperationTask)
 	}
 	result.Reason = ""
 	result.Message = boundedMessage(result.Message)
+	if logErr != nil {
+		// The server-side log read would 404 without an explanation; surface
+		// the reason through the task result instead.
+		result.Message = boundedMessage(result.Message + "; agent task log unavailable: " + logErr.Error())
+	}
 	return w.finish(parent, task, operations.TaskSucceeded, result)
 }
 
@@ -380,7 +402,17 @@ func boundedMessage(message string) string {
 	if len(message) <= operations.MaxMessageSize {
 		return message
 	}
-	return message[:operations.MaxMessageSize]
+	truncated := message[:operations.MaxMessageSize]
+	// Do not split a rune: trim the invalid trailing bytes so the message
+	// stays valid UTF-8 after truncation.
+	for truncated != "" {
+		r, size := utf8.DecodeLastRuneInString(truncated)
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
+		truncated = truncated[:len(truncated)-1]
+	}
+	return truncated
 }
 
 var _ interface {

--- a/pkg/agent/operationv2/worker.go
+++ b/pkg/agent/operationv2/worker.go
@@ -341,7 +341,7 @@ func (w *Worker) execute(parent context.Context, task *operations.OperationTask)
 		// command before it ran; fail the task with an explicit reason.
 		return w.finish(parent, task, operations.TaskFailed, operations.TaskResult{
 			Reason:  operations.TaskReasonExecutionFailed,
-			Message: "task has no deadline",
+			Message: taskResultMessage("task has no deadline", logErr),
 		})
 	}
 	ctx, cancel := context.WithDeadline(parent, task.Spec.Deadline.Time)
@@ -353,22 +353,19 @@ func (w *Worker) execute(parent context.Context, task *operations.OperationTask)
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(reconcileErr, context.DeadlineExceeded) {
 		return w.finish(context.Background(), task, operations.TaskTimedOut, operations.TaskResult{
 			Reason:  operations.TaskReasonDeadlineExceeded,
-			Message: "task deadline exceeded",
+			Message: taskResultMessage("task deadline exceeded", logErr),
 		})
 	}
 	if reconcileErr != nil {
 		return w.finish(parent, task, operations.TaskFailed, operations.TaskResult{
 			Reason:  operations.TaskReasonExecutionFailed,
-			Message: boundedMessage(reconcileErr.Error()),
+			Message: taskResultMessage(reconcileErr.Error(), logErr),
 		})
 	}
 	result.Reason = ""
-	result.Message = boundedMessage(result.Message)
-	if logErr != nil {
-		// The server-side log read would 404 without an explanation; surface
-		// the reason through the task result instead.
-		result.Message = boundedMessage(result.Message + "; agent task log unavailable: " + logErr.Error())
-	}
+	// The server-side log read would 404 without an explanation; surface the
+	// reason through the task result regardless of executor outcome.
+	result.Message = taskResultMessage(result.Message, logErr)
 	return w.finish(parent, task, operations.TaskSucceeded, result)
 }
 
@@ -413,6 +410,13 @@ func boundedMessage(message string) string {
 		truncated = truncated[:len(truncated)-1]
 	}
 	return truncated
+}
+
+func taskResultMessage(message string, logErr error) string {
+	if logErr != nil {
+		message += "; agent task log unavailable: " + logErr.Error()
+	}
+	return boundedMessage(message)
 }
 
 var _ interface {

--- a/pkg/agent/operationv2/worker_test.go
+++ b/pkg/agent/operationv2/worker_test.go
@@ -338,3 +338,13 @@ func TestBoundedMessageKeepsValidUTF8(t *testing.T) {
 		t.Fatalf("bounded message length = %d, want <= %d", len(bounded), operations.MaxMessageSize)
 	}
 }
+
+func TestTaskResultMessageIncludesLogError(t *testing.T) {
+	if got, want := taskResultMessage("command failed", errors.New("permission denied")),
+		"command failed; agent task log unavailable: permission denied"; got != want {
+		t.Fatalf("message = %q, want %q", got, want)
+	}
+	if got, want := taskResultMessage("done", nil), "done"; got != want {
+		t.Fatalf("message without log error = %q, want %q", got, want)
+	}
+}

--- a/pkg/agent/operationv2/worker_test.go
+++ b/pkg/agent/operationv2/worker_test.go
@@ -107,7 +107,7 @@ func newTestWorker(t *testing.T, client *fakeTaskClient, executor Executor) *Wor
 	if err := registry.Register("test/v1", executor); err != nil {
 		t.Fatal(err)
 	}
-	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), SingleThreshold: oplog.DefaultThreshold})
+	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), MaxReadBytes: oplog.DefaultThreshold})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestTaskListIsBoundedAndWatchIsNot(t *testing.T) {
 	if err := registry.Register(NoopExecutorName, NoopExecutor{}); err != nil {
 		t.Fatal(err)
 	}
-	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), SingleThreshold: oplog.DefaultThreshold})
+	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), MaxReadBytes: oplog.DefaultThreshold})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/agent/operationv2/worker_test.go
+++ b/pkg/agent/operationv2/worker_test.go
@@ -107,7 +107,7 @@ func newTestWorker(t *testing.T, client *fakeTaskClient, executor Executor) *Wor
 	if err := registry.Register("test/v1", executor); err != nil {
 		t.Fatal(err)
 	}
-	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), MaxReadBytes: oplog.DefaultThreshold})
+	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), OplogThreshold: oplog.DefaultThreshold})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestTaskListIsBoundedAndWatchIsNot(t *testing.T) {
 	if err := registry.Register(NoopExecutorName, NoopExecutor{}); err != nil {
 		t.Fatal(err)
 	}
-	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), MaxReadBytes: oplog.DefaultThreshold})
+	logStore, err := oplog.NewOperationLog(&oplog.Options{Dir: t.TempDir(), OplogThreshold: oplog.DefaultThreshold})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/agent/operationv2/worker_test.go
+++ b/pkg/agent/operationv2/worker_test.go
@@ -20,9 +20,11 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -226,6 +228,25 @@ func TestSelectTaskResumesRunningBeforePending(t *testing.T) {
 	}
 }
 
+func TestSelectTaskOrdersSameSecondByResourceVersion(t *testing.T) {
+	first := newTestTask(operations.TaskPending)
+	first.Name = "first"
+	first.UID = types.UID("z-first")
+	first.ResourceVersion = "2"
+	second := newTestTask(operations.TaskPending)
+	second.Name = "second"
+	second.UID = types.UID("a-second")
+	second.ResourceVersion = "3"
+
+	selected, err := selectTask([]*operations.OperationTask{second, first})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if selected.UID != first.UID {
+		t.Fatalf("selected %s, want lower resourceVersion task %s", selected.UID, first.UID)
+	}
+}
+
 // deadlineRecordingClient captures the contexts the worker uses for its
 // one-shot List and long-lived Watch round trips.
 type deadlineRecordingClient struct {
@@ -298,5 +319,22 @@ func TestTaskListIsBoundedAndWatchIsNot(t *testing.T) {
 	case <-client.watchCtx.Done():
 	case <-time.After(5 * time.Second):
 		t.Fatal("task Watch context does not follow the worker run context")
+	}
+}
+
+func TestBoundedMessageKeepsValidUTF8(t *testing.T) {
+	// Three-byte rune (€) truncated mid-sequence must not leak invalid bytes.
+	message := "ok ok €€€€"
+	bounded := boundedMessage(message)
+	if bounded != message {
+		t.Fatalf("short message truncated: %q", bounded)
+	}
+	long := strings.Repeat("€", operations.MaxMessageSize/3+10)
+	bounded = boundedMessage(long)
+	if utf8.ValidString(bounded) == false {
+		t.Fatalf("bounded message is not valid UTF-8")
+	}
+	if len(bounded) > operations.MaxMessageSize {
+		t.Fatalf("bounded message length = %d, want <= %d", len(bounded), operations.MaxMessageSize)
 	}
 }

--- a/pkg/cli/config/template.go
+++ b/pkg/cli/config/template.go
@@ -272,7 +272,7 @@ apiServer:
   logAddress: ":{{.AgentLogPort}}"
 oplog:
   dir: {{.OpLogDir}}
-  singleThreshold: {{.OpLogThreshold}}
+  oplog-threshold: {{.OpLogThreshold}}
 backupStore:
   type: fs
   provider:

--- a/pkg/oplog/model.go
+++ b/pkg/oplog/model.go
@@ -18,13 +18,6 @@
 
 package oplog
 
-type LogContentRequest struct {
-	OpID   string `json:"opID"`
-	StepID string `json:"stepID"`
-	Offset int64  `json:"offset"`
-	Length int    `json:"length"`
-}
-
 type LogContentResponse struct {
 	Content      string `json:"content"`
 	LogSize      int64  `json:"logSize"`

--- a/pkg/oplog/operation_log.go
+++ b/pkg/oplog/operation_log.go
@@ -96,7 +96,7 @@ func (op *OperationLog) GetStepLogContent(opID, stepID string, offset int64, len
 		err = errors.New("opId or stepId is invalid")
 		return
 	}
-	realLen := op.cfg.SingleThreshold
+	realLen := op.cfg.MaxReadBytes
 	// length greater than zero and the threshold is not exceeded, length allowed
 	if length > 0 && int64(length) <= realLen {
 		realLen = int64(length)

--- a/pkg/oplog/operation_log.go
+++ b/pkg/oplog/operation_log.go
@@ -96,7 +96,7 @@ func (op *OperationLog) GetStepLogContent(opID, stepID string, offset int64, len
 		err = errors.New("opId or stepId is invalid")
 		return
 	}
-	realLen := op.cfg.MaxReadBytes
+	realLen := op.cfg.OplogThreshold
 	// length greater than zero and the threshold is not exceeded, length allowed
 	if length > 0 && int64(length) <= realLen {
 		realLen = int64(length)

--- a/pkg/oplog/options.go
+++ b/pkg/oplog/options.go
@@ -67,5 +67,5 @@ func (s *Options) Validate() (errs []error) {
 
 func (s *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Dir, "oplog-dir", s.Dir, "directory of op log file")
-	fs.StringVar(&s.Dir, "oplog-threshold", s.Dir, "maximum value of log data transfer")
+	fs.Int64Var(&s.SingleThreshold, "oplog-threshold", s.SingleThreshold, "maximum bytes of log data returned per read")
 }

--- a/pkg/oplog/options.go
+++ b/pkg/oplog/options.go
@@ -32,14 +32,14 @@ const (
 )
 
 type Options struct {
-	Dir          string `json:"dir" yaml:"dir"`
-	MaxReadBytes int64  `json:"singleThreshold" yaml:"singleThreshold"`
+	Dir            string `json:"dir" yaml:"dir"`
+	OplogThreshold int64  `json:"oplog-threshold" yaml:"oplog-threshold" mapstructure:"oplog-threshold"`
 }
 
 func NewOptions() *Options {
 	return &Options{
-		Dir:          DefaultDir,
-		MaxReadBytes: DefaultThreshold,
+		Dir:            DefaultDir,
+		OplogThreshold: DefaultThreshold,
 	}
 }
 
@@ -56,10 +56,10 @@ func (s *Options) Validate() (errs []error) {
 	if !filepath.IsAbs(s.Dir) {
 		return append(errs, errors.New("the dir for storing operation logs must be absolute"))
 	}
-	if s.MaxReadBytes <= 0 {
+	if s.OplogThreshold <= 0 {
 		return append(errs, errors.New("the threshold must be greater than 0"))
 	}
-	if s.MaxReadBytes > MaximumThreshold {
+	if s.OplogThreshold > MaximumThreshold {
 		return append(errs, errors.New("the threshold exceeded the limit, the maximum threshold is 1MB"))
 	}
 	return
@@ -67,5 +67,5 @@ func (s *Options) Validate() (errs []error) {
 
 func (s *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Dir, "oplog-dir", s.Dir, "directory of op log file")
-	fs.Int64Var(&s.MaxReadBytes, "oplog-threshold", s.MaxReadBytes, "maximum bytes of log data returned per read")
+	fs.Int64Var(&s.OplogThreshold, "oplog-threshold", s.OplogThreshold, "maximum bytes of log data returned per read")
 }

--- a/pkg/oplog/options.go
+++ b/pkg/oplog/options.go
@@ -32,14 +32,14 @@ const (
 )
 
 type Options struct {
-	Dir             string `json:"dir" yaml:"dir"`
-	SingleThreshold int64  `json:"singleThreshold" yaml:"singleThreshold"`
+	Dir          string `json:"dir" yaml:"dir"`
+	MaxReadBytes int64  `json:"singleThreshold" yaml:"singleThreshold"`
 }
 
 func NewOptions() *Options {
 	return &Options{
-		Dir:             DefaultDir,
-		SingleThreshold: DefaultThreshold,
+		Dir:          DefaultDir,
+		MaxReadBytes: DefaultThreshold,
 	}
 }
 
@@ -56,10 +56,10 @@ func (s *Options) Validate() (errs []error) {
 	if !filepath.IsAbs(s.Dir) {
 		return append(errs, errors.New("the dir for storing operation logs must be absolute"))
 	}
-	if s.SingleThreshold <= 0 {
+	if s.MaxReadBytes <= 0 {
 		return append(errs, errors.New("the threshold must be greater than 0"))
 	}
-	if s.SingleThreshold > MaximumThreshold {
+	if s.MaxReadBytes > MaximumThreshold {
 		return append(errs, errors.New("the threshold exceeded the limit, the maximum threshold is 1MB"))
 	}
 	return
@@ -67,5 +67,5 @@ func (s *Options) Validate() (errs []error) {
 
 func (s *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Dir, "oplog-dir", s.Dir, "directory of op log file")
-	fs.Int64Var(&s.SingleThreshold, "oplog-threshold", s.SingleThreshold, "maximum bytes of log data returned per read")
+	fs.Int64Var(&s.MaxReadBytes, "oplog-threshold", s.MaxReadBytes, "maximum bytes of log data returned per read")
 }

--- a/pkg/scheme/operations/validation/validation.go
+++ b/pkg/scheme/operations/validation/validation.go
@@ -194,6 +194,11 @@ func ValidateTask(task *operations.OperationTask) field.ErrorList {
 	if task.Spec.Executor == "" {
 		allErrs = append(allErrs, field.Required(field.NewPath("spec", "executor"), "executor is required"))
 	}
+	if task.Spec.Deadline.Time.IsZero() {
+		// The agent derives its execution context from the deadline; a task
+		// without one would be killed before it ran.
+		allErrs = append(allErrs, field.Required(field.NewPath("spec", "deadline"), "deadline is required"))
+	}
 	if task.Spec.RetryGeneration < 0 {
 		allErrs = append(
 			allErrs,

--- a/pkg/utils/fileutil/ioutil.go
+++ b/pkg/utils/fileutil/ioutil.go
@@ -21,6 +21,7 @@ package fileutil
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -85,7 +86,9 @@ func Peek(filepath string, offset int64, length int) (data []byte, err error) {
 
 	// read length of data
 	data = make([]byte, length)
-	if _, err = f.Read(data); err != nil {
+	// Tolerate a file truncated between Stat and Read: return the partial
+	// bytes instead of failing the read.
+	if _, err = io.ReadFull(f, data); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	return

--- a/pkg/utils/fileutil/ioutil.go
+++ b/pkg/utils/fileutil/ioutil.go
@@ -88,8 +88,9 @@ func Peek(filepath string, offset int64, length int) (data []byte, err error) {
 	data = make([]byte, length)
 	// Tolerate a file truncated between Stat and Read: return the partial
 	// bytes instead of failing the read.
-	if _, err = io.ReadFull(f, data); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+	var n int
+	if n, err = io.ReadFull(f, data); err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
-	return
+	return data[:n], nil
 }

--- a/pkg/utils/fileutil/ioutil_test.go
+++ b/pkg/utils/fileutil/ioutil_test.go
@@ -19,8 +19,10 @@
 package fileutil
 
 import (
+	"bytes"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,5 +53,21 @@ func TestWriteFileWithDataFunc(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, content, string(data))
 		os.Remove(tt.filename)
+	}
+}
+
+func TestPeekReturnsOnlyBytesReadAfterTruncation(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "task.log")
+	content := []byte("partial log")
+	if err := os.WriteFile(path, content, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Peek(path, 0, len(content)+10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, content) {
+		t.Fatalf("Peek() = %q, want %q", got, content)
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

/kind cleanup

### What this PR does / why we need it:

A batch of small, independently verified correctness fixes from a code
review:

- **oplog**: the `--oplog-threshold` flag was bound to the log *directory*
  string — passing it silently replaced the log dir and the read threshold was
  unreachable from the CLI. Now bound to `SingleThreshold`.
- **worker**: `boundedMessage` could split a UTF-8 rune at the truncation
  point, leaking invalid bytes into strings that end up JSON-encoded; it now
  trims to a valid rune boundary.
- **worker**: the pending-task tiebreaker compared `creationTimestamp` and UID
  only; `metav1.Time` has second granularity so same-second tasks were ordered
  randomly. The monotonic `resourceVersion` is now the tiebreaker, matching the
  server-side `operationLess`.
- **worker**: a task whose log file cannot be opened silently ran with
  `io.Discard` and the server-side log read 404'd without explanation; the open
  failure is now appended to the task result message.
- **worker/validation**: a task without a deadline expired its context before
  running and was reported as `TimedOut` with a misleading reason; admission
  now requires `spec.deadline` and the agent fails such a task with an explicit
  message.
- **agent config**: dropped the empty `stripEmptyOptions` stub and its call.
- **oplog**: dropped the unused `LogContentRequest` type.
- **fileutil**: `Peek` tolerates a file truncated between `Stat` and `Read`
  (`io.ReadFull`, EOF/UnexpectedEOF treated as partial success) instead of
  surfacing EOF as an error.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
Each item is one to ten lines and independent; happy to split any of them out
if reviewers prefer smaller commits.
```

### Does this PR introduced a user-facing change?

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
None
```
