### PR TITLE
docs: update v1.7 supported Kubernetes versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ KubeClipper has passed the [CNCF Kubernetes Conformance Certification](https://w
 | Kubernetes | Calico | Containerd |
 |------------|--------|------------|
 | v1.37.0 (default) | v3.31.5 | v2.2.4 |
-| v1.36.1 | v3.31.5 | v2.2.4 |
-| v1.35.0 | v3.29.6 | v1.7.29 |
+| v1.36.4 | v3.31.5 | v2.2.4 |
+| v1.35.8 | v3.31.5 | v2.2.4 |
 
 ## Roadmap & Todo list
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -90,8 +90,8 @@ KubeClipper 已通过 [CNCF Kubernetes 一致性认证](https://www.cncf.io/cert
 | Kubernetes | Calico | Containerd |
 |------------|--------|------------|
 | v1.37.0 (默认) | v3.31.5 | v2.2.4 |
-| v1.36.1 | v3.31.5 | v2.2.4 |
-| v1.35.0 | v3.29.6 | v1.7.29 |
+| v1.36.4 | v3.31.5 | v2.2.4 |
+| v1.35.8 | v3.31.5 | v2.2.4 |
 
 ## Roadmap & Todo list
 


### PR DESCRIPTION
### What type of PR is this?

/kind documentation

### What this PR does / why we need it:

Align the English and Chinese supported-version tables with the v1.7 release package matrix:
- Kubernetes v1.37.0 (default), v1.36.4, and v1.35.8
- containerd 2.2.4
- Calico v3.31.5

### Which issue(s) this PR fixes:

None.

### Special notes for reviewers:

This changes only the classic v1.7 release documentation. OCI configuration and workflows are not changed.

### Does this PR introduced a user-facing change?

No functional behavior change.

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
README.md and README_zh.md
```