### PR TITLE
fix: render operation tasks by node IP

### DIFF
--- a/pkg/apis/operations/v1alpha1/handler.go
+++ b/pkg/apis/operations/v1alpha1/handler.go
@@ -102,19 +102,35 @@ func (h *handler) validateTargetRefs(req *restful.Request, op *operations.Operat
 	if clusterObj.UID != op.Spec.TargetRef.UID {
 		return apierrors.NewConflict(corev1.Resource("clusters"), clusterObj.Name, fmt.Errorf("cluster UID does not match"))
 	}
-	nodes := make(map[string]operations.NodeReference)
+	return validateAndEnrichTargetIPs(req.Request.Context(), op, h.clusterReader)
+}
+
+func validateAndEnrichTargetIPs(
+	ctx context.Context,
+	op *operations.Operation,
+	nodeReader interface {
+		GetNodeEx(context.Context, string, string) (*corev1.Node, error)
+	},
+) error {
+	nodes := make(map[string]*corev1.Node)
 	for stepIndex := range op.Spec.Steps {
-		for _, node := range op.Spec.Steps[stepIndex].Targets {
-			nodes[node.Name] = node
-		}
-	}
-	for _, ref := range nodes {
-		node, err := h.clusterReader.GetNodeEx(req.Request.Context(), ref.Name, "")
-		if err != nil {
-			return err
-		}
-		if node.UID != ref.UID {
-			return apierrors.NewConflict(corev1.Resource("nodes"), node.Name, fmt.Errorf("node UID does not match"))
+		for targetIndex := range op.Spec.Steps[stepIndex].Targets {
+			target := &op.Spec.Steps[stepIndex].Targets[targetIndex]
+			node := nodes[target.Name]
+			if node == nil {
+				var err error
+				node, err = nodeReader.GetNodeEx(ctx, target.Name, "")
+				if err != nil {
+					return err
+				}
+				nodes[target.Name] = node
+			}
+			if node.UID != target.UID {
+				return apierrors.NewConflict(corev1.Resource("nodes"), node.Name, fmt.Errorf("node UID does not match"))
+			}
+			// Keep the display address authoritative even when a client submits
+			// an Operation directly instead of using the core-operation builder.
+			target.IP = node.Status.Ipv4DefaultIP
 		}
 	}
 	return nil

--- a/pkg/apis/operations/v1alpha1/handler_ip_test.go
+++ b/pkg/apis/operations/v1alpha1/handler_ip_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 KubeClipper Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1alpha1
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "github.com/kubeclipper/kubeclipper/pkg/scheme/core/v1"
+	operations "github.com/kubeclipper/kubeclipper/pkg/scheme/operations/v1alpha1"
+)
+
+type targetNodeReader map[string]*corev1.Node
+
+func (r targetNodeReader) GetNodeEx(_ context.Context, name, _ string) (*corev1.Node, error) {
+	return r[name], nil
+}
+
+func TestValidateAndEnrichTargetIPs(t *testing.T) {
+	op := &operations.Operation{
+		Spec: operations.OperationSpec{Steps: []operations.OperationStep{{
+			Targets: []operations.NodeReference{{Name: "node-a", UID: types.UID("node-a-uid"), IP: "192.0.2.99"}},
+		}}},
+	}
+	reader := targetNodeReader{
+		"node-a": {
+			ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid")},
+			Status:     corev1.NodeStatus{Ipv4DefaultIP: "192.0.2.10"},
+		},
+	}
+
+	if err := validateAndEnrichTargetIPs(context.Background(), op, reader); err != nil {
+		t.Fatal(err)
+	}
+	if got := op.Spec.Steps[0].Targets[0].IP; got != "192.0.2.10" {
+		t.Fatalf("target IP = %q, want authoritative node IP", got)
+	}
+}

--- a/pkg/cli/operation/tui/log_view.go
+++ b/pkg/cli/operation/tui/log_view.go
@@ -18,15 +18,26 @@ import (
 type StepEntry struct {
 	ID     string
 	Status string
+	Groups []TaskGroup
+}
+
+// TaskGroup keeps all execution attempts for nodes sharing one IP together.
+// An operation creates one task per node and attempt, so rendering the raw
+// task list directly makes retries look like unrelated nodes.
+type TaskGroup struct {
+	IP     string
+	Status string
 	Tasks  []TaskEntry
 }
 
 type TaskEntry struct {
-	Name     string
-	Node     string
-	Attempt  int32
-	Status   string
-	Duration string
+	Name            string
+	NodeUID         string
+	RetryGeneration int64
+	Attempt         int32
+	Status          string
+	Duration        string
+	CreatedAt       time.Time
 }
 
 type tickMsg time.Time
@@ -44,19 +55,21 @@ type operationStatusMsg struct {
 }
 
 type LogModel struct {
-	client     *kc.Client
-	operation  *operationsv1alpha1.Operation
-	tasks      []operationsv1alpha1.OperationTask
-	steps      []StepEntry
-	cursor     int
-	followMode bool
-	lastOffset map[string]int64
-	logContent map[string]string
-	displayed  string
-	viewport   viewport.Model
-	rawContent string
-	width      int
-	height     int
+	client       *kc.Client
+	operation    *operationsv1alpha1.Operation
+	tasks        []operationsv1alpha1.OperationTask
+	steps        []StepEntry
+	cursor       int
+	followMode   bool
+	lastOffset   map[string]int64
+	logContent   map[string]string
+	displayed    string
+	stepViewport viewport.Model
+	stepLines    []int
+	viewport     viewport.Model
+	rawContent   string
+	width        int
+	height       int
 }
 
 const (
@@ -68,14 +81,22 @@ func NewLogModel(client *kc.Client, op *operationsv1alpha1.Operation, width, hei
 	stepPanelWidth := width * 35 / 100
 	logPanelWidth := width - stepPanelWidth - 2
 	logPanelWidth = max(minLogPanelWidth, logPanelWidth)
-	return LogModel{
+	stepViewportWidth := maxInt(1, stepPanelWidth-4)
+	viewHeight := maxInt(1, height-3)
+	m := LogModel{
 		client: client, operation: op, steps: buildStepEntries(op, nil),
-		lastOffset: make(map[string]int64), logContent: make(map[string]string), viewport: viewport.New(logPanelWidth, height-3),
-		width: width, height: height,
+		lastOffset: make(map[string]int64), logContent: make(map[string]string),
+		stepViewport: viewport.New(stepViewportWidth, viewHeight),
+		viewport:     viewport.New(logPanelWidth, viewHeight), width: width, height: height,
 	}
+	m.rebuildStepViewport()
+	return m
 }
 
 func buildStepEntries(op *operationsv1alpha1.Operation, tasks []operationsv1alpha1.OperationTask) []StepEntry {
+	if op == nil {
+		return nil
+	}
 	byStep := make(map[string][]operationsv1alpha1.OperationTask)
 	for i := range tasks {
 		byStep[tasks[i].Spec.StepID] = append(byStep[tasks[i].Spec.StepID], tasks[i])
@@ -91,9 +112,27 @@ func buildStepEntries(op *operationsv1alpha1.Operation, tasks []operationsv1alph
 			if stepTasks[i].Spec.Attempt != stepTasks[j].Spec.Attempt {
 				return stepTasks[i].Spec.Attempt < stepTasks[j].Spec.Attempt
 			}
-			return stepTasks[i].Spec.NodeRef.Name < stepTasks[j].Spec.NodeRef.Name
+			if stepTasks[i].Spec.NodeRef.IP != stepTasks[j].Spec.NodeRef.IP {
+				return stepTasks[i].Spec.NodeRef.IP < stepTasks[j].Spec.NodeRef.IP
+			}
+			return stepTasks[i].Name < stepTasks[j].Name
 		})
 		entry := StepEntry{ID: step.ID, Status: string(operationsv1alpha1.TaskPending)}
+		groups := make([]TaskGroup, 0, len(step.Targets))
+		groupByKey := make(map[string]int, len(step.Targets))
+		groupByUID := make(map[string]int, len(step.Targets))
+		for _, target := range step.Targets {
+			key := nodeGroupKey(target)
+			groupIndex, exists := groupByKey[key]
+			if !exists {
+				groupIndex = len(groups)
+				groups = append(groups, TaskGroup{IP: target.IP})
+				groupByKey[key] = groupIndex
+			}
+			if target.UID != "" {
+				groupByUID[string(target.UID)] = groupIndex
+			}
+		}
 		for i := range stepTasks {
 			task := &stepTasks[i]
 			duration := ""
@@ -104,21 +143,92 @@ func buildStepEntries(op *operationsv1alpha1.Operation, tasks []operationsv1alph
 				}
 				duration = d.String()
 			}
-			entry.Tasks = append(
-				entry.Tasks,
-				TaskEntry{
-					Name:     task.Name,
-					Node:     task.Spec.NodeRef.Name,
-					Attempt:  task.Spec.Attempt,
-					Status:   string(task.Status.Phase),
-					Duration: duration,
-				},
-			)
+			entryTask := TaskEntry{
+				Name:            task.Name,
+				NodeUID:         string(task.Spec.NodeRef.UID),
+				RetryGeneration: task.Spec.RetryGeneration,
+				Attempt:         task.Spec.Attempt,
+				Status:          string(task.Status.Phase),
+				Duration:        duration,
+				CreatedAt:       task.CreationTimestamp.Time,
+			}
+			groupIndex, exists := groupByUID[string(task.Spec.NodeRef.UID)]
+			if !exists {
+				key := nodeGroupKey(task.Spec.NodeRef)
+				groupIndex, exists = groupByKey[key]
+				if !exists {
+					groupIndex = len(groups)
+					groups = append(groups, TaskGroup{IP: task.Spec.NodeRef.IP})
+					groupByKey[key] = groupIndex
+				}
+			}
+			groups[groupIndex].Tasks = append(groups[groupIndex].Tasks, entryTask)
 		}
+		for groupIndex := range groups {
+			groups[groupIndex].Status = aggregateTaskGroupPhase(groups[groupIndex].Tasks)
+		}
+		entry.Groups = groups
 		entry.Status = aggregateStepPhase(step, stepTasks, op.Status.Phase)
 		entries = append(entries, entry)
 	}
 	return entries
+}
+
+func nodeGroupKey(node operationsv1alpha1.NodeReference) string {
+	if node.IP != "" {
+		return "ip:" + node.IP
+	}
+	if node.UID != "" {
+		return "uid:" + string(node.UID)
+	}
+	return "name:" + node.Name
+}
+
+func aggregateTaskGroupPhase(tasks []TaskEntry) string {
+	if len(tasks) == 0 {
+		return string(operationsv1alpha1.TaskPending)
+	}
+	latestByNode := make(map[string]TaskEntry, len(tasks))
+	for _, task := range tasks {
+		current, exists := latestByNode[task.NodeUID]
+		if !exists || newerTask(task, current) {
+			latestByNode[task.NodeUID] = task
+		}
+	}
+	allSucceeded := true
+	for _, task := range latestByNode {
+		switch task.Status {
+		case string(operationsv1alpha1.TaskFailed), string(operationsv1alpha1.TaskTimedOut), string(operationsv1alpha1.TaskCancelled):
+			return task.Status
+		case string(operationsv1alpha1.TaskRunning):
+			allSucceeded = false
+		case string(operationsv1alpha1.TaskSucceeded):
+		default:
+			allSucceeded = false
+		}
+	}
+	if allSucceeded {
+		return string(operationsv1alpha1.TaskSucceeded)
+	}
+	for _, task := range latestByNode {
+		if task.Status == string(operationsv1alpha1.TaskRunning) {
+			return string(operationsv1alpha1.TaskRunning)
+		}
+	}
+	return string(operationsv1alpha1.TaskPending)
+}
+
+func newerTask(left, right TaskEntry) bool {
+	if left.RetryGeneration != right.RetryGeneration {
+		return left.RetryGeneration > right.RetryGeneration
+	}
+	if left.Attempt != right.Attempt {
+		return left.Attempt > right.Attempt
+	}
+	if !left.CreatedAt.Equal(right.CreatedAt) {
+		return left.CreatedAt.After(right.CreatedAt)
+	}
+	return left.Name > right.Name
 }
 
 func aggregateStepPhase(
@@ -189,10 +299,74 @@ func missingStepPhase(operationPhase operationsv1alpha1.OperationPhase) string {
 }
 
 func (m *LogModel) currentTask() *TaskEntry {
-	if m.cursor >= len(m.steps) || len(m.steps[m.cursor].Tasks) == 0 {
+	if m.cursor >= len(m.steps) || len(m.steps[m.cursor].Groups) == 0 {
 		return nil
 	}
-	return &m.steps[m.cursor].Tasks[len(m.steps[m.cursor].Tasks)-1]
+	var latest *TaskEntry
+	for groupIndex := range m.steps[m.cursor].Groups {
+		for taskIndex := range m.steps[m.cursor].Groups[groupIndex].Tasks {
+			task := &m.steps[m.cursor].Groups[groupIndex].Tasks[taskIndex]
+			if latest == nil || newerTask(*task, *latest) {
+				latest = task
+			}
+		}
+	}
+	return latest
+}
+
+func (m *LogModel) rebuildStepViewport() {
+	lines := []string{HeaderStyle.Render("Steps and Tasks")}
+	m.stepLines = make([]int, len(m.steps))
+	for stepIndex, step := range m.steps {
+		m.stepLines[stepIndex] = len(lines)
+		stepLine := fmt.Sprintf(" %s %s", stepStatusMark(step.Status), step.ID)
+		if stepIndex == m.cursor {
+			stepLine = SelectedStyle.Render(stepLine)
+		}
+		lines = append(lines, stepLine)
+		for _, group := range step.Groups {
+			groupLine := fmt.Sprintf("   %s %s", stepStatusMark(group.Status), displayIP(group.IP))
+			if stepIndex == m.cursor {
+				groupLine = SelectedStyle.Render(groupLine)
+			}
+			lines = append(lines, groupLine)
+			for _, task := range group.Tasks {
+				taskLine := fmt.Sprintf("      %s attempt=%d", stepStatusMark(task.Status), task.Attempt)
+				if task.Duration != "" {
+					taskLine += " [" + task.Duration + "]"
+				}
+				if stepIndex == m.cursor {
+					taskLine = SelectedStyle.Render(taskLine)
+				}
+				lines = append(lines, taskLine)
+			}
+		}
+	}
+	m.stepViewport.SetContent(strings.Join(lines, "\n"))
+	m.ensureStepCursorVisible()
+}
+
+func (m *LogModel) ensureStepCursorVisible() {
+	if m.cursor < 0 || m.cursor >= len(m.stepLines) {
+		return
+	}
+	line := m.stepLines[m.cursor]
+	height := maxInt(1, m.stepViewport.Height)
+	if line < m.stepViewport.YOffset || line >= m.stepViewport.YOffset+height {
+		offset := line
+		maxOffset := maxInt(0, m.stepViewport.TotalLineCount()-height)
+		if offset > maxOffset {
+			offset = maxOffset
+		}
+		m.stepViewport.SetYOffset(offset)
+	}
+}
+
+func displayIP(ip string) string {
+	if ip == "" {
+		return "-"
+	}
+	return ip
 }
 
 func (m *LogModel) showCurrentLog() bool {
@@ -255,7 +429,10 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		m.viewport.Width = maxInt(minLogPanelWidth, m.width-m.width*35/100-2)
-		m.viewport.Height = m.height - 3
+		m.viewport.Height = maxInt(1, m.height-3)
+		m.stepViewport.Width = maxInt(1, m.width*35/100-4)
+		m.stepViewport.Height = maxInt(1, m.height-3)
+		m.rebuildStepViewport()
 	case logFetchedMsg:
 		if msg.content != "" && msg.key != "" {
 			m.logContent[msg.key] += msg.content
@@ -279,6 +456,7 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 			if m.cursor >= len(m.steps) {
 				m.cursor = maxInt(0, len(m.steps)-1)
 			}
+			m.rebuildStepViewport()
 			if m.currentTask() == nil || m.currentTask().Name != m.displayed {
 				if m.showCurrentLog() {
 					cmds = append(cmds, m.fetchCurrentLogCmd())
@@ -295,6 +473,7 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 		case DefaultKeyMap.Up, "k":
 			if m.cursor > 0 {
 				m.cursor--
+				m.rebuildStepViewport()
 				if m.showCurrentLog() {
 					cmds = append(cmds, m.fetchCurrentLogCmd())
 				}
@@ -302,6 +481,7 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 		case DefaultKeyMap.Down, "j":
 			if m.cursor < len(m.steps)-1 {
 				m.cursor++
+				m.rebuildStepViewport()
 				if m.showCurrentLog() {
 					cmds = append(cmds, m.fetchCurrentLogCmd())
 				}
@@ -323,9 +503,16 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 		}
 	}
 	var cmd tea.Cmd
+	m.stepViewport, cmd = m.stepViewport.Update(msg)
+	if cmd != nil {
+		cmds = append(cmds, cmd)
+	}
 	m.viewport, cmd = m.viewport.Update(msg)
 	if cmd != nil {
 		cmds = append(cmds, cmd)
+	}
+	if key, ok := msg.(tea.KeyMsg); ok && (key.String() == DefaultKeyMap.Up || key.String() == DefaultKeyMap.Down || key.String() == "k" || key.String() == "j") {
+		m.ensureStepCursorVisible()
 	}
 	return m, tea.Batch(cmds...)
 }
@@ -338,31 +525,9 @@ func (m LogModel) View() string {
 	}
 	stepPanelWidth := m.width * 35 / 100
 	logPanelWidth := maxInt(minLogPanelWidth, m.width-stepPanelWidth-2)
-	var left strings.Builder
-	left.WriteString(HeaderStyle.Render("Steps and Tasks"))
-	left.WriteString("\n")
-	for i, step := range m.steps {
-		line := fmt.Sprintf(" %s %s", stepStatusMark(step.Status), step.ID)
-		if i == m.cursor {
-			line = SelectedStyle.Render(line)
-		}
-		left.WriteString(line)
-		left.WriteString("\n")
-		for _, task := range step.Tasks {
-			taskLine := fmt.Sprintf("   %s %s attempt=%d", stepStatusMark(task.Status), task.Node, task.Attempt)
-			if task.Duration != "" {
-				taskLine += " [" + task.Duration + "]"
-			}
-			if i == m.cursor {
-				taskLine = SelectedStyle.Render(taskLine)
-			}
-			left.WriteString(taskLine)
-			left.WriteString("\n")
-		}
-	}
 	combined := lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		StepPanelStyle.Width(stepPanelWidth).Render(left.String()),
+		StepPanelStyle.Width(stepPanelWidth).Render(m.stepViewport.View()),
 		LogPanelStyle.Width(logPanelWidth).Render(m.viewport.View()),
 	)
 	follow := "off"

--- a/pkg/cli/operation/tui/log_view.go
+++ b/pkg/cli/operation/tui/log_view.go
@@ -73,15 +73,16 @@ type LogModel struct {
 }
 
 const (
-	followTickInterval = 2 * time.Second
-	minLogPanelWidth   = 10
+	followTickInterval         = 2 * time.Second
+	minLogPanelWidth           = 10
+	stepPanelHorizontalPadding = 4
 )
 
 func NewLogModel(client *kc.Client, op *operationsv1alpha1.Operation, width, height int) LogModel {
 	stepPanelWidth := width * 35 / 100
 	logPanelWidth := width - stepPanelWidth - 2
 	logPanelWidth = max(minLogPanelWidth, logPanelWidth)
-	stepViewportWidth := maxInt(1, stepPanelWidth-4)
+	stepViewportWidth := maxInt(1, stepPanelWidth-stepPanelHorizontalPadding)
 	viewHeight := maxInt(1, height-3)
 	m := LogModel{
 		client: client, operation: op, steps: buildStepEntries(op, nil),
@@ -188,8 +189,9 @@ func aggregateTaskGroupPhase(tasks []TaskEntry) string {
 	if len(tasks) == 0 {
 		return string(operationsv1alpha1.TaskPending)
 	}
-	latestByNode := make(map[string]TaskEntry, len(tasks))
-	for _, task := range tasks {
+	latestByNode := make(map[string]*TaskEntry, len(tasks))
+	for taskIndex := range tasks {
+		task := &tasks[taskIndex]
 		current, exists := latestByNode[task.NodeUID]
 		if !exists || newerTask(task, current) {
 			latestByNode[task.NodeUID] = task
@@ -218,7 +220,7 @@ func aggregateTaskGroupPhase(tasks []TaskEntry) string {
 	return string(operationsv1alpha1.TaskPending)
 }
 
-func newerTask(left, right TaskEntry) bool {
+func newerTask(left, right *TaskEntry) bool {
 	if left.RetryGeneration != right.RetryGeneration {
 		return left.RetryGeneration > right.RetryGeneration
 	}
@@ -306,7 +308,7 @@ func (m *LogModel) currentTask() *TaskEntry {
 	for groupIndex := range m.steps[m.cursor].Groups {
 		for taskIndex := range m.steps[m.cursor].Groups[groupIndex].Tasks {
 			task := &m.steps[m.cursor].Groups[groupIndex].Tasks[taskIndex]
-			if latest == nil || newerTask(*task, *latest) {
+			if latest == nil || newerTask(task, latest) {
 				latest = task
 			}
 		}
@@ -430,7 +432,7 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 		m.width, m.height = msg.Width, msg.Height
 		m.viewport.Width = maxInt(minLogPanelWidth, m.width-m.width*35/100-2)
 		m.viewport.Height = maxInt(1, m.height-3)
-		m.stepViewport.Width = maxInt(1, m.width*35/100-4)
+		m.stepViewport.Width = maxInt(1, m.width*35/100-stepPanelHorizontalPadding)
 		m.stepViewport.Height = maxInt(1, m.height-3)
 		m.rebuildStepViewport()
 	case logFetchedMsg:
@@ -511,10 +513,19 @@ func (m LogModel) Update(msg tea.Msg) (LogModel, tea.Cmd) {
 	if cmd != nil {
 		cmds = append(cmds, cmd)
 	}
-	if key, ok := msg.(tea.KeyMsg); ok && (key.String() == DefaultKeyMap.Up || key.String() == DefaultKeyMap.Down || key.String() == "k" || key.String() == "j") {
+	if key, ok := msg.(tea.KeyMsg); ok && isStepNavigationKey(key.String()) {
 		m.ensureStepCursorVisible()
 	}
 	return m, tea.Batch(cmds...)
+}
+
+func isStepNavigationKey(key string) bool {
+	switch key {
+	case DefaultKeyMap.Up, DefaultKeyMap.Down, "k", "j":
+		return true
+	default:
+		return false
+	}
 }
 
 type backMsg struct{}

--- a/pkg/cli/operation/tui/operation_v2_test.go
+++ b/pkg/cli/operation/tui/operation_v2_test.go
@@ -21,20 +21,58 @@ func TestListViewUsesV2PhaseAndSteps(t *testing.T) {
 }
 
 func TestBuildStepEntriesKeepsAttempts(t *testing.T) {
-	op := &operationsv1alpha1.Operation{Spec: operationsv1alpha1.OperationSpec{Steps: []operationsv1alpha1.OperationStep{{ID: "step", Targets: []operationsv1alpha1.NodeReference{{Name: "node", UID: "node-uid"}}}}}}
+	op := &operationsv1alpha1.Operation{Spec: operationsv1alpha1.OperationSpec{Steps: []operationsv1alpha1.OperationStep{{ID: "step", Targets: []operationsv1alpha1.NodeReference{{Name: "node", UID: "node-uid", IP: "10.0.0.1"}}}}}}
 	tasks := []operationsv1alpha1.OperationTask{
-		{ObjectMeta: metav1.ObjectMeta{Name: "task-1"}, Spec: operationsv1alpha1.OperationTaskSpec{StepID: "step", NodeRef: operationsv1alpha1.NodeReference{Name: "node", UID: "node-uid"}, Attempt: 1}, Status: operationsv1alpha1.OperationTaskStatus{Phase: operationsv1alpha1.TaskSucceeded}},
-		{ObjectMeta: metav1.ObjectMeta{Name: "task-0"}, Spec: operationsv1alpha1.OperationTaskSpec{StepID: "step", NodeRef: operationsv1alpha1.NodeReference{Name: "node", UID: "node-uid"}, Attempt: 0}, Status: operationsv1alpha1.OperationTaskStatus{Phase: operationsv1alpha1.TaskFailed}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "task-1"}, Spec: operationsv1alpha1.OperationTaskSpec{StepID: "step", NodeRef: operationsv1alpha1.NodeReference{Name: "node", UID: "node-uid", IP: "10.0.0.1"}, Attempt: 1}, Status: operationsv1alpha1.OperationTaskStatus{Phase: operationsv1alpha1.TaskSucceeded}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "task-0"}, Spec: operationsv1alpha1.OperationTaskSpec{StepID: "step", NodeRef: operationsv1alpha1.NodeReference{Name: "node", UID: "node-uid", IP: "10.0.0.1"}, Attempt: 0}, Status: operationsv1alpha1.OperationTaskStatus{Phase: operationsv1alpha1.TaskFailed}},
 	}
 	entries := buildStepEntries(op, tasks)
-	if len(entries) != 1 || len(entries[0].Tasks) != 2 {
+	if len(entries) != 1 || len(entries[0].Groups) != 1 || len(entries[0].Groups[0].Tasks) != 2 {
 		t.Fatalf("entries = %#v", entries)
 	}
-	if entries[0].Tasks[0].Attempt != 0 || entries[0].Tasks[1].Attempt != 1 {
-		t.Fatalf("attempt order = %#v", entries[0].Tasks)
+	if entries[0].Groups[0].IP != "10.0.0.1" {
+		t.Fatalf("group ip = %q", entries[0].Groups[0].IP)
+	}
+	if entries[0].Groups[0].Tasks[0].Attempt != 0 || entries[0].Groups[0].Tasks[1].Attempt != 1 {
+		t.Fatalf("attempt order = %#v", entries[0].Groups[0].Tasks)
 	}
 	if entries[0].Status != string(operationsv1alpha1.TaskSucceeded) {
 		t.Fatalf("step status = %q", entries[0].Status)
+	}
+}
+
+func TestBuildStepEntriesGroupsTasksByIP(t *testing.T) {
+	op := &operationsv1alpha1.Operation{Spec: operationsv1alpha1.OperationSpec{Steps: []operationsv1alpha1.OperationStep{{
+		ID: "step",
+		Targets: []operationsv1alpha1.NodeReference{
+			{Name: "node-a", UID: "node-a-uid", IP: "10.0.0.1"},
+			{Name: "node-b", UID: "node-b-uid", IP: "10.0.0.2"},
+		},
+	}}}}
+	tasks := []operationsv1alpha1.OperationTask{
+		{ObjectMeta: metav1.ObjectMeta{Name: "task-a-0"}, Spec: operationsv1alpha1.OperationTaskSpec{StepID: "step", NodeRef: operationsv1alpha1.NodeReference{Name: "node-a", UID: "node-a-uid", IP: "10.0.0.1"}, Attempt: 0}, Status: operationsv1alpha1.OperationTaskStatus{Phase: operationsv1alpha1.TaskSucceeded}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "task-a-1"}, Spec: operationsv1alpha1.OperationTaskSpec{StepID: "step", NodeRef: operationsv1alpha1.NodeReference{Name: "node-a", UID: "node-a-uid", IP: "10.0.0.1"}, Attempt: 1}, Status: operationsv1alpha1.OperationTaskStatus{Phase: operationsv1alpha1.TaskFailed}},
+		{ObjectMeta: metav1.ObjectMeta{Name: "task-b-0"}, Spec: operationsv1alpha1.OperationTaskSpec{StepID: "step", NodeRef: operationsv1alpha1.NodeReference{Name: "node-b", UID: "node-b-uid", IP: "10.0.0.2"}, Attempt: 0}, Status: operationsv1alpha1.OperationTaskStatus{Phase: operationsv1alpha1.TaskSucceeded}},
+	}
+	entries := buildStepEntries(op, tasks)
+	if len(entries[0].Groups) != 2 {
+		t.Fatalf("groups = %#v", entries[0].Groups)
+	}
+	if entries[0].Groups[0].IP != "10.0.0.1" || len(entries[0].Groups[0].Tasks) != 2 {
+		t.Fatalf("first group = %#v", entries[0].Groups[0])
+	}
+	if entries[0].Groups[1].IP != "10.0.0.2" || len(entries[0].Groups[1].Tasks) != 1 {
+		t.Fatalf("second group = %#v", entries[0].Groups[1])
+	}
+
+	view := NewLogModel(nil, op, 100, 20).View()
+	if !strings.Contains(view, "10.0.0.1") || !strings.Contains(view, "10.0.0.2") {
+		t.Fatalf("view does not show IP groups: %s", view)
+	}
+	for _, taskName := range []string{"task-a-0", "task-a-1", "task-b-0"} {
+		if strings.Contains(view, taskName) {
+			t.Fatalf("view exposes task UID/name %q: %s", taskName, view)
+		}
 	}
 }
 
@@ -50,8 +88,8 @@ func TestTaskStatusMarks(t *testing.T) {
 func TestLogModelRestoresTaskLogAfterNavigation(t *testing.T) {
 	m := NewLogModel(nil, &operationsv1alpha1.Operation{}, 100, 20)
 	m.steps = []StepEntry{
-		{ID: "first", Tasks: []TaskEntry{{Name: "first-task"}}},
-		{ID: "second", Tasks: []TaskEntry{{Name: "second-task"}}},
+		{ID: "first", Groups: []TaskGroup{{IP: "10.0.0.1", Tasks: []TaskEntry{{Name: "first-task"}}}}},
+		{ID: "second", Groups: []TaskGroup{{IP: "10.0.0.2", Tasks: []TaskEntry{{Name: "second-task"}}}}},
 	}
 	if !m.showCurrentLog() {
 		t.Fatal("expected first task to be selected")
@@ -78,8 +116,8 @@ func TestLogModelRestoresTaskLogAfterNavigation(t *testing.T) {
 func TestLogModelIgnoresStaleLogForAnotherTask(t *testing.T) {
 	m := NewLogModel(nil, &operationsv1alpha1.Operation{}, 100, 20)
 	m.steps = []StepEntry{
-		{ID: "first", Tasks: []TaskEntry{{Name: "first-task"}}},
-		{ID: "second", Tasks: []TaskEntry{{Name: "second-task"}}},
+		{ID: "first", Groups: []TaskGroup{{IP: "10.0.0.1", Tasks: []TaskEntry{{Name: "first-task"}}}}},
+		{ID: "second", Groups: []TaskGroup{{IP: "10.0.0.2", Tasks: []TaskEntry{{Name: "second-task"}}}}},
 	}
 	if !m.showCurrentLog() {
 		t.Fatal("expected first task to be selected")
@@ -93,5 +131,31 @@ func TestLogModelIgnoresStaleLogForAnotherTask(t *testing.T) {
 	m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
 	if m.rawContent != "first log\n" {
 		t.Fatalf("restored log = %q, want stale first task response", m.rawContent)
+	}
+}
+
+func TestLogModelScrollsStepPanelWithLongTaskList(t *testing.T) {
+	op := &operationsv1alpha1.Operation{Spec: operationsv1alpha1.OperationSpec{Steps: make([]operationsv1alpha1.OperationStep, 30)}}
+	for i := range op.Spec.Steps {
+		op.Spec.Steps[i] = operationsv1alpha1.OperationStep{
+			ID:      "step-" + string(rune('a'+i)),
+			Targets: []operationsv1alpha1.NodeReference{{Name: "node", UID: "node-uid", IP: "10.0.0.1"}},
+		}
+	}
+	m := NewLogModel(nil, op, 100, 10)
+	if m.stepViewport.YOffset != 0 {
+		t.Fatalf("initial step offset = %d, want 0", m.stepViewport.YOffset)
+	}
+	for i := 0; i < 20; i++ {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	}
+	if m.stepViewport.YOffset == 0 {
+		t.Fatal("long step list did not scroll")
+	}
+	for i := 0; i < 20; i++ {
+		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	}
+	if m.cursor != 0 || m.stepViewport.YOffset != 0 {
+		t.Fatalf("returned to cursor=%d offset=%d, want 0/0", m.cursor, m.stepViewport.YOffset)
 	}
 }

--- a/pkg/cli/operation/tui/operation_v2_test.go
+++ b/pkg/cli/operation/tui/operation_v2_test.go
@@ -146,13 +146,13 @@ func TestLogModelScrollsStepPanelWithLongTaskList(t *testing.T) {
 	if m.stepViewport.YOffset != 0 {
 		t.Fatalf("initial step offset = %d, want 0", m.stepViewport.YOffset)
 	}
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyDown})
 	}
 	if m.stepViewport.YOffset == 0 {
 		t.Fatal("long step list did not scroll")
 	}
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		m, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
 	}
 	if m.cursor != 0 || m.stepViewport.YOffset != 0 {

--- a/pkg/operationv2/builder.go
+++ b/pkg/operationv2/builder.go
@@ -139,7 +139,7 @@ func resolveTargets(
 			}
 			cache[target.ID] = node
 		}
-		targets = append(targets, operations.NodeReference{Name: node.Name, UID: node.UID})
+		targets = append(targets, operations.NodeReference{Name: node.Name, UID: node.UID, IP: node.Status.Ipv4DefaultIP})
 	}
 	return targets, nil
 }

--- a/pkg/operationv2/builder_test.go
+++ b/pkg/operationv2/builder_test.go
@@ -30,7 +30,7 @@ func TestFromCoreOperationBuildsUIDBoundOrderedPlan(t *testing.T) {
 	}
 	cluster := &corev1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster-a", UID: types.UID("cluster-uid")}}
 	nodes := fakeNodes{
-		"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid")}},
+		"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "node-a", UID: types.UID("node-a-uid")}, Status: corev1.NodeStatus{Ipv4DefaultIP: "10.0.0.1"}},
 		"node-b": {ObjectMeta: metav1.ObjectMeta{Name: "node-b", UID: types.UID("node-b-uid")}},
 	}
 
@@ -40,6 +40,9 @@ func TestFromCoreOperationBuildsUIDBoundOrderedPlan(t *testing.T) {
 	}
 	if result.Spec.TargetRef.UID != cluster.UID || result.Spec.Steps[0].Targets[0].UID != nodes["node-a"].UID {
 		t.Fatalf("target identities were not bound: %#v", result.Spec)
+	}
+	if result.Spec.Steps[0].Targets[0].IP != "10.0.0.1" {
+		t.Fatalf("target ip = %q, want 10.0.0.1", result.Spec.Steps[0].Targets[0].IP)
 	}
 	if result.Spec.Steps[0].RetryLimit != 1 {
 		t.Fatalf("retryLimit = %d, want 1", result.Spec.Steps[0].RetryLimit)

--- a/pkg/scheme/operations/v1alpha1/types.go
+++ b/pkg/scheme/operations/v1alpha1/types.go
@@ -62,6 +62,8 @@ type ObjectReference struct {
 type NodeReference struct {
 	Name string    `json:"name"`
 	UID  types.UID `json:"uid"`
+	// IP is the node's default IPv4 address, used for display in the console.
+	IP string `json:"ip,omitempty"`
 }
 
 type OperationDesiredState string


### PR DESCRIPTION
## Summary

- carry the authoritative node IPv4 address into Operation targets for builder and direct API creates
- group TUI task attempts under each node IP instead of rendering task UIDs as nodes
- make long step/task lists scrollable while keeping the selected step visible

## Tests

- go test ./pkg/apis/operations/v1alpha1 ./pkg/cli/operation/tui ./pkg/operationv2