### PR TITLE
fix(operationv2): avoid nil delete validation panic

### DIFF
--- a/pkg/models/operationv2/store.go
+++ b/pkg/models/operationv2/store.go
@@ -857,7 +857,15 @@ func (s *store) deleteStaleLocks(ctx context.Context, targetUID types.UID) error
 // deleteObject deletes by name and tolerates an already-deleted object, which
 // is what makes repeated cleanup calls safe.
 func (*store) deleteObject(ctx context.Context, storage rest.StandardStorage, name string) error {
-	_, _, err := storage.Delete(withNamespace(ctx), name, nil, &metav1.DeleteOptions{})
+	// The apiserver storage implementation invokes the deletion validator
+	// unconditionally, so cleanup must provide a callback even without custom
+	// validation rules for these internal objects.
+	_, _, err := storage.Delete(
+		withNamespace(ctx),
+		name,
+		func(_ context.Context, _ runtime.Object) error { return nil },
+		&metav1.DeleteOptions{},
+	)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}

--- a/pkg/models/operationv2/store_test.go
+++ b/pkg/models/operationv2/store_test.go
@@ -174,10 +174,11 @@ func TestStrongStoragesFallBackToInjected(t *testing.T) {
 // configurable list/get views so the quorum re-check can be exercised.
 type recordingDeletes struct {
 	rest.StandardStorage
-	listObj  runtime.Object
-	getObj   runtime.Object
-	deleted  []string
-	notFound map[string]bool
+	listObj              runtime.Object
+	getObj               runtime.Object
+	deleted              []string
+	notFound             map[string]bool
+	nilDeleteValidations int
 }
 
 func (r *recordingDeletes) List(_ context.Context, _ *metainternalversion.ListOptions) (runtime.Object, error) {
@@ -198,8 +199,11 @@ func (r *recordingDeletes) Get(_ context.Context, name string, _ *metav1.GetOpti
 }
 
 func (r *recordingDeletes) Delete(
-	_ context.Context, name string, _ rest.ValidateObjectFunc, _ *metav1.DeleteOptions,
+	_ context.Context, name string, validateDeletion rest.ValidateObjectFunc, _ *metav1.DeleteOptions,
 ) (runtime.Object, bool, error) {
+	if validateDeletion == nil {
+		r.nilDeleteValidations++
+	}
 	r.deleted = append(r.deleted, name)
 	return nil, true, nil
 }
@@ -310,5 +314,8 @@ func TestCleanupByTargetUIDPurgesTerminalHistoryIdempotently(t *testing.T) {
 	}
 	if len(locks.deleted) != 2 || locks.deleted[0] != "cluster-stale-lock" {
 		t.Fatalf("lock deletes = %v", locks.deleted)
+	}
+	if ops.nilDeleteValidations != 0 || tasks.nilDeleteValidations != 0 || locks.nilDeleteValidations != 0 {
+		t.Fatalf("cleanup passed nil delete validation: ops:%d tasks:%d locks:%d", ops.nilDeleteValidations, tasks.nilDeleteValidations, locks.nilDeleteValidations)
 	}
 }


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

When a cluster is deleted, Operation v2 purges terminal Operation, Task, and ExecutionLock objects through `rest.StandardStorage.Delete`. The embedded Kubernetes apiserver invokes the delete validation callback unconditionally. Passing `nil` caused a panic and left the cluster finalizer stuck in `Terminating`.

This change supplies a no-op validation callback for internal history cleanup and adds regression coverage that cleanup never passes a nil callback.

### Which issue(s) this PR fixes:

Not linked to an issue.

### Special notes for reviewers:

```
- Base: upstream/master at 0e8195358dfb5cd2a8d0767de5838d6c12f4836e.
- `go test ./pkg/models/operationv2 ./pkg/controller/clustercontroller` passed.
- All unit packages excluding environment-dependent `pkg/utils/systemctl` and `test/e2e` passed.
- `go build ./cmd/kubeclipper-server ./cmd/kubeclipper-agent ./cmd/kcctl` passed.
- The built server was deployed to sh-dev-3; a Kubernetes v1.37.0 cluster reached Running with a Ready node, and deletion cleanup completed with zero post-restart panic.
```

### Does this PR introduced a user-facing change?

<!-- This fixes a user-visible cluster deletion failure. -->

```release-note
Bug fix: prevent cluster deletion from remaining in Terminating when operation history cleanup runs.
```

### Additional documentation, usage docs, etc.:

```docs
```
