### PR TITLE
chore: prepare v1.7.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ KubeClipper has passed the [CNCF Kubernetes Conformance Certification](https://w
 
 | Kubernetes | Calico | Containerd |
 |------------|--------|------------|
-| v1.36.1 (default) | v3.31.5 | v2.2.4 |
+| v1.37.0 (default) | v3.31.5 | v2.2.4 |
+| v1.36.1 | v3.31.5 | v2.2.4 |
 | v1.35.0 | v3.29.6 | v1.7.29 |
-| v1.34.2 | v3.29.6 | v1.7.29 |
 
 ## Roadmap & Todo list
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -89,9 +89,9 @@ KubeClipper 已通过 [CNCF Kubernetes 一致性认证](https://www.cncf.io/cert
 
 | Kubernetes | Calico | Containerd |
 |------------|--------|------------|
-| v1.36.1 (默认) | v3.31.5 | v2.2.4 |
+| v1.37.0 (默认) | v3.31.5 | v2.2.4 |
+| v1.36.1 | v3.31.5 | v2.2.4 |
 | v1.35.0 | v3.29.6 | v1.7.29 |
-| v1.34.2 | v3.29.6 | v1.7.29 |
 
 ## Roadmap & Todo list
 

--- a/pkg/cli/deploy/deploy.go
+++ b/pkg/cli/deploy/deploy.go
@@ -239,7 +239,7 @@ func (d *DeployOptions) Complete() error {
 		if v == "" {
 			v, ok = strutil.ParseGitDescribeInfo(version.Get().GitVersion)
 			if !ok {
-				v = "v1.6.0"
+				v = "v1.7.0"
 			}
 		}
 		d.deployConfig.Pkg = fmt.Sprintf(defaultPkg, v, runtime.GOARCH)

--- a/scripts/get-kubeclipper.sh
+++ b/scripts/get-kubeclipper.sh
@@ -50,7 +50,7 @@ DOWNLOAD_URL="${OSS_ENDPOINT}/kc"
 BIN_DIR="/usr/local/bin"
 
 if [[ -z "${KC_VERSION}" ]]; then
-  KC_VERSION="v1.6.0"
+  KC_VERSION="v1.7.0"
 fi
 info "The ${KC_VERSION} version will be installed"
 


### PR DESCRIPTION
### What type of PR is this?
/kind cleanup
/kind documentation

### What this PR does / why we need it:
- Bumps the default installer and deployment fallback to v1.7.0.
- Documents v1.37.0 as the default Kubernetes version and keeps the latest three supported versions (v1.37.0, v1.36.1, v1.35.0).
- This PR is based on upstream master and intentionally excludes OCI release work.

### Which issue(s) this PR fixes:
None

### Special notes for reviewers:

- Base commit: `a30e4114`.
- Validation: `go test -race ./pkg/cli/deploy`; `golangci-lint run`.
- The existing OCI changes in the local feature worktree are not included.

### Does this PR introduced a user-facing change?
```release-note
Update the default KubeClipper release to v1.7.0 and document Kubernetes v1.37.0 support.
```

### Additional documentation, usage docs, etc.:
None