### PR TITLE
fix: restore terminal access for operation v2 clusters

### DIFF
--- a/pkg/apis/config/v1/handler.go
+++ b/pkg/apis/config/v1/handler.go
@@ -19,6 +19,9 @@
 package v1
 
 import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 
@@ -153,7 +156,7 @@ func (h *handler) GetSSHRSAKey(req *restful.Request, resp *restful.Response) {
 		}
 		_, err = h.platformOperator.CreatePlatformSetting(req.Request.Context(), setting)
 	} else {
-		if setting.Terminal.PrivateKey == "" {
+		if !hasSecureWebTerminalKey(setting.Terminal) {
 			setting.Terminal, err = generateWebTerminal()
 			if err != nil {
 				restplus.HandleInternalError(resp, req, err)
@@ -177,7 +180,7 @@ func (h *handler) CreateSSHRSAKey(req *restful.Request, resp *restful.Response) 
 		restplus.HandleInternalError(resp, req, err)
 		return
 	}
-	t.PrivateKey, t.PublicKey, err = certs.GetSSHKeyPair(512)
+	t.PrivateKey, t.PublicKey, err = certs.GetSSHKeyPair(certs.DefaultRSAKeySize)
 	if err != nil {
 		restplus.HandleInternalError(resp, req, err)
 		return
@@ -192,7 +195,7 @@ func (h *handler) CreateSSHRSAKey(req *restful.Request, resp *restful.Response) 
 }
 
 func generateWebTerminal() (v1.WebTerminal, error) {
-	priv, pub, err := certs.GetSSHKeyPair(512)
+	priv, pub, err := certs.GetSSHKeyPair(certs.DefaultRSAKeySize)
 	if err != nil {
 		return v1.WebTerminal{}, err
 	}
@@ -201,6 +204,22 @@ func generateWebTerminal() (v1.WebTerminal, error) {
 		PublicKey:  pub,
 	}, nil
 
+}
+
+func hasSecureWebTerminalKey(terminal v1.WebTerminal) bool {
+	if terminal.PrivateKey == "" || terminal.PublicKey == "" {
+		return false
+	}
+	privateKeyPEM, err := base64.StdEncoding.DecodeString(terminal.PrivateKey)
+	if err != nil {
+		return false
+	}
+	block, _ := pem.Decode(privateKeyPEM)
+	if block == nil {
+		return false
+	}
+	privateKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	return err == nil && privateKey.N.BitLen() >= certs.DefaultRSAKeySize
 }
 
 func generatePlatformSetting() *v1.PlatformSetting {

--- a/pkg/apis/config/v1/handler_test.go
+++ b/pkg/apis/config/v1/handler_test.go
@@ -1,0 +1,26 @@
+package v1
+
+import (
+	"testing"
+
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	"github.com/kubeclipper/kubeclipper/pkg/utils/certs"
+)
+
+func TestHasSecureWebTerminalKey(t *testing.T) {
+	weakPrivate, weakPublic, err := certs.GetSSHKeyPair(1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasSecureWebTerminalKey(corev1.WebTerminal{PrivateKey: weakPrivate, PublicKey: weakPublic}) {
+		t.Fatal("key smaller than 2048 bits must be rejected")
+	}
+
+	privateKey, publicKey, err := certs.GetSSHKeyPair(certs.DefaultRSAKeySize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasSecureWebTerminalKey(corev1.WebTerminal{PrivateKey: privateKey, PublicKey: publicKey}) {
+		t.Fatal("2048-bit web terminal key must be accepted")
+	}
+}

--- a/pkg/auditing/audit.go
+++ b/pkg/auditing/audit.go
@@ -211,7 +211,7 @@ func (a *auditing) LogRequestObject(req *http.Request, info *request.Info) *audi
 					e.User.Username = obj.Username
 				}
 			} else {
-				e.RequestObject = &runtime.Unknown{Raw: body}
+				e.RequestObject = &runtime.Unknown{Raw: redactAuditObject(body, info.Resource)}
 			}
 		}
 
@@ -229,9 +229,56 @@ func (a *auditing) LogResponseObject(e *audit.Event, resp *ResponseCapture) {
 	e.StageTimestamp = metav1.NowMicro()
 	e.ResponseStatus = &metav1.Status{Code: int32(resp.StatusCode())}
 	if e.Level.GreaterOrEqual(audit.LevelRequestResponse) {
-		e.ResponseObject = &runtime.Unknown{Raw: resp.Bytes()}
+		resource := ""
+		if e.ObjectRef != nil {
+			resource = e.ObjectRef.Resource
+		}
+		e.ResponseObject = &runtime.Unknown{Raw: redactAuditObject(resp.Bytes(), resource)}
 	}
 	a.sendEvent(e)
+}
+
+const redactedAuditValue = "[REDACTED]"
+
+// redactAuditObject returns a copy of an API object that is safe to retain in
+// an audit event. Operation task outputs can contain controller-only data, and
+// Cluster.KubeConfig contains a service account credential. Neither belongs in
+// the audit log.
+func redactAuditObject(raw []byte, resource string) []byte {
+	var object any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		return raw
+	}
+	redactAuditFields(object, resource)
+	redacted, err := json.Marshal(object)
+	if err != nil {
+		return raw
+	}
+	return redacted
+}
+
+func redactAuditFields(value any, resource string) {
+	switch object := value.(type) {
+	case map[string]any:
+		for key, child := range object {
+			switch key {
+			case "kubeConfig", "privateKey":
+				object[key] = redactedAuditValue
+			case "outputs":
+				if resource == "operationtasks" {
+					object[key] = redactedAuditValue
+					continue
+				}
+				redactAuditFields(child, resource)
+			default:
+				redactAuditFields(child, resource)
+			}
+		}
+	case []any:
+		for _, child := range object {
+			redactAuditFields(child, resource)
+		}
+	}
 }
 
 func (a *auditing) sendEvent(e *audit.Event) {

--- a/pkg/auditing/audit_test.go
+++ b/pkg/auditing/audit_test.go
@@ -209,3 +209,45 @@ func Test_auditing_LogResponseObject(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactAuditObject(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		body     string
+		secrets  []string
+	}{
+		{
+			name:     "operation task outputs",
+			resource: "operationtasks",
+			body:     `{"status":{"result":{"outputs":{"response":"task-secret"}}}}`,
+			secrets:  []string{"task-secret"},
+		},
+		{
+			name:     "cluster kubeconfig",
+			resource: "clusters",
+			body:     `{"kubeConfig":"cluster-credential"}`,
+			secrets:  []string{"cluster-credential"},
+		},
+		{
+			name:     "terminal private key",
+			resource: "platformsettings",
+			body:     `{"terminal":{"privateKey":"private-key"}}`,
+			secrets:  []string{"private-key"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			redacted := string(redactAuditObject([]byte(tt.body), tt.resource))
+			for _, secret := range tt.secrets {
+				if bytes.Contains([]byte(redacted), []byte(secret)) {
+					t.Fatalf("audit body exposes %q: %s", secret, redacted)
+				}
+			}
+			if !bytes.Contains([]byte(redacted), []byte(redactedAuditValue)) {
+				t.Fatalf("audit body was not redacted: %s", redacted)
+			}
+		})
+	}
+}

--- a/pkg/controller/clustercontroller/controller.go
+++ b/pkg/controller/clustercontroller/controller.go
@@ -20,6 +20,7 @@ package clustercontroller
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"sort"
@@ -60,6 +61,7 @@ import (
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 	v1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/cri"
+	k8s "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1/k8s"
 	operationsv1alpha1 "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
 
 	ctrl "github.com/kubeclipper/kubeclipper/pkg/controller-runtime"
@@ -78,6 +80,11 @@ type ClusterReconciler struct {
 	CronBackupWriter    cluster.CronBackupWriter
 	CloudProviderLister listerv1.CloudProviderLister
 }
+
+const (
+	kubeConfigSyncOperationTimeoutSecs = "120"
+	kubeConfigAuthCheckTimeout         = 5 * time.Second
+)
 
 func (r *ClusterReconciler) SetupWithManager(mgr manager.Manager, cache informers.InformerCache) error {
 	c, err := controller.NewUnmanaged("cluster", controller.Options{
@@ -384,6 +391,9 @@ func (r *ClusterReconciler) getKubeconfigFromProvider(c *v1.Cluster) (string, er
 // clientset need local lb
 func (r *ClusterReconciler) getKubeConfig(ctx context.Context, c *v1.Cluster) (string, error) {
 	log := logger.FromContext(ctx)
+	if len(c.Masters) == 0 {
+		return "", fmt.Errorf("cluster %q has no master node", c.Name)
+	}
 
 	node, err := r.NodeLister.Get(c.Masters[0].ID)
 	if err != nil {
@@ -404,10 +414,105 @@ func (r *ClusterReconciler) getKubeConfig(ctx context.Context, c *v1.Cluster) (s
 		return "", nil
 	}
 
-	if len(c.KubeConfig) == 0 {
+	if len(c.KubeConfig) != 0 {
+		valid, validationErr := kubeConfigCredentialValid(ctx, c.KubeConfig)
+		if validationErr != nil {
+			return "", validationErr
+		}
+		if valid {
+			return string(c.KubeConfig), nil
+		}
+	}
+
+	operationName := kubeConfigSyncOperationName(c.UID, c.KubeConfig)
+	op, err := r.OperationStore.GetOperation(ctx, operationName, "")
+	if errors.IsNotFound(err) {
+		if createErr := r.createKubeConfigSyncOperation(ctx, c, operationName); createErr != nil {
+			return "", createErr
+		}
 		return "", nil
 	}
-	return string(c.KubeConfig), nil
+	if err != nil {
+		return "", fmt.Errorf("get kubeconfig sync operation: %w", err)
+	}
+	if op.Status.Phase != operationsv1alpha1.OperationSucceeded {
+		return "", fmt.Errorf("kubeconfig sync operation %q finished with phase %q", operationName, op.Status.Phase)
+	}
+	tasks, err := r.OperationStore.ListTasksByOperationUID(ctx, op.UID, "")
+	if err != nil {
+		return "", fmt.Errorf("list kubeconfig sync tasks: %w", err)
+	}
+	token, err := kubeConfigTokenFromTasks(tasks.Items)
+	if err != nil {
+		return "", err
+	}
+	return getKubeConfig(c.Name, fmt.Sprintf("https://%s", apiServer), "kc-server", token), nil
+}
+
+func kubeConfigSyncOperationName(clusterUID types.UID, kubeconfig []byte) string {
+	if len(kubeconfig) == 0 {
+		return fmt.Sprintf("sync-kubeconfig-%s", clusterUID)
+	}
+	sum := sha256.Sum256(kubeconfig)
+	return fmt.Sprintf("sync-kubeconfig-%s-%x", clusterUID, sum[:6])
+}
+
+func kubeConfigCredentialValid(ctx context.Context, kubeconfig []byte) (bool, error) {
+	clientConfig, err := clientcmd.NewClientConfigFromBytes(kubeconfig)
+	if err != nil {
+		// A malformed stored kubeconfig cannot authenticate and should be replaced.
+		return false, nil
+	}
+	config, err := clientConfig.ClientConfig()
+	if err != nil {
+		return false, nil
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return false, nil
+	}
+	checkCtx, cancel := context.WithTimeout(ctx, kubeConfigAuthCheckTimeout)
+	defer cancel()
+	if _, err = clientset.CoreV1().Pods("kube-system").List(checkCtx, metav1.ListOptions{Limit: 1}); err == nil {
+		return true, nil
+	}
+	if errors.IsUnauthorized(err) {
+		return false, nil
+	}
+	return false, fmt.Errorf("check stored kubeconfig: %w", err)
+}
+
+func (r *ClusterReconciler) createKubeConfigSyncOperation(ctx context.Context, c *v1.Cluster, name string) error {
+	plan := &v1.Operation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				common.LabelClusterName:     c.Name,
+				common.LabelOperationAction: v1.OperationSyncKubeConfig,
+				common.LabelTimeoutSeconds:  kubeConfigSyncOperationTimeoutSecs,
+			},
+		},
+		Steps: []v1.Step{k8s.ClusterAccessStep([]v1.StepNode{{ID: c.Masters[0].ID}})},
+	}
+	_, err := operationv2builder.CreateFromCore(ctx, r.OperationStore, r.ClusterOperator, c, plan)
+	if errors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+func kubeConfigTokenFromTasks(tasks []operationsv1alpha1.OperationTask) (string, error) {
+	for index := range tasks {
+		task := &tasks[index]
+		if task.Spec.StepID != k8s.ClusterAccessStepID || task.Status.Phase != operationsv1alpha1.TaskSucceeded || task.Status.Result == nil {
+			continue
+		}
+		token := strings.TrimSpace(task.Status.Result.Outputs["response"])
+		if token != "" {
+			return token, nil
+		}
+	}
+	return "", fmt.Errorf("kubeconfig sync operation completed without a service account token")
 }
 
 func (r *ClusterReconciler) updateCRIRegistries(ctx context.Context, c *v1.Cluster) error {

--- a/pkg/controller/clustercontroller/controller_test.go
+++ b/pkg/controller/clustercontroller/controller_test.go
@@ -58,6 +58,47 @@ func TestFindOperationCluster(t *testing.T) {
 	}
 }
 
+func TestKubeConfigTokenFromTasks(t *testing.T) {
+	tasks := []operations.OperationTask{
+		{
+			Spec:   operations.OperationTaskSpec{StepID: "another-step"},
+			Status: operations.OperationTaskStatus{Phase: operations.TaskSucceeded},
+		},
+		{
+			Spec: operations.OperationTaskSpec{StepID: "capture-cluster-access"},
+			Status: operations.OperationTaskStatus{
+				Phase:  operations.TaskSucceeded,
+				Result: &operations.TaskResult{Outputs: map[string]string{"response": " cluster-token\n"}},
+			},
+		},
+	}
+	token, err := kubeConfigTokenFromTasks(tasks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if token != "cluster-token" {
+		t.Fatalf("token = %q, want cluster-token", token)
+	}
+	if _, err := kubeConfigTokenFromTasks(nil); err == nil {
+		t.Fatal("missing task output must fail")
+	}
+}
+
+func TestKubeConfigSyncOperationName(t *testing.T) {
+	uid := types.UID("f1a8e6a3-9b05-40a7-9ddc-f5580c33fe88")
+	if got, want := kubeConfigSyncOperationName(uid, nil), "sync-kubeconfig-f1a8e6a3-9b05-40a7-9ddc-f5580c33fe88"; got != want {
+		t.Fatalf("empty kubeconfig operation name = %q, want %q", got, want)
+	}
+	first := kubeConfigSyncOperationName(uid, []byte("old-kubeconfig"))
+	second := kubeConfigSyncOperationName(uid, []byte("old-kubeconfig"))
+	if first != second {
+		t.Fatalf("operation name must be stable: %q != %q", first, second)
+	}
+	if first == kubeConfigSyncOperationName(uid, []byte("new-kubeconfig")) {
+		t.Fatal("operation name must change when the stored kubeconfig changes")
+	}
+}
+
 func TestFinalizeClusterCleansOperationHistoryBeforeReleasingFinalizer(t *testing.T) {
 	clusterObject := &v1.Cluster{ObjectMeta: metav1.ObjectMeta{
 		Name:       "cluster-a",

--- a/pkg/controller/operationv2/business.go
+++ b/pkg/controller/operationv2/business.go
@@ -53,6 +53,9 @@ func (r *BusinessReconciler) Reconcile(ctx context.Context, request ctrl.Request
 	if op.Status.Phase == operations.OperationSucceeded {
 		desired = corev1.ClusterRunning
 	}
+	if op.Spec.Action == corev1.OperationSyncKubeConfig {
+		return ctrl.Result{}, nil
+	}
 	if clusterObject.Status.Phase == desired &&
 		(op.Spec.Action != corev1.OperationUpgradeCluster || op.Status.Phase != operations.OperationSucceeded) {
 		return ctrl.Result{}, nil

--- a/pkg/scheme/core/v1/k8s/kubeadm.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm.go
@@ -75,6 +75,10 @@ func init() {
 	if err := component.RegisterAgentStep(fmt.Sprintf(component.RegisterStepKeyFormat, health, version, component.TypeStep), &Health{}); err != nil {
 		panic(err)
 	}
+	clusterAccessKey := fmt.Sprintf(component.RegisterStepKeyFormat, clusterAccess, version, component.TypeStep)
+	if err := component.RegisterAgentStep(clusterAccessKey, &KubeConfigToken{}); err != nil {
+		panic(err)
+	}
 	if err := component.RegisterAgentStep(
 		fmt.Sprintf(component.RegisterStepKeyFormat, addedNodesReady, version, component.TypeStep),
 		&AddedNodesReady{},
@@ -106,6 +110,7 @@ var (
 	_ component.StepRunnable   = (*ClusterNode)(nil)
 	_ component.TemplateRender = (*KubectlTerminal)(nil)
 	_ component.StepRunnable   = (*Health)(nil)
+	_ component.StepRunnable   = (*KubeConfigToken)(nil)
 	_ component.StepRunnable   = (*AddedNodesReady)(nil)
 	_ component.StepRunnable   = (*Container)(nil)
 	_ component.StepRunnable   = (*Kubectl)(nil)
@@ -169,6 +174,11 @@ type Health struct {
 	KubernetesVersion string
 	*kubernetes.Clientset
 }
+
+// KubeConfigToken returns the credential used by kc-server to access a
+// KubeClipper-managed Kubernetes cluster. It is only scheduled by the
+// cluster controller after the cluster's ServiceAccount has been created.
+type KubeConfigToken struct{}
 
 // AddedNodesReady waits until the API server reports every node added by the
 // current operation as Ready. It intentionally does not evaluate unrelated
@@ -895,6 +905,37 @@ func (stepper *Health) Install(ctx context.Context, opts component.Options) (b [
 	}
 
 	return
+}
+
+func (*KubeConfigToken) NewInstance() component.ObjectMeta {
+	return &KubeConfigToken{}
+}
+
+func (*KubeConfigToken) Install(ctx context.Context, _ component.Options) ([]byte, error) {
+	clientset, err := utils.BuildKubeClientset(DefaultKubeConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("build kube clientset: %w", err)
+	}
+	secret, err := clientset.CoreV1().Secrets("kube-system").Get(ctx, "kc-server-secret", metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get kc-server ServiceAccount secret: %w", err)
+	}
+	return kubeConfigTokenFromSecret(secret)
+}
+
+func kubeConfigTokenFromSecret(secret *corev1.Secret) ([]byte, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("kc-server ServiceAccount secret is nil")
+	}
+	token := secret.Data["token"]
+	if len(token) == 0 {
+		return nil, fmt.Errorf("kc-server ServiceAccount token is empty")
+	}
+	return token, nil
+}
+
+func (*KubeConfigToken) Uninstall(context.Context, component.Options) ([]byte, error) {
+	return nil, fmt.Errorf("KubeConfigToken does not support uninstall")
 }
 
 func (stepper *Health) Uninstall(ctx context.Context, opts component.Options) ([]byte, error) {

--- a/pkg/scheme/core/v1/k8s/kubeadm_step.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_step.go
@@ -51,6 +51,7 @@ const (
 	clusterNode     = "clusterNode"
 	cniInfo         = "cniInfo"
 	health          = "health"
+	clusterAccess   = "clusterAccess"
 	addedNodesReady = "addedNodesReady"
 	container       = "container"
 	kubectl         = "kubectl"
@@ -59,10 +60,13 @@ const (
 	KubeCertsCluVersion          = "1.20"
 	defaultStepTimeout           = 10 * time.Minute
 	addedNodesReadyRetryInterval = 10 * time.Second
-	bashCommand                  = "bash"
-	binBashCommand               = "/bin/bash"
-	shellCommandFlag             = "-c"
-	restartControlPlaneCommand   = "mv /etc/kubernetes/manifests/etcd.yaml " +
+	// ClusterAccessStepID identifies the internal Operation step that reads
+	// the kc-server ServiceAccount credential from a running cluster.
+	ClusterAccessStepID        = "capture-cluster-access"
+	bashCommand                = "bash"
+	binBashCommand             = "/bin/bash"
+	shellCommandFlag           = "-c"
+	restartControlPlaneCommand = "mv /etc/kubernetes/manifests/etcd.yaml " +
 		"/etc/kubernetes/manifests/kube-apiserver.yaml " +
 		"/etc/kubernetes/manifests/kube-controller-manager.yaml " +
 		"/etc/kubernetes/manifests/kube-scheduler.yaml /tmp/.k8s/config && sleep 20"
@@ -680,6 +684,25 @@ func (stepper *Health) InstallSteps(nodes []v1.StepNode) ([]v1.Step, error) {
 			Action:     v1.ActionInstall,
 			Commands:   registerSaCommands,
 		}}, nil
+}
+
+// ClusterAccessStep returns the internal step used by the cluster controller
+// to initialize the API client for a cluster created by KubeClipper.
+func ClusterAccessStep(nodes []v1.StepNode) v1.Step {
+	return v1.Step{
+		ID:         ClusterAccessStepID,
+		Name:       ClusterAccessStepID,
+		Timeout:    metav1.Duration{Duration: 30 * time.Second},
+		ErrIgnore:  false,
+		RetryTimes: 1,
+		Nodes:      nodes,
+		Action:     v1.ActionInstall,
+		Commands: []v1.Command{{
+			Type:          v1.CommandCustom,
+			Identity:      fmt.Sprintf(component.RegisterStepKeyFormat, clusterAccess, version, component.TypeStep),
+			CustomCommand: []byte("{}"),
+		}},
+	}
 }
 
 func (stepper *AddedNodesReady) InstallSteps(nodes []v1.StepNode) ([]v1.Step, error) {

--- a/pkg/scheme/core/v1/k8s/kubeadm_test.go
+++ b/pkg/scheme/core/v1/k8s/kubeadm_test.go
@@ -49,6 +49,29 @@ func TestNodeReady(t *testing.T) {
 	}
 }
 
+func TestClusterAccessStep(t *testing.T) {
+	step := ClusterAccessStep([]v1.StepNode{{ID: "master-1"}})
+	if step.ID != ClusterAccessStepID || step.Name != ClusterAccessStepID {
+		t.Fatalf("unexpected kubeconfig token step: %#v", step)
+	}
+	if len(step.Nodes) != 1 || step.Nodes[0].ID != "master-1" {
+		t.Fatalf("unexpected kubeconfig token targets: %#v", step.Nodes)
+	}
+}
+
+func TestKubeConfigTokenFromSecret(t *testing.T) {
+	token, err := kubeConfigTokenFromSecret(&corev1.Secret{Data: map[string][]byte{"token": []byte("cluster-token")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := string(token); got != "cluster-token" {
+		t.Fatalf("service account token = %q, want cluster-token", got)
+	}
+	if _, err := kubeConfigTokenFromSecret(&corev1.Secret{}); err == nil {
+		t.Fatal("missing token must fail")
+	}
+}
+
 func TestAddedNodesReadyStepTargetsOnlyRequestedNodes(t *testing.T) {
 	steps, err := (&AddedNodesReady{NodeNames: []string{"worker-1", "worker-2"}}).InstallSteps([]v1.StepNode{{ID: "master-1"}})
 	if err != nil {

--- a/pkg/scheme/core/v1/operation_types.go
+++ b/pkg/scheme/core/v1/operation_types.go
@@ -58,6 +58,9 @@ const (
 	OperationUninstallComponents          = "UninstallComponents"
 	OperationUpdateCertification          = "UpdateCertifications"
 	OperationUpdateAPIServerCertification = "UpdateAPIServerCertifications"
+	// OperationSyncKubeConfig is an internal operation that initializes the
+	// client credential for a KubeClipper-managed cluster.
+	OperationSyncKubeConfig = "SyncKubeConfig"
 )
 
 // Step TODO: add commands struct instead of string

--- a/pkg/utils/certs/certs.go
+++ b/pkg/utils/certs/certs.go
@@ -50,7 +50,7 @@ const (
 	CertificateBlockType = "CERTIFICATE"
 	// RSAPrivateKeyBlockType is a possible value for pem.Block.Type.
 	RSAPrivateKeyBlockType = "RSA PRIVATE KEY"
-	rsaKeySize             = 2048
+	DefaultRSAKeySize      = 2048
 	duration365d           = time.Hour * 24 * 365
 )
 
@@ -80,7 +80,7 @@ func NewPrivateKey(keyType x509.PublicKeyAlgorithm) (crypto.Signer, error) {
 		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	}
 
-	return rsa.GenerateKey(rand.Reader, rsaKeySize)
+	return rsa.GenerateKey(rand.Reader, DefaultRSAKeySize)
 }
 
 // NewSelfSignedCACert creates a CA certificate


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind regression

### What this PR does / why we need it:

Restores web-terminal access after the Operation v2 migration:
- regenerate weak persisted web-terminal RSA keys with 2048-bit keys;
- create a dedicated Agent Step to initialize a managed cluster kubeconfig;
- persist the generated config on `Cluster.KubeConfig`, which remains the sole source for cluster clients;
- redact task outputs and kubeconfig values in audit payloads.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
Validated on sh-dev-2 with the v1.37 demo cluster: the sync operation succeeded,
the persisted kubeconfig authenticated to the cluster, and task-output audit
records were redacted.
```

### Does this PR introduced a user-facing change?

```release-note
Fix web terminal access for Operation v2 managed clusters.
```

### Additional documentation, usage docs, etc.:

```docs
None.
```