### PR TITLE
fix(agent): make Kubernetes process cleanup idempotent

### DIFF
--- a/pkg/scheme/core/v1/k8s/kubeadm.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm.go
@@ -573,18 +573,15 @@ func getProcessID(ctx context.Context, dryRun bool) ([]string, error) {
 	processes := []string{"kube-proxy", "kube-apiserver", "kube-controller", "kube-scheduler", "containerd-shim", "etcd"}
 
 	for _, process := range processes {
+		command := "ps -ef | grep " + process + " | grep -v grep | awk '{print $2}'"
 		if strings.Contains(process, "etcd") {
-			ec, err = cmdutil.RunCmdWithContext(ctx, dryRun, "/bin/bash", "-c", "ps -ef | grep "+process+" | grep -v grep | grep -v \"/usr\" | awk '{print $2}'")
-			if err != nil {
-				logger.Error("run ps -ef error", zap.Error(err))
-				return pids, err
-			}
-		} else {
-			ec, err = cmdutil.RunCmdWithContext(ctx, dryRun, "/bin/bash", "-c", "ps -ef | grep "+process+" | grep -v grep | awk '{print $2}'")
-			if err != nil {
-				logger.Error("run ps -ef error", zap.Error(err))
-				return pids, err
-			}
+			command = "ps -ef | grep -E \"[[:space:]]" + process +
+				"([[:space:]]|$)\" | grep -v grep | grep -v \"/usr\" | awk '{print $2}'"
+		}
+		ec, err = cmdutil.RunCmdWithContext(ctx, dryRun, "/bin/bash", "-c", command)
+		if err != nil {
+			logger.Error("run ps -ef error", zap.Error(err))
+			return pids, err
 		}
 		if ec.StdOut() != "" {
 			p := strings.Split(ec.StdOut(), "\n")
@@ -597,13 +594,31 @@ func getProcessID(ctx context.Context, dryRun bool) ([]string, error) {
 		}
 	}
 
-	return pids, nil
+	return deduplicateProcessIDs(pids), nil
+}
+
+func deduplicateProcessIDs(pids []string) []string {
+	result := make([]string, 0, len(pids))
+	seen := make(map[string]struct{}, len(pids))
+	for _, pid := range pids {
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		result = append(result, pid)
+	}
+	return result
 }
 
 func killProcess(ctx context.Context, dryRun bool, pids []string) error {
-	for _, pid := range pids {
-		_, err := cmdutil.RunCmdWithContext(ctx, dryRun, "kill", "-9", pid)
+	for _, pid := range deduplicateProcessIDs(pids) {
+		ec, err := cmdutil.RunCmdWithContext(ctx, dryRun, "kill", "-9", pid)
 		if err != nil {
+			// A process can exit between ps and kill. That is already the
+			// desired state for cleanup, so do not fail the whole operation.
+			if ec != nil && strings.Contains(ec.StdErr(), "No such process") {
+				continue
+			}
 			logger.Error("kill the process error", zap.Error(err))
 			return err
 		}

--- a/pkg/scheme/core/v1/k8s/kubeadm_test.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_test.go
@@ -86,6 +86,19 @@ func TestKubeadmResetIsSafeWhenKubeadmIsAbsent(t *testing.T) {
 	}
 }
 
+func TestDeduplicateProcessIDs(t *testing.T) {
+	got := deduplicateProcessIDs([]string{"101", "202", "101", "303", "202"})
+	want := []string{"101", "202", "303"}
+	if len(got) != len(want) {
+		t.Fatalf("deduplicateProcessIDs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("deduplicateProcessIDs() = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestRemoveDummyInterfaceIsSafeWhenInterfaceIsAbsent(t *testing.T) {
 	steps, err := (&Health{}).UninstallSteps(&v1.Networking{ProxyMode: "ipvs"}, v1.StepNode{ID: "node-1"})
 	if err != nil {


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

Make Kubernetes control-plane process cleanup idempotent during cluster deletion. Match the standalone etcd process name instead of matching kube-apiserver arguments containing `--etcd-*`, deduplicate discovered PIDs, and tolerate a process exiting between discovery and `kill -9`.

Without this fix, the same kube-apiserver PID can be discovered twice. The second `kill -9` returns `No such process`, causing the cleanup task and DeleteCluster operation to fail and leaving the cluster in `TerminateFailed`.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

- Based on the current upstream/master.
- Validated with `go test ./pkg/agent/operationv2 ./pkg/controller/operationv2 ./pkg/scheme/core/v1/k8s ./pkg/utils/cmdutil`.
- Runtime-validated on sh-dev-3 with Kubernetes v1.37.0: normal deletion completed after retry with the fix, and recreating the same cluster succeeded.

### Does this PR introduced a user-facing change?

```release-note
Fix Kubernetes process cleanup so duplicate or already-exited PIDs do not fail cluster deletion.
```

### Additional documentation, usage docs, etc.:

```docs
```