### PR TITLE
ci(release): create prerelease releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
             dist/kc-linux-amd64.tar.gz
             dist/kc-darwin-amd64.tar.gz
             dist/kc-darwin-arm64.tar.gz
+          prerelease: true
           # note you'll typically need to create a personal access token
           # with permissions to create releases in the other repo
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
/kind cleanup

### What this PR does / why we need it:

Set `prerelease: true` for the KC GitHub release workflow so tag-triggered releases remain prereleases until the release is manually promoted.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

The current release workflow only changes the GitHub Release status; OSS upload paths and release assets are unchanged.

### Does this PR introduced a user-facing change?

None

```release-note
None
```

### Additional documentation, usage docs, etc.:

```docs
```