### PR TITLE
fix: paginate operation lists by creation time

### DIFF
--- a/pkg/cli/operation/list.go
+++ b/pkg/cli/operation/list.go
@@ -89,12 +89,12 @@ func (o *ListOptions) Complete(opts *options.CliOptions) error {
 
 // RunList fetches and displays the operation list.
 func (o *ListOptions) RunList() error {
-	q := query.New()
+	listOptions := kc.OperationListOptions{}
 	if o.Cluster != "" {
-		q.LabelSelector = fmt.Sprintf("%s=%s", common.LabelClusterName, o.Cluster)
+		listOptions.LabelSelector = fmt.Sprintf("%s=%s", common.LabelClusterName, o.Cluster)
 	}
 
-	result, err := o.Client.ListOperation(context.TODO(), kc.Queries(*q))
+	result, err := o.Client.ListOperations(context.TODO(), listOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/operation/logs.go
+++ b/pkg/cli/operation/logs.go
@@ -142,7 +142,7 @@ func (o *LogsOptions) runClusterMode() error {
 func (o *LogsOptions) nonTTYClusterFallback() error {
 	ctx := context.Background()
 	labelSelector := fmt.Sprintf("kubeclipper.io/cluster=%s", o.Cluster)
-	list, err := o.Client.ListOperation(ctx, kc.Queries{
+	list, err := o.Client.ListOperations(ctx, kc.OperationListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {

--- a/pkg/cli/operation/tui/app.go
+++ b/pkg/cli/operation/tui/app.go
@@ -119,7 +119,7 @@ func RunTUI(client *kc.Client, clusterName string, in io.Reader, out io.Writer) 
 	ctx := context.Background()
 
 	labelSelector := fmt.Sprintf("kubeclipper.io/cluster=%s", clusterName)
-	list, err := client.ListOperation(ctx, kc.Queries{
+	list, err := client.ListOperations(ctx, kc.OperationListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {

--- a/pkg/models/operationv2/store.go
+++ b/pkg/models/operationv2/store.go
@@ -24,7 +24,10 @@ package operationv2
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -223,7 +226,45 @@ func (s *store) ListOperationsWithOptions(ctx context.Context, options *metav1.L
 	if options == nil {
 		options = &metav1.ListOptions{}
 	}
-	internal, err := internalListOptions(options)
+	if options.Watch {
+		internal, err := internalListOptions(options)
+		if err != nil {
+			return nil, err
+		}
+		obj, err := s.operations.List(withNamespace(ctx), internal)
+		if err != nil {
+			return nil, err
+		}
+		list, ok := obj.(*operations.OperationList)
+		if !ok {
+			return nil, fmt.Errorf("operation storage returned %T", obj)
+		}
+		return list, nil
+	}
+	if options.Limit < 0 {
+		return nil, apierrors.NewBadRequest("limit must be a non-negative integer")
+	}
+
+	continueToken, err := decodeOperationContinue(options.Continue)
+	if err != nil {
+		return nil, err
+	}
+	storageOptions := *options
+	pageLimit := options.Limit
+	// The generic storage layer applies its limit before returning the list,
+	// while Operation V2 needs to sort by creation time first. Fetch the
+	// selected snapshot without storage pagination and apply the stable cursor
+	// below after sorting.
+	storageOptions.Limit = 0
+	storageOptions.Continue = ""
+	if continueToken != nil {
+		if storageOptions.ResourceVersion != "" &&
+			storageOptions.ResourceVersion != continueToken.ResourceVersion {
+			return nil, apierrors.NewBadRequest("resourceVersion does not match continue token")
+		}
+		storageOptions.ResourceVersion = continueToken.ResourceVersion
+	}
+	internal, err := internalListOptions(&storageOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -235,7 +276,105 @@ func (s *store) ListOperationsWithOptions(ctx context.Context, options *metav1.L
 	if !ok {
 		return nil, fmt.Errorf("operation storage returned %T", obj)
 	}
+	list = list.DeepCopy()
+	sort.SliceStable(list.Items, func(i, j int) bool {
+		return operationNewer(&list.Items[i], &list.Items[j])
+	})
+
+	start := 0
+	if continueToken != nil {
+		start = sort.Search(len(list.Items), func(i int) bool {
+			return operationAfterCursor(&list.Items[i], continueToken)
+		})
+	}
+	if start > 0 {
+		list.Items = list.Items[start:]
+	}
+	if pageLimit == 0 {
+		return list, nil
+	}
+
+	end := len(list.Items)
+	if pageLimit < int64(len(list.Items)) {
+		end = int(pageLimit)
+	}
+	remaining := len(list.Items) - end
+	if remaining == 0 {
+		list.Items = list.Items[:end]
+		return list, nil
+	}
+
+	page := list.Items[:end]
+	last := page[len(page)-1]
+	resourceVersion := list.ResourceVersion
+	if resourceVersion == "" && continueToken != nil {
+		resourceVersion = continueToken.ResourceVersion
+	}
+	encoded, err := encodeOperationContinue(operationContinueToken{
+		Version:           operationContinueTokenVersion,
+		ResourceVersion:   resourceVersion,
+		CreationTimestamp: last.CreationTimestamp.Time,
+		UID:               last.UID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	list.Items = page
+	list.Continue = encoded
+	remainingCount := int64(remaining)
+	list.RemainingItemCount = &remainingCount
 	return list, nil
+}
+
+const operationContinueTokenVersion = 1
+
+type operationContinueToken struct {
+	Version           int       `json:"version"`
+	ResourceVersion   string    `json:"resourceVersion,omitempty"`
+	CreationTimestamp time.Time `json:"creationTimestamp"`
+	UID               types.UID `json:"uid"`
+}
+
+func encodeOperationContinue(token operationContinueToken) (string, error) {
+	payload, err := json.Marshal(token)
+	if err != nil {
+		return "", fmt.Errorf("encode operation continue token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func decodeOperationContinue(value string) (*operationContinueToken, error) {
+	if value == "" {
+		return nil, nil
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(value)
+	if err != nil {
+		return nil, apierrors.NewBadRequest("invalid operation continue token")
+	}
+	token := &operationContinueToken{}
+	if err := json.Unmarshal(payload, token); err != nil ||
+		token.Version != operationContinueTokenVersion || token.UID == "" {
+		return nil, apierrors.NewBadRequest("invalid operation continue token")
+	}
+	return token, nil
+}
+
+func operationNewer(left, right *operations.Operation) bool {
+	if !left.CreationTimestamp.Equal(&right.CreationTimestamp) {
+		return left.CreationTimestamp.After(right.CreationTimestamp.Time)
+	}
+	return string(left.UID) > string(right.UID)
+}
+
+func operationAfterCursor(op *operations.Operation, token *operationContinueToken) bool {
+	cursorTime := metav1.Time{Time: token.CreationTimestamp}
+	if op.CreationTimestamp.Before(&cursorTime) {
+		return true
+	}
+	if op.CreationTimestamp.After(cursorTime.Time) {
+		return false
+	}
+	return string(op.UID) < string(token.UID)
 }
 
 func (s *store) WatchOperations(ctx context.Context, resourceVersion string) (watch.Interface, error) {

--- a/pkg/models/operationv2/store_test.go
+++ b/pkg/models/operationv2/store_test.go
@@ -20,13 +20,16 @@ package operationv2
 
 import (
 	"context"
+	"sort"
 	"testing"
+	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
@@ -41,6 +44,83 @@ type recordingStorage struct {
 	getCalls  int
 	listObj   runtime.Object
 	getObj    runtime.Object
+}
+
+func TestOperationOrderingAndContinueToken(t *testing.T) {
+	first := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+	items := []operations.Operation{
+		{ObjectMeta: metav1.ObjectMeta{Name: "old", UID: types.UID("uid-old"), CreationTimestamp: metav1.NewTime(first)}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "newer-b", UID: types.UID("uid-newer-b"), CreationTimestamp: metav1.NewTime(second)}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "newer-a", UID: types.UID("uid-newer-a"), CreationTimestamp: metav1.NewTime(second)}},
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		return operationNewer(&items[i], &items[j])
+	})
+	if got := []string{items[0].Name, items[1].Name, items[2].Name}; got[0] != "newer-b" || got[1] != "newer-a" || got[2] != "old" {
+		t.Fatalf("ordered operations = %v", got)
+	}
+
+	tokenValue, err := encodeOperationContinue(operationContinueToken{
+		Version:           operationContinueTokenVersion,
+		ResourceVersion:   "42",
+		CreationTimestamp: items[1].CreationTimestamp.Time,
+		UID:               items[1].UID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := decodeOperationContinue(tokenValue)
+	if err != nil {
+		t.Fatal(err)
+	}
+	start := sort.Search(len(items), func(i int) bool {
+		return operationAfterCursor(&items[i], token)
+	})
+	if start != 2 || items[start].Name != "old" {
+		t.Fatalf("next page starts at %d with %q", start, items[start].Name)
+	}
+
+	if _, err := decodeOperationContinue("not-a-token"); !apierrors.IsBadRequest(err) {
+		t.Fatalf("invalid token error = %v, want BadRequest", err)
+	}
+}
+
+func TestListOperationsWithOptionsPaginatesNewestFirst(t *testing.T) {
+	first := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	second := first.Add(time.Minute)
+	storage := &recordingStorage{listObj: &operations.OperationList{
+		ListMeta: metav1.ListMeta{ResourceVersion: "42"},
+		Items: []operations.Operation{
+			{ObjectMeta: metav1.ObjectMeta{Name: "old", UID: types.UID("uid-old"), CreationTimestamp: metav1.NewTime(first)}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "newer-a", UID: types.UID("uid-newer-a"), CreationTimestamp: metav1.NewTime(second)}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "newer-b", UID: types.UID("uid-newer-b"), CreationTimestamp: metav1.NewTime(second)}},
+		},
+	}}
+	store, err := NewStore(StoreOptions{Operations: storage, Tasks: &recordingStorage{}, Locks: &recordingStorage{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstPage, err := store.ListOperationsWithOptions(context.Background(), &metav1.ListOptions{Limit: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := []string{firstPage.Items[0].Name, firstPage.Items[1].Name}; got[0] != "newer-b" || got[1] != "newer-a" {
+		t.Fatalf("first page = %v", got)
+	}
+	if firstPage.Continue == "" || firstPage.RemainingItemCount == nil || *firstPage.RemainingItemCount != 1 {
+		t.Fatalf("first page metadata = continue:%q remaining:%v", firstPage.Continue, firstPage.RemainingItemCount)
+	}
+
+	secondPage, err := store.ListOperationsWithOptions(context.Background(), &metav1.ListOptions{Limit: 2, Continue: firstPage.Continue})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondPage.Items) != 1 || secondPage.Items[0].Name != "old" || secondPage.Continue != "" {
+		t.Fatalf("second page = %#v", secondPage)
+	}
 }
 
 func (r *recordingStorage) List(_ context.Context, _ *metainternalversion.ListOptions) (runtime.Object, error) {

--- a/pkg/simple/client/kc/api.go
+++ b/pkg/simple/client/kc/api.go
@@ -176,8 +176,36 @@ func (cli *Client) DescribeCluster(ctx context.Context, name string) (*ClustersL
 	return &clusters, err
 }
 
-func (cli *Client) ListOperation(ctx context.Context, query Queries) (*OperationList, error) {
-	serverResp, err := cli.get(ctx, operationPath, query.ToRawQuery(), nil)
+// OperationListOptions contains the Kubernetes-style list options supported by
+// the Operation V2 endpoint. Continue is opaque and must be passed back to
+// the server unchanged when fetching the next page.
+type OperationListOptions struct {
+	LabelSelector   string
+	FieldSelector   string
+	Limit           int64
+	Continue        string
+	ResourceVersion string
+}
+
+func (cli *Client) ListOperations(ctx context.Context, options OperationListOptions) (*OperationList, error) {
+	query := url.Values{}
+	if options.LabelSelector != "" {
+		query.Set("labelSelector", options.LabelSelector)
+	}
+	if options.FieldSelector != "" {
+		query.Set("fieldSelector", options.FieldSelector)
+	}
+	if options.Limit > 0 {
+		query.Set("limit", fmt.Sprintf("%d", options.Limit))
+	}
+	if options.Continue != "" {
+		query.Set("continue", options.Continue)
+	}
+	if options.ResourceVersion != "" {
+		query.Set("resourceVersion", options.ResourceVersion)
+	}
+
+	serverResp, err := cli.get(ctx, operationPath, query, nil)
 	defer ensureReaderClosed(serverResp)
 	if err != nil {
 		return nil, err

--- a/pkg/simple/client/kc/api_test.go
+++ b/pkg/simple/client/kc/api_test.go
@@ -65,6 +65,42 @@ func TestListOperationTasksFiltersByOperationUID(t *testing.T) {
 	}
 }
 
+func TestListOperationsUsesV2ListOptions(t *testing.T) {
+	var request *http.Request
+	client := testClient(t, func(w http.ResponseWriter, r *http.Request) {
+		request = r
+		if err := json.NewEncoder(w).Encode(&OperationList{
+			ListMeta: metav1.ListMeta{Continue: "next-page"},
+		}); err != nil {
+			t.Errorf("encode operation list: %v", err)
+		}
+	})
+
+	list, err := client.ListOperations(context.Background(), OperationListOptions{
+		LabelSelector:   "kubeclipper.io/cluster=demo",
+		FieldSelector:   "metadata.name=operation-a",
+		Limit:           10,
+		Continue:        "opaque-token",
+		ResourceVersion: "42",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list.Continue != "next-page" {
+		t.Fatalf("continue = %q", list.Continue)
+	}
+	query := request.URL.Query()
+	if query.Get("labelSelector") != "kubeclipper.io/cluster=demo" {
+		t.Fatalf("labelSelector = %q", query.Get("labelSelector"))
+	}
+	if query.Get("fieldSelector") != "metadata.name=operation-a" {
+		t.Fatalf("fieldSelector = %q", query.Get("fieldSelector"))
+	}
+	if query.Get("limit") != "10" || query.Get("continue") != "opaque-token" || query.Get("resourceVersion") != "42" {
+		t.Fatalf("list options = %s", request.URL.RawQuery)
+	}
+}
+
 func TestOperationControlUsesCASPreconditions(t *testing.T) {
 	for _, subresource := range []string{"retry", "cancel"} {
 		t.Run(subresource, func(t *testing.T) {

--- a/pkg/simple/client/kc/scheme.go
+++ b/pkg/simple/client/kc/scheme.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"strconv"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 
 	iamv1 "github.com/kubeclipper/kubeclipper/pkg/scheme/iam/v1"
@@ -306,8 +308,9 @@ func (n *TemplateList) TablePrint() ([]string, [][]string) {
 var _ printer.ResourcePrinter = (*OperationList)(nil)
 
 type OperationList struct {
-	Items      []operationsv1alpha1.Operation `json:"items" description:"paging data"`
-	TotalCount int                            `json:"totalCount,omitempty" description:"total count"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []operationsv1alpha1.Operation `json:"items" description:"paging data"`
+	TotalCount      int                            `json:"totalCount,omitempty" description:"total count"`
 }
 
 func (n *OperationList) JSONPrint() ([]byte, error) {

--- a/test/framework/cluster/wait.go
+++ b/test/framework/cluster/wait.go
@@ -27,7 +27,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/kubeclipper/kubeclipper/pkg/query"
 	"github.com/kubeclipper/kubeclipper/pkg/scheme/common"
 	operationsv1alpha1 "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
 
@@ -94,9 +93,9 @@ func WaitForClusterCondition(
 }
 
 func printClusterOperationLogs(c *kc.Client, clusterName string) {
-	q := query.New()
-	q.LabelSelector = fmt.Sprintf("%s=%s", common.LabelClusterName, clusterName)
-	opList, err := c.ListOperation(context.TODO(), kc.Queries(*q))
+	opList, err := c.ListOperations(context.TODO(), kc.OperationListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", common.LabelClusterName, clusterName),
+	})
 	if err != nil {
 		framework.Logf("List Cluster Operation Failed: %v", err)
 		return


### PR DESCRIPTION
### What type of PR is this?

/kind bug
/kind api-change

### What this PR does / why we need it:

Makes the Operation v2 list endpoint return newest operations first and support
Kubernetes-style `limit`/`continue` cursor pagination. Updates the simple
client, kcctl operation list/logs/TUI, and test log collection to use the V2
ListOptions API.

### Which issue(s) this PR fixes:

Fixes #

### Special notes for reviewers:

```
The TUI per-task log switching implementation was already present on master,
so this PR intentionally does not duplicate it.
```

### Does this PR introduced a user-facing change?

```release-note
Operation lists are ordered newest first and support cursor pagination.
```

### Additional documentation, usage docs, etc.:

```docs
None.
```