### PR TITLE
fix: preserve component image registry defaults

### DIFF
--- a/pkg/component/utils/utils.go
+++ b/pkg/component/utils/utils.go
@@ -194,15 +194,17 @@ func GetClusterCRIRegistriesForMode(ctx context.Context, c *v1.Cluster, offline 
 	return registries, nil
 }
 
-// ResolveClusterImageRegistry returns the registry used to pull cluster images.
-// Offline clusters without an image registry load packaged images on each node.
+// ResolveClusterImageRegistry resolves only an explicitly selected registry.
+// Component-specific defaults are applied later when the cluster steps render.
 func ResolveClusterImageRegistry(ctx context.Context, c *v1.Cluster, op cluster.Operator) (v1.RegistrySpec, error) {
 	return ResolveImageRegistryForMode(ctx, c.Offline(), c.ImageRegistry, op)
 }
 
-// ResolveImageRegistryForMode returns an empty registry only for offline local-image mode.
-func ResolveImageRegistryForMode(ctx context.Context, offline bool, name string, op cluster.Operator) (v1.RegistrySpec, error) {
-	if offline && strings.TrimSpace(name) == "" {
+// ResolveImageRegistryForMode returns an empty registry when no registry resource
+// is explicitly selected. Online components apply their own defaults, including
+// the configured agent-side image repository mirror.
+func ResolveImageRegistryForMode(ctx context.Context, _ bool, name string, op cluster.Operator) (v1.RegistrySpec, error) {
+	if strings.TrimSpace(name) == "" {
 		return v1.RegistrySpec{}, nil
 	}
 	return ResolveImageRegistry(ctx, name, op)

--- a/pkg/component/utils/utils_test.go
+++ b/pkg/component/utils/utils_test.go
@@ -32,13 +32,13 @@ import (
 )
 
 func TestResolveClusterImageRegistry(t *testing.T) {
-	t.Run("online cluster uses default registry", func(t *testing.T) {
+	t.Run("online cluster without registry uses component defaults", func(t *testing.T) {
 		registry, err := ResolveClusterImageRegistry(context.Background(), &v1.Cluster{}, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if registry.Host != v1.DefaultImageRegistry {
-			t.Fatalf("registry host = %q, want %q", registry.Host, v1.DefaultImageRegistry)
+		if registry.Host != "" {
+			t.Fatalf("registry host = %q, want empty", registry.Host)
 		}
 	})
 
@@ -54,6 +54,16 @@ func TestResolveClusterImageRegistry(t *testing.T) {
 	})
 }
 
+func TestResolveImageRegistryDefaultsToKubernetesRegistry(t *testing.T) {
+	registry, err := ResolveImageRegistry(context.Background(), "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if registry.Host != v1.DefaultImageRegistry {
+		t.Fatalf("registry host = %q, want %q", registry.Host, v1.DefaultImageRegistry)
+	}
+}
+
 func TestGetClusterCRIRegistriesUsesLocalImagesForOfflineClusterWithoutRegistry(t *testing.T) {
 	cluster := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{common.AnnotationOffline: "true"}}}
 	registries, err := GetClusterCRIRegistriesWithContext(context.Background(), cluster, nil)
@@ -65,6 +75,16 @@ func TestGetClusterCRIRegistriesUsesLocalImagesForOfflineClusterWithoutRegistry(
 	}
 	if cluster.ResolvedImageRegistry != "" {
 		t.Fatalf("resolved image registry = %q, want empty", cluster.ResolvedImageRegistry)
+	}
+}
+
+func TestGetClusterCRIRegistriesLeavesOnlineDefaultToComponent(t *testing.T) {
+	registries, err := GetClusterCRIRegistriesWithContext(context.Background(), &v1.Cluster{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(registries) != 0 {
+		t.Fatalf("registries = %#v, want none", registries)
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips:

1. If you want **faster** PR reviews, read how: https://github.com/kubeclipper/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how you got reviewed, read: https://github.com/kubeclipper/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding conventions followed by KubeClipper community: https://github.com/kubeclipper/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?

/kind bug

### What this PR does / why we need it:

When a cluster does not explicitly select an `ImageRegistry`, keep the cluster-level registry empty and let each component apply its own default. This allows the Agent's configured image mirror to be used for Kubernetes/containerd images without forcing Calico to inherit `registry.k8s.io`.

The direct registry resolver keeps its existing Kubernetes default for callers that use it explicitly. Tests cover both behaviors and the online CRI registry path.

### Which issue(s) this PR fixes:

Not linked.

### Special notes for reviewers:

- `go test ./pkg/component/utils` passed.
- `go test ./pkg/scheme/core/v1/k8s ./pkg/scheme/core/v1/cri ./pkg/scheme/core/v1/cni` passed.
- `golangci-lint run ./pkg/component/utils/...` reported 0 issues.
- On `sh-dev-3`, the local Linux amd64 binaries generated `imageRepository: registry.aliyuncs.com/google_containers` in kubeadm configuration and `registry.aliyuncs.com/google_containers/pause:3.10.2` in containerd when the Agent mirror was configured. Full cluster readiness was delayed by the first pull of `quay.io/calico/node:v3.31.5`.

### Does this PR introduced a user-facing change?

```release-note
When no ImageRegistry is configured, Kubernetes components use their component-specific defaults and the configured Agent image mirror; Calico keeps its native image registry defaults.
```

### Additional documentation, usage docs, etc.:

```docs
```
