### PR TITLE
fix(release): use resolved ref for OSS uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,10 @@ jobs:
           #sts-token: "sts_token"
       - name: Upload to oss
         run: |
-          ossutil cp -rf dist/kc-linux-arm64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.version }}/
-          ossutil cp -rf dist/kc-linux-amd64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.version }}/
-          ossutil cp -rf dist/kc-darwin-amd64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.version }}/
-          ossutil cp -rf dist/kc-darwin-arm64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.version }}/
+          ossutil cp -rf dist/kc-linux-arm64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.branch }}/
+          ossutil cp -rf dist/kc-linux-amd64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.branch }}/
+          ossutil cp -rf dist/kc-darwin-amd64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.branch }}/
+          ossutil cp -rf dist/kc-darwin-arm64.tar.gz oss://${{ secrets.OSS_BUCKET }}/kc/${{ steps.extract_branch.outputs.branch }}/
 
       - name: Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
### What type of PR is this?

/kind bug

### What this PR does / why we need it:

Fix the classic release workflow to use the ref output that the extraction step actually publishes. This keeps tag-triggered OSS uploads under the expected version path instead of an empty path.

### Which issue(s) this PR fixes:

None.

### Special notes for reviewers:

This changes only `.github/workflows/release.yml`. OCI workflows and packaging configuration are not changed.

### Does this PR introduced a user-facing change?

No direct CLI behavior change; release artifacts are uploaded to the correct OSS path.

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
None
```